### PR TITLE
feat(notifications): add OpenClawNotificationChannel

### DIFF
--- a/examples/nexus-bot/.env.example
+++ b/examples/nexus-bot/.env.example
@@ -81,7 +81,7 @@ NEXUS_COMMAND_BRIDGE_ALLOWED_SENDER_IDS=
 # OpenClaw push notification channel (runtime=openclaw)
 # When set, Nexus will push workflow step completions and alerts directly to the
 # OpenClaw agent session via the OpenClaw hooks endpoint (/hooks/agent).
-# Requires hooks to be enabled in openclaw.json (see docs/automation/webhook.md).
+# Requires hooks to be enabled in openclaw.json (see openclaw.py module docstring for config).
 # NEXUS_OPENCLAW_BRIDGE_URL=http://127.0.0.1:18789
 # NEXUS_OPENCLAW_BRIDGE_TOKEN=your_openclaw_hooks_token_here
 # NEXUS_OPENCLAW_SENDER_ID=your_telegram_chat_id_here   # e.g. 47168736

--- a/examples/nexus-bot/.env.example
+++ b/examples/nexus-bot/.env.example
@@ -78,6 +78,14 @@ NEXUS_COMMAND_BRIDGE_ALLOWED_SOURCES=openclaw
 # Optional comma-separated allowlist of caller sender IDs.
 NEXUS_COMMAND_BRIDGE_ALLOWED_SENDER_IDS=
 
+# OpenClaw push notification channel (runtime=openclaw)
+# When set, Nexus will push workflow step completions and alerts to the OpenClaw
+# agent session instead of (or in addition to) the Telegram bot.
+# NEXUS_OPENCLAW_BRIDGE_URL=http://127.0.0.1:8082
+# NEXUS_OPENCLAW_BRIDGE_TOKEN=your_openclaw_gateway_token_here
+# NEXUS_OPENCLAW_SENDER_ID=your_telegram_chat_id_here
+# NEXUS_OPENCLAW_CHANNEL=telegram
+
 # ================================
 # INFRASTRUCTURE / STORAGE
 # ================================

--- a/examples/nexus-bot/.env.example
+++ b/examples/nexus-bot/.env.example
@@ -79,11 +79,12 @@ NEXUS_COMMAND_BRIDGE_ALLOWED_SOURCES=openclaw
 NEXUS_COMMAND_BRIDGE_ALLOWED_SENDER_IDS=
 
 # OpenClaw push notification channel (runtime=openclaw)
-# When set, Nexus will push workflow step completions and alerts to the OpenClaw
-# agent session instead of (or in addition to) the Telegram bot.
-# NEXUS_OPENCLAW_BRIDGE_URL=http://127.0.0.1:8082
-# NEXUS_OPENCLAW_BRIDGE_TOKEN=your_openclaw_gateway_token_here
-# NEXUS_OPENCLAW_SENDER_ID=your_telegram_chat_id_here
+# When set, Nexus will push workflow step completions and alerts directly to the
+# OpenClaw agent session via the OpenClaw hooks endpoint (/hooks/agent).
+# Requires hooks to be enabled in openclaw.json (see docs/automation/webhook.md).
+# NEXUS_OPENCLAW_BRIDGE_URL=http://127.0.0.1:18789
+# NEXUS_OPENCLAW_BRIDGE_TOKEN=your_openclaw_hooks_token_here
+# NEXUS_OPENCLAW_SENDER_ID=your_telegram_chat_id_here   # e.g. 47168736
 # NEXUS_OPENCLAW_CHANNEL=telegram
 
 # ================================

--- a/nexus/adapters/notifications/__init__.py
+++ b/nexus/adapters/notifications/__init__.py
@@ -2,6 +2,7 @@
 
 from nexus.adapters.notifications.base import Button, Message, NotificationChannel
 from nexus.adapters.notifications.discord import DiscordNotificationChannel
+from nexus.adapters.notifications.openclaw import OpenClawNotificationChannel
 from nexus.adapters.notifications.slack import SlackNotificationChannel
 
 __all__ = [
@@ -9,5 +10,6 @@ __all__ = [
     "Button",
     "Message",
     "DiscordNotificationChannel",
+    "OpenClawNotificationChannel",
     "SlackNotificationChannel",
 ]

--- a/nexus/adapters/notifications/openclaw.py
+++ b/nexus/adapters/notifications/openclaw.py
@@ -1,0 +1,146 @@
+"""OpenClaw notification channel — pushes Nexus workflow events to the OpenClaw command bridge.
+
+This allows Nexus ARC running in ``NEXUS_RUNTIME_MODE=openclaw`` to deliver
+step completions, alerts, and workflow updates directly to the OpenClaw agent
+session (e.g. a Telegram chat), without requiring a dedicated Nexus Telegram bot.
+
+Configuration (env vars or project_config.yaml plugin block):
+    NEXUS_OPENCLAW_BRIDGE_URL     URL of the OpenClaw command bridge (default: http://127.0.0.1:8082)
+    NEXUS_OPENCLAW_BRIDGE_TOKEN   Bearer token for the OpenClaw bridge
+    NEXUS_OPENCLAW_SENDER_ID      Sender/chat ID to deliver notifications to
+    NEXUS_OPENCLAW_CHANNEL        Optional channel hint (e.g. "telegram")
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+from typing import Any
+
+import aiohttp
+
+from nexus.adapters.notifications.base import Message, NotificationChannel
+from nexus.core.models import Severity
+
+logger = logging.getLogger(__name__)
+
+_DEFAULT_BRIDGE_URL = "http://127.0.0.1:8082"
+_SEVERITY_EMOJI = {
+    Severity.INFO: "ℹ️",
+    Severity.WARNING: "⚠️",
+    Severity.ERROR: "🚨",
+    Severity.CRITICAL: "🔴",
+}
+
+
+class OpenClawNotificationChannel(NotificationChannel):
+    """Sends Nexus notifications to an OpenClaw agent session via the OpenClaw bridge.
+
+    When Nexus is running in ``openclaw`` runtime mode this channel replaces (or
+    supplements) the Telegram bot, so workflow step completions, alerts, and
+    human-handoff prompts all arrive in the user's primary OpenClaw chat.
+
+    Args:
+        bridge_url: OpenClaw bridge URL.  Defaults to ``NEXUS_OPENCLAW_BRIDGE_URL`` env var.
+        auth_token: Bearer token for the bridge.  Defaults to ``NEXUS_OPENCLAW_BRIDGE_TOKEN``.
+        sender_id:  Target session/chat ID.  Defaults to ``NEXUS_OPENCLAW_SENDER_ID``.
+        channel:    Optional channel hint forwarded in the payload (e.g. ``"telegram"``).
+        timeout:    HTTP request timeout in seconds.
+    """
+
+    def __init__(
+        self,
+        bridge_url: str | None = None,
+        auth_token: str | None = None,
+        sender_id: str | None = None,
+        channel: str | None = None,
+        timeout: int = 10,
+    ):
+        self._bridge_url = (
+            (bridge_url or os.getenv("NEXUS_OPENCLAW_BRIDGE_URL") or _DEFAULT_BRIDGE_URL).rstrip("/")
+        )
+        self._auth_token = auth_token or os.getenv("NEXUS_OPENCLAW_BRIDGE_TOKEN") or ""
+        self._sender_id = sender_id or os.getenv("NEXUS_OPENCLAW_SENDER_ID") or ""
+        self._channel = channel or os.getenv("NEXUS_OPENCLAW_CHANNEL") or ""
+        self._timeout = aiohttp.ClientTimeout(total=timeout)
+
+    # ------------------------------------------------------------------
+    # NotificationChannel interface
+    # ------------------------------------------------------------------
+
+    @property
+    def name(self) -> str:
+        return "openclaw"
+
+    async def send_message(self, user_id: str, message: Message) -> str:
+        """Send a notification message to the OpenClaw session.
+
+        Returns a synthetic message ID (``"openclaw:<status>"``).
+        """
+        emoji = _SEVERITY_EMOJI.get(message.severity, "ℹ️")
+        text = f"{emoji} **[Nexus]** {message.text}"
+        payload = self._build_payload(text, target_user=user_id or self._sender_id)
+        ok = await self._post(payload)
+        return f"openclaw:{'ok' if ok else 'error'}"
+
+    async def update_message(self, message_id: str, new_text: str) -> None:
+        """OpenClaw bridge does not support in-place message edits; sends a new message."""
+        payload = self._build_payload(f"ℹ️ **[Nexus update]** {new_text}")
+        await self._post(payload)
+
+    async def send_alert(self, message: str, severity: Severity) -> None:
+        """Broadcast a system alert to the configured sender."""
+        emoji = _SEVERITY_EMOJI.get(severity, "⚠️")
+        text = f"{emoji} **[Nexus alert]** {message}"
+        payload = self._build_payload(text)
+        await self._post(payload)
+
+    async def request_input(self, user_id: str, prompt: str) -> str:
+        """Send a prompt requesting human input.
+
+        Note: OpenClaw does not support synchronous reply-wait via the bridge;
+        this sends the prompt and returns an empty string.  The user's response
+        will arrive as a normal chat message handled by the OpenClaw agent.
+        """
+        text = f"💬 **[Nexus needs input]** {prompt}"
+        payload = self._build_payload(text, target_user=user_id or self._sender_id)
+        await self._post(payload)
+        return ""
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    def _build_payload(self, text: str, target_user: str | None = None) -> dict[str, Any]:
+        payload: dict[str, Any] = {
+            "event": "nexus.notification",
+            "text": text,
+            "sender_id": target_user or self._sender_id,
+        }
+        if self._channel:
+            payload["channel"] = self._channel
+        return payload
+
+    def _headers(self) -> dict[str, str]:
+        headers = {"Content-Type": "application/json"}
+        if self._auth_token:
+            headers["Authorization"] = f"Bearer {self._auth_token}"
+        return headers
+
+    async def _post(self, payload: dict[str, Any]) -> bool:
+        url = f"{self._bridge_url}/api/v1/events/publish"
+        try:
+            async with aiohttp.ClientSession(timeout=self._timeout) as session:
+                async with session.post(url, json=payload, headers=self._headers()) as resp:
+                    if resp.status < 300:
+                        logger.debug("OpenClaw notification delivered (status=%s)", resp.status)
+                        return True
+                    body = await resp.text()
+                    logger.warning(
+                        "OpenClaw notification failed: HTTP %s — %s", resp.status, body[:200]
+                    )
+                    return False
+        except Exception as exc:
+            logger.warning("OpenClaw notification error: %s", exc)
+            return False

--- a/nexus/adapters/notifications/openclaw.py
+++ b/nexus/adapters/notifications/openclaw.py
@@ -52,7 +52,7 @@ def _require_aiohttp() -> None:
     if not _AIOHTTP_AVAILABLE:
         raise ImportError(
             "aiohttp is required for OpenClawNotificationChannel. "
-            "Install it with: pip install nexus-arc[openclaw]"
+            "Install it with: pip install aiohttp"
         )
 
 
@@ -86,7 +86,8 @@ class OpenClawNotificationChannel(NotificationChannel):
         self._auth_token = auth_token or os.getenv("NEXUS_OPENCLAW_BRIDGE_TOKEN") or ""
         self._sender_id = sender_id or os.getenv("NEXUS_OPENCLAW_SENDER_ID") or ""
         self._channel = channel or os.getenv("NEXUS_OPENCLAW_CHANNEL") or "telegram"
-        self._timeout = aiohttp.ClientTimeout(total=timeout)
+        self._timeout_seconds = timeout
+        self._sessions_by_loop: dict[object, aiohttp.ClientSession] = {}
 
     # ------------------------------------------------------------------
     # NotificationChannel interface
@@ -99,13 +100,20 @@ class OpenClawNotificationChannel(NotificationChannel):
     async def send_message(self, user_id: str, message: Message) -> str:
         """Send a notification message to the OpenClaw session.
 
-        Returns a synthetic message ID (``"openclaw:<status>"``).
+        Returns a synthetic message ID (``"openclaw:ok"``) on success, or an empty string on failure.
         """
         emoji = _SEVERITY_EMOJI.get(message.severity, "ℹ️")
         text = f"{emoji} **[Nexus]** {message.text}"
         payload = self._build_payload(text, target_user=user_id or self._sender_id)
         ok = await self._post(payload)
-        return f"openclaw:{'ok' if ok else 'error'}"
+        if not ok:
+            logger.error(
+                "Failed to send OpenClaw notification for user '%s' via bridge '%s'",
+                user_id or self._sender_id,
+                self._bridge_url,
+            )
+            return ""
+        return "openclaw:ok"
 
     async def update_message(self, message_id: str, new_text: str) -> None:
         """OpenClaw bridge does not support in-place message edits; sends a new message."""
@@ -156,20 +164,44 @@ class OpenClawNotificationChannel(NotificationChannel):
             headers["Authorization"] = f"Bearer {self._auth_token}"
         return headers
 
+    def _get_session(self) -> "aiohttp.ClientSession":
+        """Return a shared aiohttp session for the current event loop, creating it on first use."""
+        import asyncio
+
+        current_loop = asyncio.get_running_loop()
+        session = self._sessions_by_loop.get(current_loop)
+        if session is not None and session.closed:
+            self._sessions_by_loop.pop(current_loop, None)
+            session = None
+
+        if session is None:
+            timeout = aiohttp.ClientTimeout(total=self._timeout_seconds)
+            session = aiohttp.ClientSession(timeout=timeout)
+            self._sessions_by_loop[current_loop] = session
+
+        return session
+
+    async def aclose(self) -> None:
+        """Close all underlying aiohttp sessions."""
+        for session in list(self._sessions_by_loop.values()):
+            if not session.closed:
+                await session.close()
+        self._sessions_by_loop = {}
+
     async def _post(self, payload: dict[str, Any]) -> bool:
         # Use /hooks/agent to trigger an isolated agent delivery turn
         url = f"{self._bridge_url}/hooks/agent"
         try:
-            async with aiohttp.ClientSession(timeout=self._timeout) as session:
-                async with session.post(url, json=payload, headers=self._headers()) as resp:
-                    if resp.status < 300:
-                        logger.debug("OpenClaw notification delivered (status=%s)", resp.status)
-                        return True
-                    body = await resp.text()
-                    logger.warning(
-                        "OpenClaw notification failed: HTTP %s — %s", resp.status, body[:200]
-                    )
-                    return False
+            session = self._get_session()
+            async with session.post(url, json=payload, headers=self._headers()) as resp:
+                if resp.status < 300:
+                    logger.debug("OpenClaw notification delivered (status=%s)", resp.status)
+                    return True
+                body = await resp.text()
+                logger.warning(
+                    "OpenClaw notification failed: HTTP %s — %s", resp.status, body[:200]
+                )
+                return False
         except Exception as exc:
             logger.warning("OpenClaw notification error: %s", exc)
             return False

--- a/nexus/adapters/notifications/openclaw.py
+++ b/nexus/adapters/notifications/openclaw.py
@@ -5,10 +5,20 @@ step completions, alerts, and workflow updates directly to the OpenClaw agent
 session (e.g. a Telegram chat), without requiring a dedicated Nexus Telegram bot.
 
 Configuration (env vars or project_config.yaml plugin block):
-    NEXUS_OPENCLAW_BRIDGE_URL     URL of the OpenClaw command bridge (default: http://127.0.0.1:8082)
-    NEXUS_OPENCLAW_BRIDGE_TOKEN   Bearer token for the OpenClaw bridge
-    NEXUS_OPENCLAW_SENDER_ID      Sender/chat ID to deliver notifications to
+    NEXUS_OPENCLAW_BRIDGE_URL     Base URL of the OpenClaw gateway (default: http://127.0.0.1:18789)
+    NEXUS_OPENCLAW_BRIDGE_TOKEN   Bearer token for the OpenClaw hooks endpoint
+    NEXUS_OPENCLAW_SENDER_ID      Telegram/channel chat ID to deliver notifications to
     NEXUS_OPENCLAW_CHANNEL        Optional channel hint (e.g. "telegram")
+
+Requires hooks to be enabled in openclaw.json:
+    {
+      "hooks": {
+        "enabled": true,
+        "token": "<same as NEXUS_OPENCLAW_BRIDGE_TOKEN>",
+        "path": "/hooks",
+        "allowedAgentIds": ["main"]
+      }
+    }
 """
 
 from __future__ import annotations
@@ -25,7 +35,7 @@ from nexus.core.models import Severity
 
 logger = logging.getLogger(__name__)
 
-_DEFAULT_BRIDGE_URL = "http://127.0.0.1:8082"
+_DEFAULT_BRIDGE_URL = "http://127.0.0.1:18789"
 _SEVERITY_EMOJI = {
     Severity.INFO: "ℹ️",
     Severity.WARNING: "⚠️",
@@ -62,7 +72,7 @@ class OpenClawNotificationChannel(NotificationChannel):
         )
         self._auth_token = auth_token or os.getenv("NEXUS_OPENCLAW_BRIDGE_TOKEN") or ""
         self._sender_id = sender_id or os.getenv("NEXUS_OPENCLAW_SENDER_ID") or ""
-        self._channel = channel or os.getenv("NEXUS_OPENCLAW_CHANNEL") or ""
+        self._channel = channel or os.getenv("NEXUS_OPENCLAW_CHANNEL") or "telegram"
         self._timeout = aiohttp.ClientTimeout(total=timeout)
 
     # ------------------------------------------------------------------
@@ -113,13 +123,18 @@ class OpenClawNotificationChannel(NotificationChannel):
     # ------------------------------------------------------------------
 
     def _build_payload(self, text: str, target_user: str | None = None) -> dict[str, Any]:
+        """Build a /hooks/agent payload that delivers a message to the OpenClaw session."""
         payload: dict[str, Any] = {
-            "event": "nexus.notification",
-            "text": text,
-            "sender_id": target_user or self._sender_id,
+            "message": text,
+            "name": "Nexus",
+            "deliver": True,
+            "channel": self._channel or "telegram",
+            "wakeMode": "now",
         }
-        if self._channel:
-            payload["channel"] = self._channel
+        # If a specific recipient is set, pass it as `to`
+        recipient = target_user or self._sender_id
+        if recipient:
+            payload["to"] = recipient
         return payload
 
     def _headers(self) -> dict[str, str]:
@@ -129,7 +144,8 @@ class OpenClawNotificationChannel(NotificationChannel):
         return headers
 
     async def _post(self, payload: dict[str, Any]) -> bool:
-        url = f"{self._bridge_url}/api/v1/events/publish"
+        # Use /hooks/agent to trigger an isolated agent delivery turn
+        url = f"{self._bridge_url}/hooks/agent"
         try:
             async with aiohttp.ClientSession(timeout=self._timeout) as session:
                 async with session.post(url, json=payload, headers=self._headers()) as resp:

--- a/nexus/adapters/notifications/openclaw.py
+++ b/nexus/adapters/notifications/openclaw.py
@@ -23,15 +23,19 @@ Requires hooks to be enabled in openclaw.json:
 
 from __future__ import annotations
 
-import json
 import logging
 import os
 from typing import Any
 
-import aiohttp
-
 from nexus.adapters.notifications.base import Message, NotificationChannel
 from nexus.core.models import Severity
+
+try:
+    import aiohttp
+
+    _AIOHTTP_AVAILABLE = True
+except ImportError:
+    _AIOHTTP_AVAILABLE = False
 
 logger = logging.getLogger(__name__)
 
@@ -42,6 +46,14 @@ _SEVERITY_EMOJI = {
     Severity.ERROR: "🚨",
     Severity.CRITICAL: "🔴",
 }
+
+
+def _require_aiohttp() -> None:
+    if not _AIOHTTP_AVAILABLE:
+        raise ImportError(
+            "aiohttp is required for OpenClawNotificationChannel. "
+            "Install it with: pip install nexus-arc[openclaw]"
+        )
 
 
 class OpenClawNotificationChannel(NotificationChannel):
@@ -67,6 +79,7 @@ class OpenClawNotificationChannel(NotificationChannel):
         channel: str | None = None,
         timeout: int = 10,
     ):
+        _require_aiohttp()
         self._bridge_url = (
             (bridge_url or os.getenv("NEXUS_OPENCLAW_BRIDGE_URL") or _DEFAULT_BRIDGE_URL).rstrip("/")
         )

--- a/tests/test_adapters.py
+++ b/tests/test_adapters.py
@@ -1577,34 +1577,36 @@ class TestOpenClawNotificationChannel:
     def _make_channel(self):
         """Create an OpenClawNotificationChannel bypassing __init__ for test setup.
 
-        Note: aiohttp must be installed for most tests to run; tests are skipped
-        when it is unavailable.
+        Bypasses ``__init__`` entirely so no ``aiohttp`` import is needed; only
+        tests that exercise ``_post`` or ``__init__`` directly require ``aiohttp``.
         """
-        from nexus.adapters.notifications.openclaw import (
-            _AIOHTTP_AVAILABLE,
-            OpenClawNotificationChannel,
-        )
-
-        if not _AIOHTTP_AVAILABLE:
-            pytest.skip("aiohttp not installed")
+        from nexus.adapters.notifications.openclaw import OpenClawNotificationChannel
 
         channel = OpenClawNotificationChannel.__new__(OpenClawNotificationChannel)
         channel._bridge_url = "http://127.0.0.1:18789"
         channel._auth_token = "test-token"
         channel._sender_id = "12345"
         channel._channel = "telegram"
+        channel._timeout_seconds = 10
+        channel._sessions_by_loop = {}
         return channel
 
     def test_name(self):
-        from nexus.adapters.notifications.openclaw import (
-            _AIOHTTP_AVAILABLE,
-            OpenClawNotificationChannel,
-        )
+        from nexus.adapters.notifications.openclaw import OpenClawNotificationChannel
 
-        if not _AIOHTTP_AVAILABLE:
-            pytest.skip("aiohttp not installed")
         channel = OpenClawNotificationChannel.__new__(OpenClawNotificationChannel)
         assert channel.name == "openclaw"
+
+    def test_init_raises_importerror_without_aiohttp(self):
+        import nexus.adapters.notifications.openclaw as _mod
+
+        original = _mod._AIOHTTP_AVAILABLE
+        _mod._AIOHTTP_AVAILABLE = False
+        try:
+            with pytest.raises(ImportError, match="pip install aiohttp"):
+                _mod.OpenClawNotificationChannel()
+        finally:
+            _mod._AIOHTTP_AVAILABLE = original
 
     def test_build_payload_basic(self):
         channel = self._make_channel()
@@ -1660,7 +1662,7 @@ class TestOpenClawNotificationChannel:
         msg = Message(text="Step failed", severity=Severity.ERROR)
         with patch.object(channel, "_post", new=AsyncMock(return_value=False)):
             result = await channel.send_message("user1", msg)
-        assert result == "openclaw:error"
+        assert result == ""
 
     async def test_send_alert_posts_with_severity_emoji(self):
         from nexus.core.models import Severity

--- a/tests/test_adapters.py
+++ b/tests/test_adapters.py
@@ -1566,3 +1566,132 @@ class TestDiscordNotificationChannel:
         with patch.object(channel, "_post_webhook", side_effect=error):
             with pytest.raises(RuntimeError, match="Discord API 403"):
                 await channel.send_message("chan123", Message(text="test"))
+
+
+# ---------------------------------------------------------------------------
+# OpenClawNotificationChannel
+# ---------------------------------------------------------------------------
+
+
+class TestOpenClawNotificationChannel:
+    def _make_channel(self):
+        """Create an OpenClawNotificationChannel bypassing __init__ for test setup.
+
+        Note: aiohttp must be installed for most tests to run; tests are skipped
+        when it is unavailable.
+        """
+        from nexus.adapters.notifications.openclaw import (
+            _AIOHTTP_AVAILABLE,
+            OpenClawNotificationChannel,
+        )
+
+        if not _AIOHTTP_AVAILABLE:
+            pytest.skip("aiohttp not installed")
+
+        channel = OpenClawNotificationChannel.__new__(OpenClawNotificationChannel)
+        channel._bridge_url = "http://127.0.0.1:18789"
+        channel._auth_token = "test-token"
+        channel._sender_id = "12345"
+        channel._channel = "telegram"
+        return channel
+
+    def test_name(self):
+        from nexus.adapters.notifications.openclaw import (
+            _AIOHTTP_AVAILABLE,
+            OpenClawNotificationChannel,
+        )
+
+        if not _AIOHTTP_AVAILABLE:
+            pytest.skip("aiohttp not installed")
+        channel = OpenClawNotificationChannel.__new__(OpenClawNotificationChannel)
+        assert channel.name == "openclaw"
+
+    def test_build_payload_basic(self):
+        channel = self._make_channel()
+        payload = channel._build_payload("Hello OpenClaw")
+        assert payload["message"] == "Hello OpenClaw"
+        assert payload["name"] == "Nexus"
+        assert payload["deliver"] is True
+        assert payload["channel"] == "telegram"
+
+    def test_build_payload_includes_to_when_recipient_set(self):
+        channel = self._make_channel()
+        payload = channel._build_payload("Hi", target_user="99999")
+        assert payload["to"] == "99999"
+
+    def test_build_payload_falls_back_to_sender_id(self):
+        channel = self._make_channel()
+        payload = channel._build_payload("Hi")
+        assert payload["to"] == "12345"
+
+    def test_build_payload_omits_to_when_no_recipient(self):
+        channel = self._make_channel()
+        channel._sender_id = ""
+        payload = channel._build_payload("Hi", target_user="")
+        assert "to" not in payload
+
+    def test_headers_include_bearer_token(self):
+        channel = self._make_channel()
+        headers = channel._headers()
+        assert headers["Authorization"] == "Bearer test-token"
+        assert headers["Content-Type"] == "application/json"
+
+    def test_headers_omit_authorization_when_no_token(self):
+        channel = self._make_channel()
+        channel._auth_token = ""
+        headers = channel._headers()
+        assert "Authorization" not in headers
+
+    async def test_send_message_returns_ok_on_success(self):
+        from nexus.adapters.notifications.base import Message
+        from nexus.core.models import Severity
+
+        channel = self._make_channel()
+        msg = Message(text="Workflow complete", severity=Severity.INFO)
+        with patch.object(channel, "_post", new=AsyncMock(return_value=True)):
+            result = await channel.send_message("user1", msg)
+        assert result == "openclaw:ok"
+
+    async def test_send_message_returns_error_on_failure(self):
+        from nexus.adapters.notifications.base import Message
+        from nexus.core.models import Severity
+
+        channel = self._make_channel()
+        msg = Message(text="Step failed", severity=Severity.ERROR)
+        with patch.object(channel, "_post", new=AsyncMock(return_value=False)):
+            result = await channel.send_message("user1", msg)
+        assert result == "openclaw:error"
+
+    async def test_send_alert_posts_with_severity_emoji(self):
+        from nexus.core.models import Severity
+
+        channel = self._make_channel()
+        with patch.object(channel, "_post", new=AsyncMock(return_value=True)) as mock_post:
+            await channel.send_alert("Disk full", Severity.CRITICAL)
+        payload = mock_post.call_args[0][0]
+        assert "🔴" in payload["message"]
+        assert "Disk full" in payload["message"]
+
+    async def test_update_message_sends_new_message(self):
+        channel = self._make_channel()
+        with patch.object(channel, "_post", new=AsyncMock(return_value=True)) as mock_post:
+            await channel.update_message("openclaw:ok", "Updated text")
+        payload = mock_post.call_args[0][0]
+        assert "Updated text" in payload["message"]
+
+    async def test_request_input_returns_empty_string(self):
+        channel = self._make_channel()
+        with patch.object(channel, "_post", new=AsyncMock(return_value=True)):
+            result = await channel.request_input("user1", "Please confirm?")
+        assert result == ""
+
+    def test_require_aiohttp_raises_when_unavailable(self):
+        import nexus.adapters.notifications.openclaw as _mod
+
+        original = _mod._AIOHTTP_AVAILABLE
+        _mod._AIOHTTP_AVAILABLE = False
+        try:
+            with pytest.raises(ImportError, match="aiohttp"):
+                _mod._require_aiohttp()
+        finally:
+            _mod._AIOHTTP_AVAILABLE = original


### PR DESCRIPTION
- [x] Identify root cause: `import aiohttp` at module top level in `openclaw.py` causes `ModuleNotFoundError` when `aiohttp` is not installed, breaking entire test suite
- [x] Fix `openclaw.py`: wrap `import aiohttp` in `try/except ImportError`, add `_AIOHTTP_AVAILABLE` flag and `_require_aiohttp()` guard called in `__init__`, remove unused `json` import
- [x] Add `TestOpenClawNotificationChannel` to `tests/test_adapters.py` with 13 tests (name, payload building, headers, send_message, send_alert, update_message, request_input, aiohttp guard)
- [x] All 88 tests pass

<!-- START COPILOT CODING AGENT TIPS -->
---

📱 Kick off Copilot coding agent tasks wherever you are with [GitHub Mobile](https://gh.io/cca-mobile-docs), available on iOS and Android.