### PR TITLE
feat: add business agent for AI-powered feature suggestions

### DIFF
--- a/examples/agents/business-agent.yaml
+++ b/examples/agents/business-agent.yaml
@@ -1,0 +1,137 @@
+apiVersion: "nexus-core/v1"
+kind: "Agent"
+metadata:
+  name: "Business"
+  description: "Generates actionable feature suggestions for a given project using AI"
+  author: "Nexus Core Team"
+  version: "0.1.0"
+
+spec:
+  # Agent type - determines which tasks this agent can handle
+  # Types: triage | design | debug | developer | reviewer | docs | summarizer | business
+  agent_type: "business"
+
+  # Agent behavior configuration
+  timeout_seconds: 300
+  max_retries: 3
+
+  purpose: |
+    Given a project name and optional context, this agent:
+    1. Reads the project description and existing feature set (if provided)
+    2. Uses AI to brainstorm and evaluate potential new features
+    3. Returns a prioritised list of feature suggestions with rationale
+    4. Posts findings as a structured comment on the requesting issue
+
+  requires_tools:
+    - github:read_issue
+    - github:add_comment
+    - ai:completion
+
+  inputs:
+    project_name:
+      type: string
+      description: "Name of the project to generate suggestions for"
+      required: true
+      example: "nexus-core"
+    project_description:
+      type: string
+      description: "Short description of what the project does"
+      required: false
+      example: "A multi-agent orchestration framework for automating GitHub workflows"
+    existing_features:
+      type: array
+      items: string
+      description: "Optional list of features already implemented (to avoid duplicates)"
+      required: false
+      example:
+        - "Triage agent"
+        - "Design agent"
+        - "Developer agent"
+    max_suggestions:
+      type: integer
+      description: "Maximum number of feature suggestions to return"
+      required: false
+      default: 5
+
+  outputs:
+    suggestions:
+      type: array
+      items:
+        title:
+          type: string
+          description: "Short feature title"
+        description:
+          type: string
+          description: "What the feature does and why it is valuable"
+        priority:
+          type: enum
+          values: ["high", "medium", "low"]
+        effort:
+          type: enum
+          values: ["small", "medium", "large"]
+      description: "Prioritised list of feature suggestions"
+    reasoning:
+      type: string
+      description: "Overall rationale for the suggested features"
+
+  ai_instructions: |
+    You are a product strategist and software architect.
+    Analyze the project below and suggest new features that would deliver the most value.
+
+    Project Name: {project_name}
+    Project Description: {project_description}
+    Already Implemented: {existing_features}
+    Maximum Suggestions: {max_suggestions}
+
+    For each suggestion:
+    - Be specific and actionable (not vague like "improve performance")
+    - Explain the user benefit in one sentence
+    - Estimate priority (high/medium/low) based on user impact
+    - Estimate effort (small/medium/large) based on implementation complexity
+
+    Do NOT suggest features already in the "Already Implemented" list.
+
+    Return JSON:
+    {
+      "suggestions": [
+        {
+          "title": "Short feature title",
+          "description": "What it does and why it is valuable",
+          "priority": "high|medium|low",
+          "effort": "small|medium|large"
+        }
+      ],
+      "reasoning": "1-2 sentences on the overall strategy behind these suggestions"
+    }
+
+  example:
+    input:
+      project_name: "nexus-core"
+      project_description: "A multi-agent orchestration framework for automating GitHub workflows"
+      existing_features:
+        - "Triage agent"
+        - "Design agent"
+        - "Developer agent"
+        - "Reviewer agent"
+      max_suggestions: 3
+    expected_output:
+      suggestions:
+        - title: "Performance Benchmarking Agent"
+          description: "Automatically profiles PRs for runtime regressions before merge"
+          priority: "medium"
+          effort: "medium"
+        - title: "Dependency Update Agent"
+          description: "Detects stale dependencies and opens PRs to update them"
+          priority: "high"
+          effort: "small"
+        - title: "Security Audit Agent"
+          description: "Scans code changes for known vulnerability patterns"
+          priority: "high"
+          effort: "large"
+      reasoning: >
+        The suggestions focus on quality gates and automation gaps that are common
+        pain points for teams already using multi-agent CI workflows.
+
+  # Routing: what happens after this agent runs
+  next_steps:
+    - default: "close_loop"

--- a/examples/agents/triage-agent.yaml
+++ b/examples/agents/triage-agent.yaml
@@ -8,7 +8,7 @@ metadata:
 
 spec:
   # Agent type - determines which tasks this agent can handle
-  # Types: triage | design | debug | developer | reviewer | docs | summarizer | escalation
+  # Types: triage | design | debug | developer | reviewer | docs | summarizer | escalation | business
   # When a task is assigned to "triage", this agent will pick it up
   agent_type: "triage"
   

--- a/tests/test_agents.py
+++ b/tests/test_agents.py
@@ -180,3 +180,48 @@ class TestLoadAgentDefinition:
         data = load_agent_definition("Architect", [agents_dir, shared_dir])
         assert data is not None
         assert data["spec"]["agent_type"] == "Architect"
+
+
+# ---------------------------------------------------------------------------
+# Business agent — examples/agents/business-agent.yaml
+# ---------------------------------------------------------------------------
+
+EXAMPLES_AGENTS_DIR = os.path.join(
+    os.path.dirname(__file__), "..", "examples", "agents"
+)
+
+
+class TestBusinessAgentYaml:
+    """Verify the business-agent.yaml definition is well-formed and discoverable."""
+
+    def test_business_agent_found(self):
+        path = find_agent_yaml("business", [EXAMPLES_AGENTS_DIR])
+        assert path, "business-agent.yaml not found in examples/agents/"
+        assert path.endswith(".yaml") or path.endswith(".yml")
+
+    def test_business_agent_kind(self):
+        data = load_agent_definition("business", [EXAMPLES_AGENTS_DIR])
+        assert data is not None
+        assert data["kind"] == "Agent"
+
+    def test_business_agent_type_field(self):
+        data = load_agent_definition("business", [EXAMPLES_AGENTS_DIR])
+        assert data["spec"]["agent_type"] == "business"
+
+    def test_business_agent_required_inputs(self):
+        data = load_agent_definition("business", [EXAMPLES_AGENTS_DIR])
+        inputs = data["spec"]["inputs"]
+        assert "project_name" in inputs
+        assert inputs["project_name"]["required"] is True
+
+    def test_business_agent_outputs_present(self):
+        data = load_agent_definition("business", [EXAMPLES_AGENTS_DIR])
+        outputs = data["spec"]["outputs"]
+        assert "suggestions" in outputs
+        assert "reasoning" in outputs
+
+    def test_business_agent_has_ai_instructions(self):
+        data = load_agent_definition("business", [EXAMPLES_AGENTS_DIR])
+        ai_instructions = data["spec"].get("ai_instructions", "")
+        assert "{project_name}" in ai_instructions
+        assert "JSON" in ai_instructions


### PR DESCRIPTION
## Summary

Implements the business agent feature requested in #60.

The **Business** agent accepts a project name (and optional context: description, existing features) and uses an LLM to return a prioritised list of actionable feature suggestions.

## Changes

| File | Change |
|------|--------|
| `examples/agents/business-agent.yaml` | New agent definition — full input/output contract, AI prompt, and example |
| `examples/agents/triage-agent.yaml` | Add `business` to the known agent-type comment |
| `tests/test_agents.py` | 6 new tests in `TestBusinessAgentYaml` covering discovery, YAML structure, required fields, outputs, and AI instructions |

## Validation

```
pytest tests/test_agents.py -v
29 passed in 1.19s
```

Closes #60