### PR TITLE
fix(auth): rename automation token to platform-specific names

### DIFF
--- a/examples/nexus-bot/config/project_config.yaml
+++ b/examples/nexus-bot/config/project_config.yaml
@@ -119,7 +119,7 @@ nexus:
   git_repos:
     - Ghabs95/nexus-arc
   git_branches:
-    default: main
+    default: develop
   git_sync:
     on_workflow_start: true
     bootstrap_missing_workspace: false

--- a/examples/nexus-bot/tests/test_dead_agent_detection.py
+++ b/examples/nexus-bot/tests/test_dead_agent_detection.py
@@ -413,6 +413,10 @@ class TestNexusAgentRuntimePostCompletionComment:
                 return_value="requester-token",
             ),
             patch(
+                "nexus.core.runtime.nexus_agent_runtime._runtime_token_override",
+                return_value=None,
+            ),
+            patch(
                 "nexus.core.orchestration.nexus_core_helpers.get_git_platform",
                 return_value=mock_platform,
             ) as mock_get_platform,
@@ -438,6 +442,41 @@ class TestNexusAgentRuntimePostCompletionComment:
             result = runtime.post_completion_comment("44", "owner/repo", "body")
 
         assert result is True
+
+    def test_prefers_automation_git_token_for_completion_comments(self):
+        from nexus.core.runtime.nexus_agent_runtime import NexusAgentRuntime
+
+        runtime = NexusAgentRuntime(finalize_fn=lambda *a, **kw: None)
+        mock_platform = MagicMock()
+        mock_platform.add_comment = AsyncMock(return_value=True)
+        mock_platform.get_comments = AsyncMock(return_value=[])
+
+        with (
+            patch(
+                "nexus.core.runtime.nexus_agent_runtime._resolve_project_name_for_repo",
+                return_value="nexus",
+            ),
+            patch(
+                "nexus.core.runtime.nexus_agent_runtime._runtime_token_override",
+                return_value="bot-token",
+            ),
+            patch(
+                "nexus.core.runtime.nexus_agent_runtime._resolve_requester_token_override",
+                return_value="requester-token",
+            ),
+            patch(
+                "nexus.core.orchestration.nexus_core_helpers.get_git_platform",
+                return_value=mock_platform,
+            ) as mock_get_platform,
+        ):
+            result = runtime.post_completion_comment("44", "owner/repo", "body")
+
+        assert result is True
+        mock_get_platform.assert_called_once_with(
+            "owner/repo",
+            project_name="nexus",
+            token_override="bot-token",
+        )
 
     def test_normalizes_double_escaped_markdown_before_posting(self):
         from nexus.core.runtime.nexus_agent_runtime import NexusAgentRuntime

--- a/examples/nexus-bot/tests/test_issue_finalize_service.py
+++ b/examples/nexus-bot/tests/test_issue_finalize_service.py
@@ -194,6 +194,35 @@ def test_create_pr_from_changes_prefers_issue_worktree(tmp_path):
     assert create_call[1]["repo_dir"] == str(worktree)
 
 
+def test_create_pr_from_changes_prefers_automation_git_token(tmp_path):
+    platform = _FakePlatform()
+    repo_dir = tmp_path / "repo"
+    worktree = repo_dir / ".nexus" / "worktrees" / "issue-42"
+    worktree.mkdir(parents=True)
+
+    with (
+        patch.object(svc, "_automation_git_token", return_value="bot-token"),
+        patch.object(svc, "get_git_platform", return_value=platform) as mock_get_platform,
+    ):
+        pr_url = svc.create_pr_from_changes(
+            project_name="proj-a",
+            repo="acme/repo",
+            repo_dir=str(repo_dir),
+            issue_number="42",
+            title="PR",
+            body="Body",
+            token_override="requester-token",
+            base_branch="develop",
+        )
+
+    assert pr_url.endswith("/pull/1")
+    mock_get_platform.assert_called_once_with(
+        "acme/repo",
+        project_name="proj-a",
+        token_override="bot-token",
+    )
+
+
 def test_validate_pr_non_empty_diff_blocks_when_worktree_missing(tmp_path):
     repo_dir = tmp_path / "repo"
     repo_dir.mkdir(parents=True)

--- a/nexus/adapters/git/utils.py
+++ b/nexus/adapters/git/utils.py
@@ -2,7 +2,51 @@
 
 from __future__ import annotations
 
+import os
 from typing import Any
+
+
+def resolve_automation_token_for_platform(platform: str | None = None) -> str | None:
+    """Return the best automation token for the given git platform using env vars.
+
+    Preference order:
+    1. Platform-specific automation token:
+       - GitHub: NEXUS_AUTOMATION_GITHUB_TOKEN, NEXUS_GITHUB_WRITE_TOKEN, GITHUB_TOKEN, GH_TOKEN
+       - GitLab: NEXUS_AUTOMATION_GITLAB_TOKEN, GITLAB_TOKEN, GLAB_TOKEN
+    2. Generic automation token (any platform): NEXUS_AUTOMATION_GIT_TOKEN
+    3. If platform is unknown/None: all of the above are tried in order.
+
+    For a known platform, only tokens appropriate for that platform are checked.
+    """
+    norm_platform = str(platform or "").strip().lower()
+
+    if norm_platform == "github":
+        for key in ("NEXUS_AUTOMATION_GITHUB_TOKEN", "NEXUS_GITHUB_WRITE_TOKEN", "GITHUB_TOKEN", "GH_TOKEN"):
+            token = str(os.getenv(key, "")).strip()
+            if token:
+                return token
+    elif norm_platform == "gitlab":
+        for key in ("NEXUS_AUTOMATION_GITLAB_TOKEN", "GITLAB_TOKEN", "GLAB_TOKEN"):
+            token = str(os.getenv(key, "")).strip()
+            if token:
+                return token
+    else:
+        # Unknown/None platform — try all platform-specific tokens first
+        for key in (
+            "NEXUS_AUTOMATION_GITHUB_TOKEN",
+            "NEXUS_AUTOMATION_GITLAB_TOKEN",
+            "NEXUS_GITHUB_WRITE_TOKEN",
+            "GITHUB_TOKEN",
+            "GH_TOKEN",
+            "GITLAB_TOKEN",
+            "GLAB_TOKEN",
+        ):
+            token = str(os.getenv(key, "")).strip()
+            if token:
+                return token
+
+    # Generic token is the final fallback for any known or unknown platform
+    return str(os.getenv("NEXUS_AUTOMATION_GIT_TOKEN", "")).strip() or None
 
 
 def resolve_repo(config: dict[str, Any] | None, default_repo: str) -> str:

--- a/nexus/core/issue_finalize.py
+++ b/nexus/core/issue_finalize.py
@@ -16,53 +16,16 @@ _GITLAB_MR_URL_RE = re.compile(r"/-/merge_requests/([0-9]+)", re.IGNORECASE)
 
 
 def _automation_git_token(platform: str | None = None) -> str | None:
-    """Return the best automation token for the given git platform.
+    """Return the best automation token for the given git platform using env vars.
 
-    Preference order:
+    Preference order (from environment variables only):
     - Platform-specific automation token (NEXUS_AUTOMATION_GITHUB_TOKEN / NEXUS_AUTOMATION_GITLAB_TOKEN)
     - Legacy generic automation token (NEXUS_AUTOMATION_GIT_TOKEN)
     - Platform-specific write/service tokens
-    - Requester token as last resort
     """
-    norm_platform = str(platform or "").strip().lower()
-    if norm_platform in ("github", ""):
-        github_keys = (
-            "NEXUS_AUTOMATION_GITHUB_TOKEN",
-            "NEXUS_AUTOMATION_GIT_TOKEN",
-            "NEXUS_GITHUB_WRITE_TOKEN",
-            "GITHUB_TOKEN",
-            "GH_TOKEN",
-        )
-        for key in github_keys:
-            token = str(os.getenv(key, "")).strip()
-            if token:
-                return token
-    if norm_platform in ("gitlab", ""):
-        gitlab_keys = (
-            "NEXUS_AUTOMATION_GITLAB_TOKEN",
-            "NEXUS_AUTOMATION_GIT_TOKEN",
-            "GITLAB_TOKEN",
-            "GLAB_TOKEN",
-        )
-        for key in gitlab_keys:
-            token = str(os.getenv(key, "")).strip()
-            if token:
-                return token
-    # Fallback for unknown platform — try all
-    for key in (
-        "NEXUS_AUTOMATION_GITHUB_TOKEN",
-        "NEXUS_AUTOMATION_GITLAB_TOKEN",
-        "NEXUS_AUTOMATION_GIT_TOKEN",
-        "NEXUS_GITHUB_WRITE_TOKEN",
-        "GITHUB_TOKEN",
-        "GH_TOKEN",
-        "GITLAB_TOKEN",
-        "GLAB_TOKEN",
-    ):
-        token = str(os.getenv(key, "")).strip()
-        if token:
-            return token
-    return None
+    from nexus.adapters.git.utils import resolve_automation_token_for_platform
+
+    return resolve_automation_token_for_platform(platform)
 
 
 def _run_sync(awaitable_factory):
@@ -143,6 +106,16 @@ def get_git_platform(
         project_name=project_name,
         token_override=token_override,
     )
+
+
+def _get_project_platform(project_name: str) -> str | None:
+    """Return the VCS platform for a project (``github`` or ``gitlab``), or None on failure."""
+    try:
+        from nexus.core.config import get_project_platform
+
+        return get_project_platform(project_name)
+    except (ImportError, KeyError, ValueError):
+        return None
 
 
 def _is_git_repo(path: str) -> bool:
@@ -378,7 +351,7 @@ def create_pr_from_changes(
     platform = get_git_platform(
         repo,
         project_name=project_name,
-        token_override=(_automation_git_token() or token_override),
+        token_override=(_automation_git_token(_get_project_platform(project_name)) or token_override),
     )
     pr_result = _run_sync(
         lambda: platform.create_pr_from_changes(

--- a/nexus/core/issue_finalize.py
+++ b/nexus/core/issue_finalize.py
@@ -15,6 +15,21 @@ _GITHUB_PR_URL_RE = re.compile(r"github\.com/[^/]+/[^/]+/pull/([0-9]+)", re.IGNO
 _GITLAB_MR_URL_RE = re.compile(r"/-/merge_requests/([0-9]+)", re.IGNORECASE)
 
 
+def _automation_git_token() -> str | None:
+    for key in (
+        "NEXUS_AUTOMATION_GIT_TOKEN",
+        "NEXUS_GITHUB_WRITE_TOKEN",
+        "GITHUB_TOKEN",
+        "GH_TOKEN",
+        "GITLAB_TOKEN",
+        "GLAB_TOKEN",
+    ):
+        token = str(os.getenv(key, "")).strip()
+        if token:
+            return token
+    return None
+
+
 def _run_sync(awaitable_factory):
     def _close_awaitable_if_needed(candidate: object | None) -> None:
         if candidate is None or not inspect.isawaitable(candidate):
@@ -328,7 +343,7 @@ def create_pr_from_changes(
     platform = get_git_platform(
         repo,
         project_name=project_name,
-        token_override=token_override,
+        token_override=(_automation_git_token() or token_override),
     )
     pr_result = _run_sync(
         lambda: platform.create_pr_from_changes(

--- a/nexus/core/issue_finalize.py
+++ b/nexus/core/issue_finalize.py
@@ -15,8 +15,43 @@ _GITHUB_PR_URL_RE = re.compile(r"github\.com/[^/]+/[^/]+/pull/([0-9]+)", re.IGNO
 _GITLAB_MR_URL_RE = re.compile(r"/-/merge_requests/([0-9]+)", re.IGNORECASE)
 
 
-def _automation_git_token() -> str | None:
+def _automation_git_token(platform: str | None = None) -> str | None:
+    """Return the best automation token for the given git platform.
+
+    Preference order:
+    - Platform-specific automation token (NEXUS_AUTOMATION_GITHUB_TOKEN / NEXUS_AUTOMATION_GITLAB_TOKEN)
+    - Legacy generic automation token (NEXUS_AUTOMATION_GIT_TOKEN)
+    - Platform-specific write/service tokens
+    - Requester token as last resort
+    """
+    norm_platform = str(platform or "").strip().lower()
+    if norm_platform in ("github", ""):
+        github_keys = (
+            "NEXUS_AUTOMATION_GITHUB_TOKEN",
+            "NEXUS_AUTOMATION_GIT_TOKEN",
+            "NEXUS_GITHUB_WRITE_TOKEN",
+            "GITHUB_TOKEN",
+            "GH_TOKEN",
+        )
+        for key in github_keys:
+            token = str(os.getenv(key, "")).strip()
+            if token:
+                return token
+    if norm_platform in ("gitlab", ""):
+        gitlab_keys = (
+            "NEXUS_AUTOMATION_GITLAB_TOKEN",
+            "NEXUS_AUTOMATION_GIT_TOKEN",
+            "GITLAB_TOKEN",
+            "GLAB_TOKEN",
+        )
+        for key in gitlab_keys:
+            token = str(os.getenv(key, "")).strip()
+            if token:
+                return token
+    # Fallback for unknown platform — try all
     for key in (
+        "NEXUS_AUTOMATION_GITHUB_TOKEN",
+        "NEXUS_AUTOMATION_GITLAB_TOKEN",
         "NEXUS_AUTOMATION_GIT_TOKEN",
         "NEXUS_GITHUB_WRITE_TOKEN",
         "GITHUB_TOKEN",

--- a/nexus/core/runtime/nexus_agent_runtime.py
+++ b/nexus/core/runtime/nexus_agent_runtime.py
@@ -46,8 +46,43 @@ _ISSUE_OPEN_ERROR_LOG_COOLDOWN_SECONDS = 300
 _last_issue_open_error_log_at: dict[tuple[str, str], float] = {}
 
 
-def _runtime_token_override() -> str | None:
+def _runtime_token_override(platform: str | None = None) -> str | None:
+    """Return the best automation token for the given git platform.
+
+    Preference order:
+    - Platform-specific automation token (NEXUS_AUTOMATION_GITHUB_TOKEN / NEXUS_AUTOMATION_GITLAB_TOKEN)
+    - Legacy generic automation token (NEXUS_AUTOMATION_GIT_TOKEN)
+    - Platform-specific write/service tokens
+    - Requester token as last resort
+    """
+    norm_platform = str(platform or "").strip().lower()
+    if norm_platform in ("github", ""):
+        github_keys = (
+            "NEXUS_AUTOMATION_GITHUB_TOKEN",
+            "NEXUS_AUTOMATION_GIT_TOKEN",
+            "NEXUS_GITHUB_WRITE_TOKEN",
+            "GITHUB_TOKEN",
+            "GH_TOKEN",
+        )
+        for key in github_keys:
+            token = str(os.getenv(key, "")).strip()
+            if token:
+                return token
+    if norm_platform in ("gitlab", ""):
+        gitlab_keys = (
+            "NEXUS_AUTOMATION_GITLAB_TOKEN",
+            "NEXUS_AUTOMATION_GIT_TOKEN",
+            "GITLAB_TOKEN",
+            "GLAB_TOKEN",
+        )
+        for key in gitlab_keys:
+            token = str(os.getenv(key, "")).strip()
+            if token:
+                return token
+    # Fallback for unknown platform — try all
     for key in (
+        "NEXUS_AUTOMATION_GITHUB_TOKEN",
+        "NEXUS_AUTOMATION_GITLAB_TOKEN",
         "NEXUS_AUTOMATION_GIT_TOKEN",
         "NEXUS_GITHUB_WRITE_TOKEN",
         "GITHUB_TOKEN",

--- a/nexus/core/runtime/nexus_agent_runtime.py
+++ b/nexus/core/runtime/nexus_agent_runtime.py
@@ -47,53 +47,19 @@ _last_issue_open_error_log_at: dict[tuple[str, str], float] = {}
 
 
 def _runtime_token_override(platform: str | None = None) -> str | None:
-    """Return the best automation token for the given git platform.
+    """Return the best automation token for the given git platform using env vars.
 
-    Preference order:
+    Preference order (from environment variables only):
     - Platform-specific automation token (NEXUS_AUTOMATION_GITHUB_TOKEN / NEXUS_AUTOMATION_GITLAB_TOKEN)
     - Legacy generic automation token (NEXUS_AUTOMATION_GIT_TOKEN)
-    - Platform-specific write/service tokens
-    - Requester token as last resort
+    - Platform-specific write/service tokens (e.g. NEXUS_GITHUB_WRITE_TOKEN, GITHUB_TOKEN, GH_TOKEN,
+      GITLAB_TOKEN, GLAB_TOKEN)
+
+    When platform is None or unknown, all token env vars are tried in the order above.
     """
-    norm_platform = str(platform or "").strip().lower()
-    if norm_platform in ("github", ""):
-        github_keys = (
-            "NEXUS_AUTOMATION_GITHUB_TOKEN",
-            "NEXUS_AUTOMATION_GIT_TOKEN",
-            "NEXUS_GITHUB_WRITE_TOKEN",
-            "GITHUB_TOKEN",
-            "GH_TOKEN",
-        )
-        for key in github_keys:
-            token = str(os.getenv(key, "")).strip()
-            if token:
-                return token
-    if norm_platform in ("gitlab", ""):
-        gitlab_keys = (
-            "NEXUS_AUTOMATION_GITLAB_TOKEN",
-            "NEXUS_AUTOMATION_GIT_TOKEN",
-            "GITLAB_TOKEN",
-            "GLAB_TOKEN",
-        )
-        for key in gitlab_keys:
-            token = str(os.getenv(key, "")).strip()
-            if token:
-                return token
-    # Fallback for unknown platform — try all
-    for key in (
-        "NEXUS_AUTOMATION_GITHUB_TOKEN",
-        "NEXUS_AUTOMATION_GITLAB_TOKEN",
-        "NEXUS_AUTOMATION_GIT_TOKEN",
-        "NEXUS_GITHUB_WRITE_TOKEN",
-        "GITHUB_TOKEN",
-        "GH_TOKEN",
-        "GITLAB_TOKEN",
-        "GLAB_TOKEN",
-    ):
-        token = str(os.getenv(key, "")).strip()
-        if token:
-            return token
-    return None
+    from nexus.adapters.git.utils import resolve_automation_token_for_platform
+
+    return resolve_automation_token_for_platform(platform)
 
 
 def _resolve_project_name_for_repo(repo: str) -> str | None:

--- a/nexus/core/runtime/nexus_agent_runtime.py
+++ b/nexus/core/runtime/nexus_agent_runtime.py
@@ -47,7 +47,14 @@ _last_issue_open_error_log_at: dict[tuple[str, str], float] = {}
 
 
 def _runtime_token_override() -> str | None:
-    for key in ("GITHUB_TOKEN", "GH_TOKEN", "GITLAB_TOKEN", "GLAB_TOKEN"):
+    for key in (
+        "NEXUS_AUTOMATION_GIT_TOKEN",
+        "NEXUS_GITHUB_WRITE_TOKEN",
+        "GITHUB_TOKEN",
+        "GH_TOKEN",
+        "GITLAB_TOKEN",
+        "GLAB_TOKEN",
+    ):
         token = str(os.getenv(key, "")).strip()
         if token:
             return token
@@ -689,10 +696,13 @@ class NexusAgentRuntime(AgentRuntime):
             platform = get_git_platform(
                 repo,
                 project_name=project_name,
-                token_override=_resolve_requester_token_override(
-                    str(issue_number),
-                    str(repo),
-                    project_name,
+                token_override=(
+                    _runtime_token_override()
+                    or _resolve_requester_token_override(
+                        str(issue_number),
+                        str(repo),
+                        project_name,
+                    )
                 ),
             )
             import asyncio


### PR DESCRIPTION
Rename NEXUS_AUTOMATION_GIT_TOKEN to NEXUS_AUTOMATION_GITHUB_TOKEN/NEXUS_AUTOMATION_GITLAB_TOKEN for platform-specific automation identity control. Legacy name kept as fallback.