### PR TITLE
feat: add CopilotCLIProvider, GeminiCLIProvider, and AgentRegistry

### DIFF
--- a/nexus/adapters/ai/__init__.py
+++ b/nexus/adapters/ai/__init__.py
@@ -1,4 +1,13 @@
 """AI provider adapters."""
 from nexus.adapters.ai.base import AIProvider, ExecutionContext
+from nexus.adapters.ai.copilot_provider import CopilotCLIProvider
+from nexus.adapters.ai.gemini_provider import GeminiCLIProvider
+from nexus.adapters.ai.registry import AgentRegistry
 
-__all__ = ["AIProvider", "ExecutionContext"]
+__all__ = [
+    "AIProvider",
+    "ExecutionContext",
+    "CopilotCLIProvider",
+    "GeminiCLIProvider",
+    "AgentRegistry",
+]

--- a/nexus/adapters/ai/copilot_provider.py
+++ b/nexus/adapters/ai/copilot_provider.py
@@ -1,0 +1,112 @@
+"""CopilotCLI AI provider implementation."""
+import asyncio
+import logging
+import shutil
+import subprocess
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+
+from nexus.adapters.ai.base import AIProvider, ExecutionContext
+from nexus.core.models import AgentResult, RateLimitStatus
+
+logger = logging.getLogger(__name__)
+
+# Task types where Copilot CLI excels
+_COPILOT_PREFERRED_TASKS = {"code_generation", "code_review", "refactoring"}
+
+
+class CopilotCLIProvider(AIProvider):
+    """AI provider that delegates to the GitHub Copilot CLI (gh copilot)."""
+
+    def __init__(self, timeout: int = 600):
+        self._timeout = timeout
+        self._availability_cache: dict = {}
+        self._availability_ttl: int = 300  # seconds
+
+    @property
+    def name(self) -> str:
+        return "copilot"
+
+    async def check_availability(self) -> bool:
+        """Return True if gh CLI with copilot extension is installed."""
+        now = time.time()
+        cached = self._availability_cache.get("copilot")
+        if cached and now - cached["at"] < self._availability_ttl:
+            return cached["available"]
+
+        available = bool(shutil.which("gh"))
+        if available:
+            try:
+                result = subprocess.run(
+                    ["gh", "copilot", "--version"],
+                    capture_output=True,
+                    timeout=10,
+                )
+                available = result.returncode == 0
+            except Exception:
+                available = False
+
+        self._availability_cache["copilot"] = {"available": available, "at": now}
+        return available
+
+    async def get_rate_limit_status(self) -> RateLimitStatus:
+        """Copilot CLI has no programmatic rate-limit endpoint; report unlimited."""
+        return RateLimitStatus(
+            provider=self.name,
+            is_limited=False,
+        )
+
+    def get_preference_score(self, task_type: str) -> float:
+        """Return 0.9 for code tasks, 0.6 otherwise."""
+        return 0.9 if task_type in _COPILOT_PREFERRED_TASKS else 0.6
+
+    async def execute_agent(self, context: ExecutionContext) -> AgentResult:
+        """Run the agent prompt through `gh copilot suggest`."""
+        start = time.time()
+        workspace = Path(context.workspace)
+        workspace.mkdir(parents=True, exist_ok=True)
+
+        cmd = ["gh", "copilot", "suggest", "--target", "shell", context.prompt]
+        try:
+            process = await asyncio.create_subprocess_exec(
+                *cmd,
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE,
+                cwd=str(workspace),
+            )
+            stdout, stderr = await asyncio.wait_for(
+                process.communicate(),
+                timeout=context.timeout or self._timeout,
+            )
+            elapsed = time.time() - start
+            if process.returncode == 0:
+                return AgentResult(
+                    success=True,
+                    output=stdout.decode(errors="replace"),
+                    execution_time=elapsed,
+                    provider_used=self.name,
+                )
+            return AgentResult(
+                success=False,
+                output=stdout.decode(errors="replace"),
+                error=stderr.decode(errors="replace"),
+                execution_time=elapsed,
+                provider_used=self.name,
+            )
+        except asyncio.TimeoutError:
+            return AgentResult(
+                success=False,
+                output="",
+                error=f"Timeout after {context.timeout or self._timeout}s",
+                execution_time=time.time() - start,
+                provider_used=self.name,
+            )
+        except Exception as exc:
+            return AgentResult(
+                success=False,
+                output="",
+                error=str(exc),
+                execution_time=time.time() - start,
+                provider_used=self.name,
+            )

--- a/nexus/adapters/ai/gemini_provider.py
+++ b/nexus/adapters/ai/gemini_provider.py
@@ -1,0 +1,100 @@
+"""GeminiCLI AI provider implementation."""
+import asyncio
+import logging
+import shutil
+import time
+from pathlib import Path
+
+from nexus.adapters.ai.base import AIProvider, ExecutionContext
+from nexus.core.models import AgentResult, RateLimitStatus
+
+logger = logging.getLogger(__name__)
+
+# Task types where Gemini CLI excels
+_GEMINI_PREFERRED_TASKS = {"reasoning", "analysis", "content_creation"}
+
+
+class GeminiCLIProvider(AIProvider):
+    """AI provider that delegates to the Gemini CLI (`gemini` binary)."""
+
+    def __init__(self, timeout: int = 600, model: str = "gemini-2.0-flash"):
+        self._timeout = timeout
+        self._model = model
+        self._availability_cache: dict = {}
+        self._availability_ttl: int = 300  # seconds
+
+    @property
+    def name(self) -> str:
+        return "gemini"
+
+    async def check_availability(self) -> bool:
+        """Return True if the `gemini` CLI binary is installed."""
+        now = time.time()
+        cached = self._availability_cache.get("gemini")
+        if cached and now - cached["at"] < self._availability_ttl:
+            return cached["available"]
+
+        available = bool(shutil.which("gemini"))
+        self._availability_cache["gemini"] = {"available": available, "at": now}
+        return available
+
+    async def get_rate_limit_status(self) -> RateLimitStatus:
+        """Gemini CLI has no programmatic rate-limit endpoint; report unlimited."""
+        return RateLimitStatus(
+            provider=self.name,
+            is_limited=False,
+        )
+
+    def get_preference_score(self, task_type: str) -> float:
+        """Return 0.9 for reasoning/analysis tasks, 0.5 otherwise."""
+        return 0.9 if task_type in _GEMINI_PREFERRED_TASKS else 0.5
+
+    async def execute_agent(self, context: ExecutionContext) -> AgentResult:
+        """Run the agent prompt through the `gemini` CLI."""
+        start = time.time()
+        workspace = Path(context.workspace)
+        workspace.mkdir(parents=True, exist_ok=True)
+
+        cmd = ["gemini", "--model", self._model, "--prompt", context.prompt]
+        try:
+            process = await asyncio.create_subprocess_exec(
+                *cmd,
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE,
+                cwd=str(workspace),
+            )
+            stdout, stderr = await asyncio.wait_for(
+                process.communicate(),
+                timeout=context.timeout or self._timeout,
+            )
+            elapsed = time.time() - start
+            if process.returncode == 0:
+                return AgentResult(
+                    success=True,
+                    output=stdout.decode(errors="replace"),
+                    execution_time=elapsed,
+                    provider_used=self.name,
+                )
+            return AgentResult(
+                success=False,
+                output=stdout.decode(errors="replace"),
+                error=stderr.decode(errors="replace"),
+                execution_time=elapsed,
+                provider_used=self.name,
+            )
+        except asyncio.TimeoutError:
+            return AgentResult(
+                success=False,
+                output="",
+                error=f"Timeout after {context.timeout or self._timeout}s",
+                execution_time=time.time() - start,
+                provider_used=self.name,
+            )
+        except Exception as exc:
+            return AgentResult(
+                success=False,
+                output="",
+                error=str(exc),
+                execution_time=time.time() - start,
+                provider_used=self.name,
+            )

--- a/nexus/adapters/ai/registry.py
+++ b/nexus/adapters/ai/registry.py
@@ -1,0 +1,125 @@
+"""AgentRegistry — resolves the preferred AI provider for a given agent_type.
+
+Loads agent YAML definitions from a directory and maps ``spec.agent_type``
+to a provider name (``spec.provider``).  Falls back to ``copilot`` when no
+explicit provider is declared.
+
+Usage::
+
+    registry = AgentRegistry(agents_dir=Path("examples/agents"))
+    provider = registry.resolve("triage", providers)   # returns an AIProvider
+"""
+import logging
+from pathlib import Path
+from typing import Dict, List, Optional
+
+import yaml
+
+from nexus.adapters.ai.base import AIProvider
+
+logger = logging.getLogger(__name__)
+
+# Default provider name when YAML does not specify one
+_DEFAULT_PROVIDER = "copilot"
+
+
+class AgentRegistry:
+    """Loads agent YAML definitions and resolves the preferred provider.
+
+    Args:
+        agents_dir: Directory containing ``*.yaml`` agent definition files.
+    """
+
+    def __init__(self, agents_dir: Optional[Path] = None):
+        self._agents_dir = agents_dir
+        # Maps agent_type -> provider name (e.g. "copilot" | "gemini")
+        self._provider_map: Dict[str, str] = {}
+        if agents_dir:
+            self._load(agents_dir)
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+
+    def resolve(
+        self,
+        agent_type: str,
+        providers: List[AIProvider],
+    ) -> Optional[AIProvider]:
+        """Return the preferred provider for *agent_type*.
+
+        Looks up the YAML-defined provider name, then finds a matching
+        provider from *providers* by ``provider.name``.  If no match is
+        found the first available provider is returned, and if the list is
+        empty ``None`` is returned.
+
+        Args:
+            agent_type: The abstract agent type string (e.g. ``"triage"``).
+            providers: Available provider instances.
+
+        Returns:
+            The preferred :class:`~nexus.adapters.ai.base.AIProvider` or
+            ``None`` if no providers are available.
+        """
+        if not providers:
+            return None
+
+        preferred_name = self._provider_map.get(agent_type, _DEFAULT_PROVIDER)
+        for provider in providers:
+            if provider.name == preferred_name:
+                return provider
+
+        # Fall back to first provider in list
+        logger.debug(
+            "No provider named %r found for agent_type %r; falling back to %s",
+            preferred_name,
+            agent_type,
+            providers[0].name,
+        )
+        return providers[0]
+
+    def get_provider_name(self, agent_type: str) -> str:
+        """Return the raw provider name string for *agent_type*.
+
+        Returns ``"copilot"`` if no YAML definition exists for the type.
+        """
+        return self._provider_map.get(agent_type, _DEFAULT_PROVIDER)
+
+    def registered_types(self) -> List[str]:
+        """Return all agent_type values found across loaded YAML files."""
+        return list(self._provider_map.keys())
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    def _load(self, agents_dir: Path) -> None:
+        """Parse all ``*.yaml`` files under *agents_dir* and build the map."""
+        if not agents_dir.is_dir():
+            logger.warning("AgentRegistry: agents_dir %s does not exist", agents_dir)
+            return
+
+        for yaml_file in sorted(agents_dir.glob("*.yaml")):
+            try:
+                self._parse_yaml(yaml_file)
+            except Exception as exc:
+                logger.warning("AgentRegistry: failed to parse %s — %s", yaml_file, exc)
+
+    def _parse_yaml(self, path: Path) -> None:
+        """Extract ``spec.agent_type`` and ``spec.provider`` from one file."""
+        with path.open() as fh:
+            data = yaml.safe_load(fh)
+
+        spec = data.get("spec", {}) if isinstance(data, dict) else {}
+        agent_type = spec.get("agent_type")
+        if not agent_type:
+            return  # Not an agent definition with a type
+
+        provider_name = spec.get("provider", _DEFAULT_PROVIDER)
+        self._provider_map[agent_type] = provider_name
+        logger.debug(
+            "AgentRegistry: registered agent_type=%r provider=%r (source=%s)",
+            agent_type,
+            provider_name,
+            path.name,
+        )


### PR DESCRIPTION
## Summary

Closes #36 — refactors the AI provider layer by splitting provider logic into dedicated classes and introducing an AgentRegistry for YAML-driven provider selection.

## Changes

- **`nexus/adapters/ai/copilot_provider.py`** — `CopilotCLIProvider`: delegates to `gh copilot suggest`, async subprocess execution, availability caching.
- **`nexus/adapters/ai/gemini_provider.py`** — `GeminiCLIProvider`: delegates to the `gemini` CLI binary, preference score favours reasoning/analysis tasks.
- **`nexus/adapters/ai/registry.py`** — `AgentRegistry`: loads `*.yaml` agent definitions from a directory, maps `spec.agent_type → spec.provider`, exposes `resolve(agent_type, providers)` for YAML-driven provider selection. Falls back to `copilot` when no provider is declared.
- **`nexus/adapters/ai/__init__.py`** — exports all three new classes.

## Tests

All 55 existing tests pass. No breaking changes to public API.