### PR TITLE
feat: emit step-level WebSocket events for real-time visualizer (#110)

### DIFF
--- a/examples/nexus-bot/src/static/visualizer.html
+++ b/examples/nexus-bot/src/static/visualizer.html
@@ -58,6 +58,16 @@
             const node = cy.getElementById(wfId);
             if (node.length) {
                 node.style('border-color', data.status === 'success' ? '#3fb950' : '#f85149');
+                const label = data.summary || `Workflow ${data.status}`;
+                node.data('label', label);
+            }
+            if (data.summary) {
+                const badge = document.getElementById('workflow-summary-badge');
+                if (badge) {
+                    badge.textContent = data.summary;
+                    badge.style.color = data.status === 'success' ? '#3fb950' : '#f85149';
+                    badge.style.display = 'block';
+                }
             }
         });
 
@@ -256,6 +266,7 @@
     <h1>Nexus Workflow Visualizer</h1>
     <span id="status-text">Connecting…</span>
 </header>
+<div id="workflow-summary-badge" style="display:none; text-align:center; padding:4px 12px; font-size:0.85rem; font-weight:600;"></div>
 <div id="tabs">
     <div class="tab active" onclick="showTab('graph')">Network Graph (Cytoscape)</div>
     <div class="tab" onclick="showTab('mermaid')">Workflow Diagram (Mermaid)</div>

--- a/nexus/core/events.py
+++ b/nexus/core/events.py
@@ -57,6 +57,10 @@ class WorkflowCompleted(NexusEvent):
     """Emitted when a workflow finishes all steps successfully."""
 
     event_type: str = "workflow.completed"
+    total_steps: int = 0
+    completed_steps: int = 0
+    failed_steps: int = 0
+    skipped_steps: int = 0
 
 
 @dataclass
@@ -111,6 +115,17 @@ class StepFailed(NexusEvent):
     step_name: str = ""
     agent_type: str = ""
     error: str = ""
+
+
+@dataclass
+class StepSkipped(NexusEvent):
+    """Emitted when a workflow step is skipped (condition evaluated False or router bypass)."""
+
+    event_type: str = "step.skipped"
+    step_num: int = 0
+    step_name: str = ""
+    agent_type: str = ""
+    reason: str = ""
 
 
 @dataclass

--- a/nexus/core/orchestration/nexus_core_helpers.py
+++ b/nexus/core/orchestration/nexus_core_helpers.py
@@ -85,29 +85,30 @@ async def _setup_socketio_event_bridge(bus: EventBus) -> None:
                     status=status,
                 )
 
-                # 3. Emit updated mermaid diagram
-                engine = get_workflow_engine()
-                workflow = await engine.get_workflow(workflow_id)
-                if workflow:
-                    steps_data = []
-                    for s in workflow.steps:
-                        steps_data.append(
+                # 3. Emit updated mermaid diagram (skip for skipped steps to reduce I/O)
+                if event.event_type != "step.skipped":
+                    engine = get_workflow_engine()
+                    workflow = await engine.get_workflow(workflow_id)
+                    if workflow:
+                        steps_data = []
+                        for s in workflow.steps:
+                            steps_data.append(
+                                {
+                                    "name": s.name,
+                                    "status": s.status.value,
+                                    "agent": {"name": s.agent.name},
+                                }
+                            )
+                        diagram = build_mermaid_diagram(steps_data, issue)
+                        HostStateManager.emit_transition(
+                            "mermaid_diagram",
                             {
-                                "name": s.name,
-                                "status": s.status.value,
-                                "agent": {"name": s.agent.name},
-                            }
+                                "issue": issue,
+                                "workflow_id": workflow_id,
+                                "diagram": diagram,
+                                "timestamp": event.timestamp.timestamp(),
+                            },
                         )
-                    diagram = build_mermaid_diagram(steps_data, issue)
-                    HostStateManager.emit_transition(
-                        "mermaid_diagram",
-                        {
-                            "issue": issue,
-                            "workflow_id": workflow_id,
-                            "diagram": diagram,
-                            "timestamp": event.timestamp.timestamp(),
-                        },
-                    )
 
         # 4. Handle workflow completion
         elif event.event_type in ("workflow.completed", "workflow.failed"):

--- a/nexus/core/orchestration/nexus_core_helpers.py
+++ b/nexus/core/orchestration/nexus_core_helpers.py
@@ -73,6 +73,7 @@ async def _setup_socketio_event_bridge(bus: EventBus) -> None:
                 "step.started": "running",
                 "step.completed": "done",
                 "step.failed": "failed",
+                "step.skipped": "skipped",
             }
             status = status_map.get(event.event_type)
             if status:
@@ -111,13 +112,29 @@ async def _setup_socketio_event_bridge(bus: EventBus) -> None:
         # 4. Handle workflow completion
         elif event.event_type in ("workflow.completed", "workflow.failed"):
             status = "success" if event.event_type == "workflow.completed" else "failed"
+            total_steps = getattr(event, "total_steps", 0)
+            completed_steps = getattr(event, "completed_steps", 0)
+            failed_steps = getattr(event, "failed_steps", 0)
+            skipped_steps = getattr(event, "skipped_steps", 0)
+            if total_steps:
+                summary = (
+                    f"Workflow {status}: {completed_steps}/{total_steps} steps completed"
+                    + (f", {skipped_steps} skipped" if skipped_steps else "")
+                    + (f", {failed_steps} failed" if failed_steps else "")
+                )
+            else:
+                summary = f"Workflow {status}"
             HostStateManager.emit_transition(
                 "workflow_completed",
                 {
                     "issue": issue,
                     "workflow_id": workflow_id,
                     "status": status,
-                    "summary": f"Workflow {status}",
+                    "summary": summary,
+                    "total_steps": total_steps,
+                    "completed_steps": completed_steps,
+                    "failed_steps": failed_steps,
+                    "skipped_steps": skipped_steps,
                     "timestamp": event.timestamp.timestamp(),
                 },
             )

--- a/nexus/core/workflow.py
+++ b/nexus/core/workflow.py
@@ -279,7 +279,19 @@ class WorkflowEngine:
                 return workflow
 
             if workflow.state == WorkflowState.COMPLETED and activated_step is None:
-                await self._emit(WorkflowCompleted(workflow_id=workflow_id))
+                _total = len(workflow.steps)
+                _completed = sum(1 for s in workflow.steps if s.status == StepStatus.COMPLETED)
+                _failed = sum(1 for s in workflow.steps if s.status == StepStatus.FAILED)
+                _skipped = sum(1 for s in workflow.steps if s.status == StepStatus.SKIPPED)
+                await self._emit(
+                    WorkflowCompleted(
+                        workflow_id=workflow_id,
+                        total_steps=_total,
+                        completed_steps=_completed,
+                        failed_steps=_failed,
+                        skipped_steps=_skipped,
+                    )
+                )
         else:
             # Workflow failed
             workflow.state = WorkflowState.FAILED

--- a/nexus/core/workflow_engine/audit_event_service.py
+++ b/nexus/core/workflow_engine/audit_event_service.py
@@ -3,7 +3,7 @@ from datetime import UTC, datetime
 from typing import Awaitable, Callable
 
 from nexus.core.events import NexusEvent, WorkflowCompleted
-from nexus.core.models import Workflow, WorkflowState, WorkflowStep
+from nexus.core.models import StepStatus, Workflow, WorkflowState, WorkflowStep
 
 logger = logging.getLogger(__name__)
 
@@ -31,7 +31,15 @@ async def finalize_terminal_success(
         {"step_num": step_num, "step_name": step_name, "error": None},
     )
     logger.info("Completed step %s in workflow %s", step_num, workflow_id)
-    await emit(WorkflowCompleted(workflow_id=workflow_id))
+    await emit(
+        WorkflowCompleted(
+            workflow_id=workflow_id,
+            total_steps=len(workflow.steps),
+            completed_steps=sum(1 for s in workflow.steps if s.status == StepStatus.COMPLETED),
+            failed_steps=sum(1 for s in workflow.steps if s.status == StepStatus.FAILED),
+            skipped_steps=sum(1 for s in workflow.steps if s.status == StepStatus.SKIPPED),
+        )
+    )
     if on_workflow_complete:
         try:
             await on_workflow_complete(workflow, outputs)

--- a/nexus/core/workflow_engine/transition_service.py
+++ b/nexus/core/workflow_engine/transition_service.py
@@ -2,7 +2,7 @@ from dataclasses import dataclass
 from datetime import UTC, datetime
 from typing import Any, Awaitable, Callable
 
-from nexus.core.events import NexusEvent, StepStarted
+from nexus.core.events import NexusEvent, StepSkipped, StepStarted
 from nexus.core.models import StepStatus, Workflow, WorkflowState, WorkflowStep
 
 
@@ -96,6 +96,15 @@ async def advance_after_success(
                     "reason": "router evaluated",
                 },
             )
+            await emit(
+                StepSkipped(
+                    workflow_id=workflow_id,
+                    step_num=next_step.step_num,
+                    step_name=next_step.name,
+                    agent_type=next_step.agent.name,
+                    reason="router evaluated",
+                )
+            )
             workflow.current_step = next_step.step_num
             target = resolve_route(workflow, next_step, context)
             if target is None:
@@ -136,6 +145,15 @@ async def advance_after_success(
                 "condition": next_step.condition,
                 "reason": f"Condition evaluated to False: {next_step.condition}",
             },
+        )
+        await emit(
+            StepSkipped(
+                workflow_id=workflow_id,
+                step_num=next_step.step_num,
+                step_name=next_step.name,
+                agent_type=next_step.agent.name,
+                reason=f"Condition evaluated to False: {next_step.condition}",
+            )
         )
         workflow.current_step = next_step.step_num
         next_step = workflow.get_next_step()

--- a/tests/test_conditional_steps.py
+++ b/tests/test_conditional_steps.py
@@ -7,6 +7,7 @@ from unittest.mock import AsyncMock
 import pytest
 
 from nexus.adapters.storage.base import StorageBackend
+from nexus.core.events import EventBus, NexusEvent, StepSkipped, WorkflowCompleted
 from nexus.core.models import (
     Agent,
     AuditEvent,
@@ -96,9 +97,9 @@ class InMemoryStorage(StorageBackend):
         return 0
 
 
-async def engine_with_workflow(workflow: Workflow) -> tuple:
+async def engine_with_workflow(workflow: Workflow, event_bus: EventBus | None = None) -> tuple:
     storage = InMemoryStorage()
-    engine = WorkflowEngine(storage=storage)
+    engine = WorkflowEngine(storage=storage, event_bus=event_bus)
     await storage.save_workflow(workflow)
     return engine, storage
 
@@ -265,3 +266,103 @@ async def test_router_condition_error_does_not_match_first_branch():
     assert result.steps[2].status == StepStatus.PENDING
     assert result.steps[3].status == StepStatus.RUNNING
     assert result.current_step == 4
+
+
+# ---------------------------------------------------------------------------
+# StepSkipped event emission tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_condition_false_emits_step_skipped_event():
+    """A condition-false skip must emit a StepSkipped event on the EventBus."""
+    step1 = make_step(1, "analyze")
+    step2 = make_step(2, "detailed_design", condition="result['tier'] == 'high'")
+    wf = make_workflow([step1, step2])
+
+    bus = EventBus()
+    emitted: list[NexusEvent] = []
+    bus.subscribe("step.skipped", lambda e: emitted.append(e))
+
+    engine, _ = await engine_with_workflow(wf, event_bus=bus)
+    await engine.complete_step("wf-test", step_num=1, outputs={"tier": "low"})
+
+    assert len(emitted) == 1
+    skipped_event = emitted[0]
+    assert isinstance(skipped_event, StepSkipped)
+    assert skipped_event.step_name == "detailed_design"
+    assert skipped_event.workflow_id == "wf-test"
+    assert "Condition evaluated to False" in skipped_event.reason
+
+
+@pytest.mark.asyncio
+async def test_chained_condition_false_emits_multiple_step_skipped_events():
+    """Each condition-false skip in a chain must emit its own StepSkipped event."""
+    step1 = make_step(1, "analyze")
+    step2 = make_step(2, "design", condition="result['tier'] == 'high'")
+    step3 = make_step(3, "review", condition="result['tier'] == 'high'")
+    wf = make_workflow([step1, step2, step3])
+
+    bus = EventBus()
+    emitted: list[NexusEvent] = []
+    bus.subscribe("step.skipped", lambda e: emitted.append(e))
+
+    engine, _ = await engine_with_workflow(wf, event_bus=bus)
+    await engine.complete_step("wf-test", step_num=1, outputs={"tier": "low"})
+
+    assert len(emitted) == 2
+    names = [e.step_name for e in emitted]  # type: ignore[attr-defined]
+    assert "design" in names
+    assert "review" in names
+
+
+# ---------------------------------------------------------------------------
+# WorkflowCompleted step-count tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_workflow_completed_counts_include_skipped_steps():
+    """WorkflowCompleted event must carry correct step counts when steps are skipped."""
+    step1 = make_step(1, "analyze")
+    step2 = make_step(2, "detailed_design", condition="result['tier'] == 'high'")
+    wf = make_workflow([step1, step2])
+
+    bus = EventBus()
+    completed_events: list[NexusEvent] = []
+    bus.subscribe("workflow.completed", lambda e: completed_events.append(e))
+
+    engine, _ = await engine_with_workflow(wf, event_bus=bus)
+    await engine.complete_step("wf-test", step_num=1, outputs={"tier": "low"})
+
+    assert len(completed_events) == 1
+    evt = completed_events[0]
+    assert isinstance(evt, WorkflowCompleted)
+    assert evt.total_steps == 2
+    assert evt.completed_steps == 1
+    assert evt.skipped_steps == 1
+    assert evt.failed_steps == 0
+
+
+@pytest.mark.asyncio
+async def test_workflow_completed_counts_all_completed_steps():
+    """WorkflowCompleted event counts must reflect all steps completing normally."""
+    step1 = make_step(1, "analyze")
+    step2 = make_step(2, "implement")
+    wf = make_workflow([step1, step2])
+
+    bus = EventBus()
+    completed_events: list[NexusEvent] = []
+    bus.subscribe("workflow.completed", lambda e: completed_events.append(e))
+
+    engine, _ = await engine_with_workflow(wf, event_bus=bus)
+    await engine.complete_step("wf-test", step_num=1, outputs={})
+    await engine.complete_step("wf-test", step_num=2, outputs={})
+
+    assert len(completed_events) == 1
+    evt = completed_events[0]
+    assert isinstance(evt, WorkflowCompleted)
+    assert evt.total_steps == 2
+    assert evt.completed_steps == 2
+    assert evt.skipped_steps == 0
+    assert evt.failed_steps == 0

--- a/tests/test_router_steps.py
+++ b/tests/test_router_steps.py
@@ -6,6 +6,7 @@ from typing import Any
 import pytest
 
 from nexus.adapters.storage.base import StorageBackend
+from nexus.core.events import EventBus, NexusEvent, StepSkipped, WorkflowCompleted
 from nexus.core.models import (
     Agent,
     AuditEvent,
@@ -79,9 +80,9 @@ def _make_step(step_num: int, name: str, routes=None, condition=None) -> Workflo
     )
 
 
-async def _engine_with_workflow(workflow: Workflow) -> tuple:
+async def _engine_with_workflow(workflow: Workflow, event_bus: EventBus | None = None) -> tuple:
     storage = InMemoryStorage()
-    engine = WorkflowEngine(storage=storage)
+    engine = WorkflowEngine(storage=storage, event_bus=event_bus)
     await storage.save_workflow(workflow)
     return engine, storage
 
@@ -306,3 +307,74 @@ async def test_on_success_jumps_to_named_step_not_sequential():
     assert design.status == StepStatus.PENDING
     assert develop.status == StepStatus.RUNNING
     assert wf.current_step == develop.step_num
+
+
+# ---------------------------------------------------------------------------
+# StepSkipped event emission for router bypass
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_router_bypass_emits_step_skipped_event():
+    """Router evaluation bypass must emit a StepSkipped event on the EventBus."""
+    develop = _make_step(1, "develop")
+    review = _make_step(2, "review")
+    router = _make_step(
+        3,
+        "route_review",
+        routes=[
+            {"when": "review['decision'] == 'approved'", "goto": "deploy"},
+            {"default": True, "goto": "develop"},
+        ],
+    )
+    deploy = _make_step(4, "deploy")
+
+    wf = _make_workflow([develop, review, router, deploy])
+    bus = EventBus()
+    emitted: list[NexusEvent] = []
+    bus.subscribe("step.skipped", lambda e: emitted.append(e))
+
+    engine, _ = await _engine_with_workflow(wf, event_bus=bus)
+    # develop → done, review activated
+    await engine.complete_step("wf-test", step_num=1, outputs={"pr": "1"})
+    # review → approved; router is bypassed (skipped), deploy activated
+    await engine.complete_step("wf-test", step_num=2, outputs={"decision": "approved"})
+
+    assert len(emitted) == 1
+    skipped_event = emitted[0]
+    assert isinstance(skipped_event, StepSkipped)
+    assert skipped_event.step_name == "route_review"
+    assert skipped_event.workflow_id == "wf-test"
+    assert skipped_event.reason == "router evaluated"
+
+
+# ---------------------------------------------------------------------------
+# WorkflowCompleted step-count tests for the final_step path
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_final_step_workflow_completed_carries_step_counts():
+    """WorkflowCompleted emitted via the final_step path must include step counts."""
+    implement = _make_step(1, "implement")
+    close_loop = _make_step(2, "close_loop")
+    close_loop.final_step = True
+    close_rejected = _make_step(3, "close_rejected")
+
+    wf = _make_workflow([implement, close_loop, close_rejected])
+    bus = EventBus()
+    completed_events: list[NexusEvent] = []
+    bus.subscribe("workflow.completed", lambda e: completed_events.append(e))
+
+    engine, _ = await _engine_with_workflow(wf, event_bus=bus)
+    await engine.complete_step("wf-test", step_num=1, outputs={})
+    await engine.complete_step("wf-test", step_num=2, outputs={})
+
+    assert len(completed_events) == 1
+    evt = completed_events[0]
+    assert isinstance(evt, WorkflowCompleted)
+    # implement + close_loop completed; close_rejected stays PENDING (not counted)
+    assert evt.total_steps == 3
+    assert evt.completed_steps == 2
+    assert evt.skipped_steps == 0
+    assert evt.failed_steps == 0


### PR DESCRIPTION
## Summary

Extends the existing WebSocket infrastructure to broadcast `step_status_changed` and `workflow_completed` events from the workflow engine, enabling real-time node updates in the Cytoscape.js visualizer without manual page refreshes.

Closes #110 (in nexus-arc)

## Changes

### `nexus/core/events.py`
- Add `StepSkipped` event class (`event_type: step.skipped`) so skipped steps are observable via the EventBus
- Extend `WorkflowCompleted` with `total_steps`, `completed_steps`, `failed_steps`, `skipped_steps` fields for a rich completion payload

### `nexus/core/workflow_engine/transition_service.py`
- Emit `StepSkipped` for both router-bypass and condition-false step skips in `advance_after_success()`

### `nexus/core/workflow.py`
- Compute step counts and pass them to `WorkflowCompleted` emission

### `nexus/core/orchestration/nexus_core_helpers.py`
- Map `step.skipped → skipped` in the SocketIO event bridge status_map
- Include `total_steps`, `completed_steps`, `failed_steps`, `skipped_steps` in `workflow_completed` SocketIO payload
- Generate human-readable summary string (e.g. `Workflow success: 5/6 steps completed, 1 skipped`)

### `examples/nexus-bot/src/static/visualizer.html`
- Display step count summary badge on `workflow_completed` event
- Update workflow node label to include the summary

## Testing
- All pre-existing tests pass (4 pre-existing failures on `develop` baseline are unrelated to this change)