### PR TITLE
feat: implement adapter-configurable persistence layer

### DIFF
--- a/examples/telegram-bot/tests/test_broadcasting_store.py
+++ b/examples/telegram-bot/tests/test_broadcasting_store.py
@@ -18,9 +18,9 @@ _nexus_src = Path(__file__).parent.parent / "src"
 if str(_nexus_src) not in sys.path:
     sys.path.insert(0, str(_nexus_src))
 
-_nexus_core = Path(__file__).parent.parent.parent / "nexus-core"
-if str(_nexus_core) not in sys.path:
-    sys.path.insert(0, str(_nexus_core))
+_repo_root = Path(__file__).resolve().parents[3]
+if str(_repo_root) not in sys.path:
+    sys.path.insert(0, str(_repo_root))
 
 
 # ---------------------------------------------------------------------------

--- a/nexus/adapters/storage/__init__.py
+++ b/nexus/adapters/storage/__init__.py
@@ -3,5 +3,11 @@
 from nexus.adapters.storage.base import StorageBackend
 from nexus.adapters.storage.file import FileStorage
 from nexus.adapters.storage.postgres import PostgreSQLStorageBackend
+from nexus.adapters.storage.workflow_state_adapter import StorageWorkflowStateStore
 
-__all__ = ["StorageBackend", "FileStorage", "PostgreSQLStorageBackend"]
+__all__ = [
+    "StorageBackend",
+    "FileStorage",
+    "PostgreSQLStorageBackend",
+    "StorageWorkflowStateStore",
+]

--- a/nexus/adapters/storage/base.py
+++ b/nexus/adapters/storage/base.py
@@ -94,3 +94,60 @@ class StorageBackend(ABC):
     async def load_host_state(self, key: str) -> dict[str, Any] | None:
         """Load a host state blob by key. Returns None if not found."""
         raise NotImplementedError("load_host_state is not implemented by this storage backend")
+
+    # --- Issue workflow mapping / approval state storage ---
+
+    async def map_issue_to_workflow(self, issue_num: str, workflow_id: str) -> None:
+        """Persist a mapping between an issue number and workflow id."""
+        raise NotImplementedError(
+            "map_issue_to_workflow is not implemented by this storage backend"
+        )
+
+    async def get_workflow_id_for_issue(self, issue_num: str) -> str | None:
+        """Return workflow id mapped to the issue number, if present."""
+        raise NotImplementedError(
+            "get_workflow_id_for_issue is not implemented by this storage backend"
+        )
+
+    async def remove_issue_workflow_mapping(self, issue_num: str) -> None:
+        """Delete persisted issue->workflow mapping for the issue number."""
+        raise NotImplementedError(
+            "remove_issue_workflow_mapping is not implemented by this storage backend"
+        )
+
+    async def load_issue_workflow_mappings(self) -> dict[str, str]:
+        """Load all issue->workflow mappings."""
+        raise NotImplementedError(
+            "load_issue_workflow_mappings is not implemented by this storage backend"
+        )
+
+    async def set_pending_workflow_approval(
+        self,
+        issue_num: str,
+        step_num: int,
+        step_name: str,
+        approvers: list[str],
+        approval_timeout: int,
+    ) -> None:
+        """Persist pending approval state for an issue workflow step."""
+        raise NotImplementedError(
+            "set_pending_workflow_approval is not implemented by this storage backend"
+        )
+
+    async def clear_pending_workflow_approval(self, issue_num: str) -> None:
+        """Remove persisted pending approval state for an issue."""
+        raise NotImplementedError(
+            "clear_pending_workflow_approval is not implemented by this storage backend"
+        )
+
+    async def get_pending_workflow_approval(self, issue_num: str) -> dict[str, Any] | None:
+        """Load pending approval state for an issue."""
+        raise NotImplementedError(
+            "get_pending_workflow_approval is not implemented by this storage backend"
+        )
+
+    async def load_pending_workflow_approvals(self) -> dict[str, dict[str, Any]]:
+        """Load all pending approval states."""
+        raise NotImplementedError(
+            "load_pending_workflow_approvals is not implemented by this storage backend"
+        )

--- a/nexus/adapters/storage/file_workflow_state.py
+++ b/nexus/adapters/storage/file_workflow_state.py
@@ -1,70 +1,30 @@
-"""JSON-file implementation of :class:`WorkflowStateStore`.
-
-Reads/writes two sidecar JSON files inside a configurable *base_path*:
-- ``workflow_mapping.json``  — issue → workflow-id map
-- ``approval_state.json``    — pending approval records
-"""
+"""File-backed WorkflowStateStore compatibility wrapper."""
 
 from __future__ import annotations
 
-import json
-import logging
-import time
 from pathlib import Path
 
-logger = logging.getLogger(__name__)
+from nexus.adapters.storage.file import FileStorage
+from nexus.adapters.storage.workflow_state_adapter import StorageWorkflowStateStore
 
 
 class FileWorkflowStateStore:
-    """Persist workflow state as JSON files on the local filesystem."""
+    """Backward-compatible file WorkflowStateStore via StorageBackend."""
 
     def __init__(self, base_path: Path) -> None:
-        self._base = base_path
-        self._mapping_file = base_path / "workflow_mapping.json"
-        self._approval_file = base_path / "approval_state.json"
-
-    # ── helpers ──────────────────────────────────────────────────────
-
-    def _read(self, path: Path, default: dict) -> dict:
-        if not path.exists():
-            return default
-        try:
-            return json.loads(path.read_text()) or default
-        except (json.JSONDecodeError, OSError) as exc:
-            logger.warning("Failed to read %s: %s", path, exc)
-            return default
-
-    def _write(self, path: Path, data: dict) -> None:
-        path.parent.mkdir(parents=True, exist_ok=True)
-        tmp = path.with_suffix(".tmp")
-        try:
-            tmp.write_text(json.dumps(data, indent=2))
-            tmp.replace(path)
-        except OSError as exc:
-            logger.error("Failed to write %s: %s", path, exc)
-
-    # ── Workflow mapping ────────────────────────────────────────────
+        self._adapter = StorageWorkflowStateStore(FileStorage(base_path=base_path))
 
     def map_issue(self, issue_num: str, workflow_id: str) -> None:
-        data = self._read(self._mapping_file, {})
-        data[str(issue_num)] = workflow_id
-        self._write(self._mapping_file, data)
-        logger.info("Mapped issue #%s -> workflow %s", issue_num, workflow_id)
+        self._adapter.map_issue(issue_num, workflow_id)
 
     def get_workflow_id(self, issue_num: str) -> str | None:
-        data = self._read(self._mapping_file, {})
-        return data.get(str(issue_num))
+        return self._adapter.get_workflow_id(issue_num)
 
     def remove_mapping(self, issue_num: str) -> None:
-        data = self._read(self._mapping_file, {})
-        data.pop(str(issue_num), None)
-        self._write(self._mapping_file, data)
-        logger.info("Removed workflow mapping for issue #%s", issue_num)
+        self._adapter.remove_mapping(issue_num)
 
     def load_all_mappings(self) -> dict[str, str]:
-        return self._read(self._mapping_file, {})
-
-    # ── Approval gate ───────────────────────────────────────────────
+        return self._adapter.load_all_mappings()
 
     def set_pending_approval(
         self,
@@ -74,31 +34,19 @@ class FileWorkflowStateStore:
         approvers: list[str],
         approval_timeout: int,
     ) -> None:
-        data = self._read(self._approval_file, {})
-        data[str(issue_num)] = {
-            "step_num": step_num,
-            "step_name": step_name,
-            "approvers": approvers,
-            "approval_timeout": approval_timeout,
-            "requested_at": time.time(),
-        }
-        self._write(self._approval_file, data)
-        logger.info(
-            "Set pending approval for issue #%s step %d (%s)",
-            issue_num,
-            step_num,
-            step_name,
+        self._adapter.set_pending_approval(
+            issue_num=issue_num,
+            step_num=step_num,
+            step_name=step_name,
+            approvers=approvers,
+            approval_timeout=approval_timeout,
         )
 
     def clear_pending_approval(self, issue_num: str) -> None:
-        data = self._read(self._approval_file, {})
-        data.pop(str(issue_num), None)
-        self._write(self._approval_file, data)
-        logger.info("Cleared pending approval for issue #%s", issue_num)
+        self._adapter.clear_pending_approval(issue_num)
 
     def get_pending_approval(self, issue_num: str) -> dict | None:
-        data = self._read(self._approval_file, {})
-        return data.get(str(issue_num))
+        return self._adapter.get_pending_approval(issue_num)
 
     def load_all_approvals(self) -> dict[str, dict]:
-        return self._read(self._approval_file, {})
+        return self._adapter.load_all_approvals()

--- a/nexus/adapters/storage/postgres_workflow_state.py
+++ b/nexus/adapters/storage/postgres_workflow_state.py
@@ -1,87 +1,13 @@
-"""PostgreSQL implementation of :class:`WorkflowStateStore`.
-
-Re-uses the same SQLAlchemy engine/session pattern as
-:class:`~nexus.adapters.storage.postgres.PostgreSQLStorageBackend`.
-
-Requires the ``postgres`` optional extra::
-
-    pip install nexus-core[postgres]
-
-Tables:
-- ``nexus_workflow_mappings`` — issue → workflow_id
-- ``nexus_approval_state``   — pending approval records
-"""
+"""Postgres-backed WorkflowStateStore compatibility wrapper."""
 
 from __future__ import annotations
 
-import json
-import logging
-import time
-from datetime import UTC, datetime
-
-try:
-    import sqlalchemy as sa
-    from sqlalchemy.orm import DeclarativeBase, Session, sessionmaker
-
-    _SA_AVAILABLE = True
-except ImportError:
-    _SA_AVAILABLE = False
-
-logger = logging.getLogger(__name__)
-
-
-def _require_sqlalchemy() -> None:
-    if not _SA_AVAILABLE:
-        raise ImportError(
-            "sqlalchemy and psycopg2-binary are required for PostgresWorkflowStateStore. "
-            "Install them with: pip install nexus-core[postgres]"
-        )
-
-
-# ---------------------------------------------------------------------------
-# ORM definitions (only when SQLAlchemy is available)
-# ---------------------------------------------------------------------------
-
-if _SA_AVAILABLE:
-
-    class _WfBase(DeclarativeBase):
-        pass
-
-    class _WorkflowMappingRow(_WfBase):
-        __tablename__ = "nexus_workflow_mappings"
-
-        issue_num: sa.orm.Mapped[str] = sa.orm.mapped_column(
-            sa.String(64),
-            primary_key=True,
-        )
-        workflow_id: sa.orm.Mapped[str] = sa.orm.mapped_column(sa.String(128))
-        updated_at: sa.orm.Mapped[datetime] = sa.orm.mapped_column(
-            sa.DateTime(timezone=True),
-            default=lambda: datetime.now(tz=UTC),
-            onupdate=lambda: datetime.now(tz=UTC),
-        )
-
-    class _ApprovalStateRow(_WfBase):
-        __tablename__ = "nexus_approval_state"
-
-        issue_num: sa.orm.Mapped[str] = sa.orm.mapped_column(
-            sa.String(64),
-            primary_key=True,
-        )
-        step_num: sa.orm.Mapped[int] = sa.orm.mapped_column(sa.Integer)
-        step_name: sa.orm.Mapped[str] = sa.orm.mapped_column(sa.String(256))
-        approvers: sa.orm.Mapped[str] = sa.orm.mapped_column(sa.Text)  # JSON list
-        approval_timeout: sa.orm.Mapped[int] = sa.orm.mapped_column(sa.Integer)
-        requested_at: sa.orm.Mapped[float] = sa.orm.mapped_column(sa.Float)
-
-
-# ---------------------------------------------------------------------------
-# Store implementation
-# ---------------------------------------------------------------------------
+from nexus.adapters.storage.postgres import PostgreSQLStorageBackend
+from nexus.adapters.storage.workflow_state_adapter import StorageWorkflowStateStore
 
 
 class PostgresWorkflowStateStore:
-    """PostgreSQL-backed :class:`WorkflowStateStore`."""
+    """Backward-compatible postgres WorkflowStateStore via StorageBackend."""
 
     def __init__(
         self,
@@ -89,63 +15,24 @@ class PostgresWorkflowStateStore:
         pool_size: int = 5,
         echo: bool = False,
     ) -> None:
-        _require_sqlalchemy()
-
-        dsn = connection_string
-        if dsn.startswith("postgresql://") or dsn.startswith("postgres://"):
-            dsn = dsn.replace("postgresql://", "postgresql+psycopg2://", 1)
-            dsn = dsn.replace("postgres://", "postgresql+psycopg2://", 1)
-
-        self._engine = sa.create_engine(dsn, pool_size=pool_size, echo=echo)
-        self._session_factory: sessionmaker = sessionmaker(
-            bind=self._engine,
-            expire_on_commit=False,
+        self._storage = PostgreSQLStorageBackend(
+            connection_string=connection_string,
+            pool_size=pool_size,
+            echo=echo,
         )
-        _WfBase.metadata.create_all(self._engine)
-        logger.info(
-            "PostgresWorkflowStateStore connected (%s)",
-            dsn.split("@")[-1],
-        )
-
-    # ── Workflow mapping ────────────────────────────────────────────
+        self._adapter = StorageWorkflowStateStore(self._storage)
 
     def map_issue(self, issue_num: str, workflow_id: str) -> None:
-        with Session(self._engine) as session:
-            row = session.get(_WorkflowMappingRow, str(issue_num))
-            now = datetime.now(tz=UTC)
-            if row:
-                row.workflow_id = workflow_id
-                row.updated_at = now
-            else:
-                session.add(
-                    _WorkflowMappingRow(
-                        issue_num=str(issue_num),
-                        workflow_id=workflow_id,
-                        updated_at=now,
-                    )
-                )
-            session.commit()
-        logger.info("Mapped issue #%s -> workflow %s", issue_num, workflow_id)
+        self._adapter.map_issue(issue_num, workflow_id)
 
     def get_workflow_id(self, issue_num: str) -> str | None:
-        with Session(self._engine) as session:
-            row = session.get(_WorkflowMappingRow, str(issue_num))
-            return row.workflow_id if row else None
+        return self._adapter.get_workflow_id(issue_num)
 
     def remove_mapping(self, issue_num: str) -> None:
-        with Session(self._engine) as session:
-            row = session.get(_WorkflowMappingRow, str(issue_num))
-            if row:
-                session.delete(row)
-                session.commit()
-        logger.info("Removed workflow mapping for issue #%s", issue_num)
+        self._adapter.remove_mapping(issue_num)
 
     def load_all_mappings(self) -> dict[str, str]:
-        with Session(self._engine) as session:
-            rows = session.query(_WorkflowMappingRow).all()
-            return {r.issue_num: r.workflow_id for r in rows}
-
-    # ── Approval gate ───────────────────────────────────────────────
+        return self._adapter.load_all_mappings()
 
     def set_pending_approval(
         self,
@@ -155,74 +42,26 @@ class PostgresWorkflowStateStore:
         approvers: list[str],
         approval_timeout: int,
     ) -> None:
-        with Session(self._engine) as session:
-            row = session.get(_ApprovalStateRow, str(issue_num))
-            if row:
-                row.step_num = step_num
-                row.step_name = step_name
-                row.approvers = json.dumps(approvers)
-                row.approval_timeout = approval_timeout
-                row.requested_at = time.time()
-            else:
-                session.add(
-                    _ApprovalStateRow(
-                        issue_num=str(issue_num),
-                        step_num=step_num,
-                        step_name=step_name,
-                        approvers=json.dumps(approvers),
-                        approval_timeout=approval_timeout,
-                        requested_at=time.time(),
-                    )
-                )
-            session.commit()
-        logger.info(
-            "Set pending approval for issue #%s step %d (%s)",
-            issue_num,
-            step_num,
-            step_name,
+        self._adapter.set_pending_approval(
+            issue_num=issue_num,
+            step_num=step_num,
+            step_name=step_name,
+            approvers=approvers,
+            approval_timeout=approval_timeout,
         )
 
     def clear_pending_approval(self, issue_num: str) -> None:
-        with Session(self._engine) as session:
-            row = session.get(_ApprovalStateRow, str(issue_num))
-            if row:
-                session.delete(row)
-                session.commit()
-        logger.info("Cleared pending approval for issue #%s", issue_num)
+        self._adapter.clear_pending_approval(issue_num)
 
     def get_pending_approval(self, issue_num: str) -> dict | None:
-        with Session(self._engine) as session:
-            row = session.get(_ApprovalStateRow, str(issue_num))
-            if not row:
-                return None
-            return {
-                "step_num": row.step_num,
-                "step_name": row.step_name,
-                "approvers": json.loads(row.approvers),
-                "approval_timeout": row.approval_timeout,
-                "requested_at": row.requested_at,
-            }
+        return self._adapter.get_pending_approval(issue_num)
 
     def load_all_approvals(self) -> dict[str, dict]:
-        with Session(self._engine) as session:
-            rows = session.query(_ApprovalStateRow).all()
-            return {
-                r.issue_num: {
-                    "step_num": r.step_num,
-                    "step_name": r.step_name,
-                    "approvers": json.loads(r.approvers),
-                    "approval_timeout": r.approval_timeout,
-                    "requested_at": r.requested_at,
-                }
-                for r in rows
-            }
+        return self._adapter.load_all_approvals()
 
     def close(self) -> None:
         """Dispose underlying SQLAlchemy engine resources."""
-        try:
-            self._engine.dispose()
-        except Exception as exc:
-            logger.debug("Failed to dispose PostgresWorkflowStateStore engine: %s", exc)
+        self._storage.close()
 
     def __del__(self) -> None:  # pragma: no cover - defensive finalizer
         try:

--- a/nexus/adapters/storage/workflow_state_adapter.py
+++ b/nexus/adapters/storage/workflow_state_adapter.py
@@ -1,0 +1,67 @@
+"""WorkflowStateStore adapter backed by StorageBackend implementations."""
+
+from __future__ import annotations
+
+import asyncio
+from concurrent.futures import ThreadPoolExecutor
+from typing import Any
+
+from nexus.adapters.storage.base import StorageBackend
+
+
+class StorageWorkflowStateStore:
+    """Synchronous WorkflowStateStore facade over async StorageBackend methods."""
+
+    def __init__(self, storage: StorageBackend) -> None:
+        self._storage = storage
+
+    @staticmethod
+    def _run(coro):
+        try:
+            asyncio.get_running_loop()
+        except RuntimeError:
+            return asyncio.run(coro)
+
+        # Support sync call-sites invoked from async contexts.
+        with ThreadPoolExecutor(max_workers=1) as executor:
+            future = executor.submit(asyncio.run, coro)
+            return future.result()
+
+    def map_issue(self, issue_num: str, workflow_id: str) -> None:
+        self._run(self._storage.map_issue_to_workflow(issue_num, workflow_id))
+
+    def get_workflow_id(self, issue_num: str) -> str | None:
+        return self._run(self._storage.get_workflow_id_for_issue(issue_num))
+
+    def remove_mapping(self, issue_num: str) -> None:
+        self._run(self._storage.remove_issue_workflow_mapping(issue_num))
+
+    def load_all_mappings(self) -> dict[str, str]:
+        return self._run(self._storage.load_issue_workflow_mappings())
+
+    def set_pending_approval(
+        self,
+        issue_num: str,
+        step_num: int,
+        step_name: str,
+        approvers: list[str],
+        approval_timeout: int,
+    ) -> None:
+        self._run(
+            self._storage.set_pending_workflow_approval(
+                issue_num=issue_num,
+                step_num=step_num,
+                step_name=step_name,
+                approvers=approvers,
+                approval_timeout=approval_timeout,
+            )
+        )
+
+    def clear_pending_approval(self, issue_num: str) -> None:
+        self._run(self._storage.clear_pending_workflow_approval(issue_num))
+
+    def get_pending_approval(self, issue_num: str) -> dict[str, Any] | None:
+        return self._run(self._storage.get_pending_workflow_approval(issue_num))
+
+    def load_all_approvals(self) -> dict[str, dict[str, Any]]:
+        return self._run(self._storage.load_pending_workflow_approvals())

--- a/tests/test_storage_workflow_state_adapter.py
+++ b/tests/test_storage_workflow_state_adapter.py
@@ -1,0 +1,67 @@
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from nexus.adapters.storage.file import FileStorage
+from nexus.adapters.storage.workflow_state_adapter import StorageWorkflowStateStore
+
+
+def test_file_storage_workflow_state_roundtrip(tmp_path):
+    storage = FileStorage(base_path=tmp_path)
+    store = StorageWorkflowStateStore(storage)
+
+    store.map_issue("42", "wf-42")
+    assert store.get_workflow_id("42") == "wf-42"
+    assert store.load_all_mappings() == {"42": "wf-42"}
+
+    store.set_pending_approval("42", 3, "deploy", ["lead"], 3600)
+    pending = store.get_pending_approval("42")
+    assert pending is not None
+    assert pending["step_num"] == 3
+    assert pending["step_name"] == "deploy"
+    assert pending["approvers"] == ["lead"]
+    assert pending["approval_timeout"] == 3600
+
+    store.clear_pending_approval("42")
+    store.remove_mapping("42")
+    assert store.get_pending_approval("42") is None
+    assert store.get_workflow_id("42") is None
+
+
+def test_store_supports_calls_when_event_loop_is_running(tmp_path):
+    store = StorageWorkflowStateStore(FileStorage(base_path=tmp_path))
+
+    async def _call_sync_methods():
+        store.map_issue("7", "wf-7")
+        return store.get_workflow_id("7")
+
+    result = asyncio.run(_call_sync_methods())
+    assert result == "wf-7"
+
+
+try:
+    import sqlalchemy  # noqa: F401
+
+    _SA = True
+except ImportError:
+    _SA = False
+
+
+@pytest.mark.skipif(not _SA, reason="sqlalchemy not installed")
+def test_postgres_storage_workflow_state_roundtrip_sqlite():
+    from nexus.adapters.storage.postgres import PostgreSQLStorageBackend
+
+    storage = PostgreSQLStorageBackend(connection_string="sqlite:///:memory:")
+    store = StorageWorkflowStateStore(storage)
+    try:
+        store.map_issue("100", "wf-100")
+        assert store.get_workflow_id("100") == "wf-100"
+
+        store.set_pending_approval("100", 1, "review", ["dev"], 120)
+        pending = store.get_pending_approval("100")
+        assert pending is not None
+        assert pending["approvers"] == ["dev"]
+    finally:
+        storage.close()


### PR DESCRIPTION
## Summary
- unify workflow-state persistence behind  adapters
- support backend switching between file/JSON and Postgres for workflow mappings and approvals
- update Telegram workflow-state factory to resolve persistence through adapter registry
- add adapter-focused tests and fix Telegram example test path resolution

Closes #91