### PR TITLE
feat: add OpenClaw operator surface for Nexus workflows

### DIFF
--- a/docs/OPENCLAW_OPERATOR_SURFACE.md
+++ b/docs/OPENCLAW_OPERATOR_SURFACE.md
@@ -1,0 +1,169 @@
+# OpenClaw Operator Surface for Nexus ARC
+
+This document describes the operator-oriented Nexus ARC command bridge endpoints
+intended for OpenClaw and other trusted control-plane clients.
+
+## Purpose
+
+The original OpenClaw integration was primarily push-based: Nexus could send
+notifications and workflow events into OpenClaw.
+
+The operator surface adds a read/control layer so OpenClaw can also:
+- inspect workflow state
+- summarize active or failed workflows
+- inspect runtime health
+- explain routing decisions
+- perform safe workflow control actions
+
+## Authentication
+
+All `/api/v1/operator/*` endpoints use the same bearer-token protection as the
+main command bridge.
+
+Example:
+
+```bash
+curl -s http://127.0.0.1:8091/api/v1/operator/runtime-health \
+  -H "Authorization: Bearer $NEXUS_COMMAND_BRIDGE_AUTH_TOKEN"
+```
+
+## Read Endpoints
+
+### Runtime health
+
+```bash
+curl -s http://127.0.0.1:8091/api/v1/operator/runtime-health \
+  -H "Authorization: Bearer $NEXUS_COMMAND_BRIDGE_AUTH_TOKEN"
+```
+
+Returns a compact runtime summary including:
+- runtime mode
+- storage backend
+- bridge/OpenClaw env presence
+- availability of `gh`, `glab`, and `pgrep`
+- active/recent failure counts
+
+### Active workflows
+
+```bash
+curl -s "http://127.0.0.1:8091/api/v1/operator/workflows/active?limit=20" \
+  -H "Authorization: Bearer $NEXUS_COMMAND_BRIDGE_AUTH_TOKEN"
+```
+
+### Recent failures
+
+```bash
+curl -s "http://127.0.0.1:8091/api/v1/operator/workflows/recent-failures?limit=20" \
+  -H "Authorization: Bearer $NEXUS_COMMAND_BRIDGE_AUTH_TOKEN"
+```
+
+### Workflow status
+
+By workflow id:
+
+```bash
+curl -s "http://127.0.0.1:8091/api/v1/operator/workflows/status?workflow_id=nexus-123-full" \
+  -H "Authorization: Bearer $NEXUS_COMMAND_BRIDGE_AUTH_TOKEN"
+```
+
+By issue number:
+
+```bash
+curl -s "http://127.0.0.1:8091/api/v1/operator/workflows/status?issue_number=123" \
+  -H "Authorization: Bearer $NEXUS_COMMAND_BRIDGE_AUTH_TOKEN"
+```
+
+### Workflow summary
+
+This is the friendlier endpoint meant for “what is going on here?” questions.
+It returns:
+- a compact summary string
+- the inferred reason/state explanation
+- suggested next actions
+- underlying workflow details
+
+```bash
+curl -s "http://127.0.0.1:8091/api/v1/operator/workflows/summary?workflow_id=nexus-123-full" \
+  -H "Authorization: Bearer $NEXUS_COMMAND_BRIDGE_AUTH_TOKEN"
+```
+
+### Git identity status
+
+```bash
+curl -s http://127.0.0.1:8091/api/v1/operator/git/identity \
+  -H "Authorization: Bearer $NEXUS_COMMAND_BRIDGE_AUTH_TOKEN"
+```
+
+Returns best-effort authentication/availability status for:
+- `gh`
+- `glab`
+- relevant automation-token env presence (presence only, never secret values)
+
+### Routing explain
+
+```bash
+curl -s "http://127.0.0.1:8091/api/v1/operator/routing/explain?project_key=nexus&task_type=feature" \
+  -H "Authorization: Bearer $NEXUS_COMMAND_BRIDGE_AUTH_TOKEN"
+```
+
+Returns a structured explanation of:
+- resolved project config
+- workflow path
+- repo(s)
+- default branch
+- git platform
+- agent preference/profile (when determinable)
+
+## Safe Control Endpoints
+
+### Continue workflow
+
+```bash
+curl -s -X POST http://127.0.0.1:8091/api/v1/operator/workflows/continue \
+  -H "Authorization: Bearer $NEXUS_COMMAND_BRIDGE_AUTH_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"issue_number":"123"}'
+```
+
+Optional targeted reset to an agent before continuing:
+
+```bash
+curl -s -X POST http://127.0.0.1:8091/api/v1/operator/workflows/continue \
+  -H "Authorization: Bearer $NEXUS_COMMAND_BRIDGE_AUTH_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"issue_number":"123","target_agent":"developer"}'
+```
+
+### Retry step
+
+```bash
+curl -s -X POST http://127.0.0.1:8091/api/v1/operator/workflows/retry-step \
+  -H "Authorization: Bearer $NEXUS_COMMAND_BRIDGE_AUTH_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"issue_number":"123","target_agent":"developer"}'
+```
+
+### Cancel workflow
+
+```bash
+curl -s -X POST http://127.0.0.1:8091/api/v1/operator/workflows/cancel \
+  -H "Authorization: Bearer $NEXUS_COMMAND_BRIDGE_AUTH_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"issue_number":"123"}'
+```
+
+### Refresh state
+
+```bash
+curl -s -X POST http://127.0.0.1:8091/api/v1/operator/workflows/refresh-state \
+  -H "Authorization: Bearer $NEXUS_COMMAND_BRIDGE_AUTH_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"issue_number":"123"}'
+```
+
+## Notes
+
+- These endpoints are intentionally operator-oriented and best-effort.
+- They are not a replacement for deeper workflow/event inspection.
+- The summary endpoint is designed for OpenClaw-style “explain this quickly” UX.
+- Token/env reporting only exposes presence/availability, never secret values.

--- a/nexus/core/command_bridge/http.py
+++ b/nexus/core/command_bridge/http.py
@@ -9,6 +9,7 @@ import threading
 import time
 from dataclasses import dataclass, field
 from typing import Any
+from urllib.parse import parse_qs
 from wsgiref.simple_server import make_server
 
 from nexus.core.command_bridge.models import CommandRequest, CommandResult, ReplyRequest
@@ -27,6 +28,7 @@ class CommandBridgeConfig:
     auth_token: str = ""
     allowed_sources: list[str] | None = None
     allowed_sender_ids: list[str] | None = None
+    require_authorized_sender: bool = False
     require_tls: bool = False
     replay_protection_enabled: bool = False
     replay_window_seconds: int = _DEFAULT_REPLAY_WINDOW
@@ -123,6 +125,89 @@ def create_command_bridge_app(
                 payload = asyncio.run(router.get_workflow_status(workflow_id))
                 status_code = 200 if payload.get("ok") else 404
                 return _json_response(start_response, status_code, payload)
+
+            if method == "GET" and path == "/api/v1/operator/runtime-health":
+                payload = asyncio.run(router.get_runtime_health())
+                return _json_response(start_response, 200 if payload.get("ok") else 500, payload)
+
+            if method == "GET" and path == "/api/v1/operator/workflows/active":
+                params = _query_params(environ)
+                payload = asyncio.run(router.get_active_workflows(limit=_int_param(params, "limit", 20)))
+                return _json_response(start_response, 200 if payload.get("ok") else 500, payload)
+
+            if method == "GET" and path == "/api/v1/operator/workflows/recent-failures":
+                params = _query_params(environ)
+                payload = asyncio.run(router.get_recent_failures(limit=_int_param(params, "limit", 20)))
+                return _json_response(start_response, 200 if payload.get("ok") else 500, payload)
+
+            if method == "GET" and path == "/api/v1/operator/workflows/status":
+                params = _query_params(environ)
+                payload = asyncio.run(
+                    router.operator_service.workflow_status(
+                        workflow_id=_str_param(params, "workflow_id"),
+                        issue_number=_str_param(params, "issue_number"),
+                    )
+                )
+                return _json_response(start_response, 200 if payload.get("ok") else 404, payload)
+
+            if method == "GET" and path == "/api/v1/operator/git/identity":
+                payload = asyncio.run(router.get_git_identity_status())
+                return _json_response(start_response, 200 if payload.get("ok") else 500, payload)
+
+            if method == "GET" and path == "/api/v1/operator/routing/explain":
+                params = _query_params(environ)
+                payload = asyncio.run(
+                    router.explain_routing(
+                        project_key=_str_param(params, "project_key") or "",
+                        task_type=_str_param(params, "task_type") or "feature",
+                        workflow_id=_str_param(params, "workflow_id"),
+                        issue_number=_str_param(params, "issue_number"),
+                        agent_name=_str_param(params, "agent_name"),
+                    )
+                )
+                return _json_response(start_response, 200 if payload.get("ok") else 400, payload)
+
+            if method == "POST" and path == "/api/v1/operator/workflows/continue":
+                payload = _load_json_body(environ)
+                result = asyncio.run(
+                    router.continue_workflow(
+                        workflow_id=str(payload.get("workflow_id") or "").strip() or None,
+                        issue_number=str(payload.get("issue_number") or "").strip() or None,
+                        target_agent=str(payload.get("target_agent") or "").strip() or None,
+                    )
+                )
+                return _json_response(start_response, 200 if result.get("ok") else 400, result)
+
+            if method == "POST" and path == "/api/v1/operator/workflows/retry-step":
+                payload = _load_json_body(environ)
+                result = asyncio.run(
+                    router.retry_workflow_step(
+                        workflow_id=str(payload.get("workflow_id") or "").strip() or None,
+                        issue_number=str(payload.get("issue_number") or "").strip() or None,
+                        target_agent=str(payload.get("target_agent") or "").strip(),
+                    )
+                )
+                return _json_response(start_response, 200 if result.get("ok") else 400, result)
+
+            if method == "POST" and path == "/api/v1/operator/workflows/cancel":
+                payload = _load_json_body(environ)
+                result = asyncio.run(
+                    router.cancel_workflow(
+                        workflow_id=str(payload.get("workflow_id") or "").strip() or None,
+                        issue_number=str(payload.get("issue_number") or "").strip() or None,
+                    )
+                )
+                return _json_response(start_response, 200 if result.get("ok") else 400, result)
+
+            if method == "POST" and path == "/api/v1/operator/workflows/refresh-state":
+                payload = _load_json_body(environ)
+                result = asyncio.run(
+                    router.refresh_workflow_state(
+                        workflow_id=str(payload.get("workflow_id") or "").strip() or None,
+                        issue_number=str(payload.get("issue_number") or "").strip() or None,
+                    )
+                )
+                return _json_response(start_response, 200 if result.get("ok") else 400, result)
 
             if method == "POST" and path == "/api/v1/bridge/openclaw/reply":
                 payload = _load_json_body(environ)
@@ -240,6 +325,30 @@ def _validate_requester(
         if sender_id not in allowed_sender_ids:
             return f"Sender '{sender_id}' is not allowed", "sender_not_allowed"
     return None
+
+
+
+def _query_params(environ: dict[str, Any]) -> dict[str, list[str]]:
+    raw = str(environ.get("QUERY_STRING", "") or "")
+    return parse_qs(raw, keep_blank_values=False)
+
+
+def _str_param(params: dict[str, list[str]], name: str) -> str | None:
+    values = params.get(name) or []
+    if not values:
+        return None
+    value = str(values[0] or "").strip()
+    return value or None
+
+
+def _int_param(params: dict[str, list[str]], name: str, default: int) -> int:
+    raw = _str_param(params, name)
+    if raw is None:
+        return int(default)
+    try:
+        return int(raw)
+    except ValueError as exc:
+        raise ValueError(f"Query parameter '{name}' must be an integer") from exc
 
 
 def _validate_reply_payload(payload: dict[str, Any]) -> None:

--- a/nexus/core/command_bridge/http.py
+++ b/nexus/core/command_bridge/http.py
@@ -150,6 +150,16 @@ def create_command_bridge_app(
                 )
                 return _json_response(start_response, 200 if payload.get("ok") else 404, payload)
 
+            if method == "GET" and path == "/api/v1/operator/workflows/summary":
+                params = _query_params(environ)
+                payload = asyncio.run(
+                    router.get_workflow_summary(
+                        workflow_id=_str_param(params, "workflow_id"),
+                        issue_number=_str_param(params, "issue_number"),
+                    )
+                )
+                return _json_response(start_response, 200 if payload.get("ok") else 404, payload)
+
             if method == "GET" and path == "/api/v1/operator/git/identity":
                 payload = asyncio.run(router.get_git_identity_status())
                 return _json_response(start_response, 200 if payload.get("ok") else 500, payload)

--- a/nexus/core/command_bridge/http.py
+++ b/nexus/core/command_bridge/http.py
@@ -142,30 +142,54 @@ def create_command_bridge_app(
 
             if method == "GET" and path == "/api/v1/operator/workflows/status":
                 params = _query_params(environ)
+                workflow_id = _str_param(params, "workflow_id")
+                issue_number = _str_param(params, "issue_number")
+                if not workflow_id and not issue_number:
+                    return _json_response(
+                        start_response,
+                        400,
+                        {"ok": False, "error": "Missing query parameter: provide 'workflow_id' or 'issue_number'."},
+                    )
                 payload = asyncio.run(
                     router.operator_service.workflow_status(
-                        workflow_id=_str_param(params, "workflow_id"),
-                        issue_number=_str_param(params, "issue_number"),
+                        workflow_id=workflow_id,
+                        issue_number=issue_number,
                     )
                 )
                 return _json_response(start_response, 200 if payload.get("ok") else 404, payload)
 
             if method == "GET" and path == "/api/v1/operator/workflows/summary":
                 params = _query_params(environ)
+                workflow_id = _str_param(params, "workflow_id")
+                issue_number = _str_param(params, "issue_number")
+                if not workflow_id and not issue_number:
+                    return _json_response(
+                        start_response,
+                        400,
+                        {"ok": False, "error": "Missing query parameter: provide 'workflow_id' or 'issue_number'."},
+                    )
                 payload = asyncio.run(
                     router.get_workflow_summary(
-                        workflow_id=_str_param(params, "workflow_id"),
-                        issue_number=_str_param(params, "issue_number"),
+                        workflow_id=workflow_id,
+                        issue_number=issue_number,
                     )
                 )
                 return _json_response(start_response, 200 if payload.get("ok") else 404, payload)
 
             if method == "GET" and path == "/api/v1/operator/workflows/why-stuck":
                 params = _query_params(environ)
+                workflow_id = _str_param(params, "workflow_id")
+                issue_number = _str_param(params, "issue_number")
+                if not workflow_id and not issue_number:
+                    return _json_response(
+                        start_response,
+                        400,
+                        {"ok": False, "error": "Missing query parameter: provide 'workflow_id' or 'issue_number'."},
+                    )
                 payload = asyncio.run(
                     router.get_workflow_diagnosis(
-                        workflow_id=_str_param(params, "workflow_id"),
-                        issue_number=_str_param(params, "issue_number"),
+                        workflow_id=workflow_id,
+                        issue_number=issue_number,
                     )
                 )
                 return _json_response(start_response, 200 if payload.get("ok") else 404, payload)
@@ -200,11 +224,14 @@ def create_command_bridge_app(
 
             if method == "POST" and path == "/api/v1/operator/workflows/retry-step":
                 payload = _load_json_body(environ)
+                target_agent = str(payload.get("target_agent") or "").strip()
+                if not target_agent:
+                    raise ValueError("target_agent is required for retry-step requests")
                 result = asyncio.run(
                     router.retry_workflow_step(
                         workflow_id=str(payload.get("workflow_id") or "").strip() or None,
                         issue_number=str(payload.get("issue_number") or "").strip() or None,
-                        target_agent=str(payload.get("target_agent") or "").strip(),
+                        target_agent=target_agent,
                     )
                 )
                 return _json_response(start_response, 200 if result.get("ok") else 400, result)

--- a/nexus/core/command_bridge/http.py
+++ b/nexus/core/command_bridge/http.py
@@ -160,6 +160,16 @@ def create_command_bridge_app(
                 )
                 return _json_response(start_response, 200 if payload.get("ok") else 404, payload)
 
+            if method == "GET" and path == "/api/v1/operator/workflows/why-stuck":
+                params = _query_params(environ)
+                payload = asyncio.run(
+                    router.get_workflow_diagnosis(
+                        workflow_id=_str_param(params, "workflow_id"),
+                        issue_number=_str_param(params, "issue_number"),
+                    )
+                )
+                return _json_response(start_response, 200 if payload.get("ok") else 404, payload)
+
             if method == "GET" and path == "/api/v1/operator/git/identity":
                 payload = asyncio.run(router.get_git_identity_status())
                 return _json_response(start_response, 200 if payload.get("ok") else 500, payload)

--- a/nexus/core/command_bridge/http.py
+++ b/nexus/core/command_bridge/http.py
@@ -7,7 +7,7 @@ import json
 import logging
 import threading
 import time
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from typing import Any
 from urllib.parse import parse_qs
 from wsgiref.simple_server import make_server

--- a/nexus/core/command_bridge/operator.py
+++ b/nexus/core/command_bridge/operator.py
@@ -95,6 +95,15 @@ class BridgeOperatorService:
         workflow = await _maybe_await(engine.get_workflow(resolved_workflow_id))
         return workflow, resolved_issue, resolved_workflow_id
 
+    @staticmethod
+    def _issue_from_metadata(workflow: Any) -> str | None:
+        """Return the issue_number embedded in *workflow* metadata, or None."""
+        metadata = getattr(workflow, "metadata", None)
+        if not isinstance(metadata, dict):
+            return None
+        meta_issue = metadata.get("issue_number") or metadata.get("issue")
+        return str(meta_issue) if meta_issue is not None else None
+
     def _workflow_summary(self, workflow: Any, *, issue_number: str | None = None) -> dict[str, Any]:
         metadata = getattr(workflow, "metadata", {}) or {}
         current_step_num = int(getattr(workflow, "current_step", 0) or 0)
@@ -185,11 +194,7 @@ class BridgeOperatorService:
             }
         # Recover issue_number from workflow metadata when only workflow_id was given.
         if resolved_issue is None:
-            metadata = getattr(workflow, "metadata", None)
-            if isinstance(metadata, dict):
-                meta_issue = metadata.get("issue_number") or metadata.get("issue")
-                if meta_issue is not None:
-                    resolved_issue = str(meta_issue)
+            resolved_issue = self._issue_from_metadata(workflow)
         plugin = self._workflow_plugin()
         plugin_status = None
         if resolved_issue:
@@ -491,11 +496,7 @@ class BridgeOperatorService:
             }
         # Recover issue_number from workflow metadata when only workflow_id was given.
         if resolved_issue is None:
-            metadata = getattr(workflow, "metadata", None)
-            if isinstance(metadata, dict):
-                meta_issue = metadata.get("issue_number") or metadata.get("issue")
-                if meta_issue is not None:
-                    resolved_issue = str(meta_issue)
+            resolved_issue = self._issue_from_metadata(workflow)
         if target_agent:
             if resolved_issue is None:
                 return {

--- a/nexus/core/command_bridge/operator.py
+++ b/nexus/core/command_bridge/operator.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 import inspect
 import os
 import shutil
@@ -182,6 +183,13 @@ class BridgeOperatorService:
                 "workflow_id": resolved_workflow_id,
                 "issue_number": resolved_issue,
             }
+        # Recover issue_number from workflow metadata when only workflow_id was given.
+        if resolved_issue is None:
+            metadata = getattr(workflow, "metadata", None)
+            if isinstance(metadata, dict):
+                meta_issue = metadata.get("issue_number") or metadata.get("issue")
+                if meta_issue is not None:
+                    resolved_issue = str(meta_issue)
         plugin = self._workflow_plugin()
         plugin_status = None
         if resolved_issue:
@@ -388,8 +396,10 @@ class BridgeOperatorService:
         }
 
     async def git_identity_status(self) -> dict[str, Any]:
-        github = self._cli_identity("gh", ["auth", "status"])
-        gitlab = self._cli_identity("glab", ["auth", "status"])
+        github, gitlab = await asyncio.gather(
+            asyncio.to_thread(self._cli_identity, "gh", ["auth", "status"]),
+            asyncio.to_thread(self._cli_identity, "glab", ["auth", "status"]),
+        )
         env_presence = {
             "github": {
                 "NEXUS_AUTOMATION_GITHUB_TOKEN": bool(str(os.getenv("NEXUS_AUTOMATION_GITHUB_TOKEN") or "").strip()),
@@ -468,17 +478,43 @@ class BridgeOperatorService:
         target_agent: str | None = None,
     ) -> dict[str, Any]:
         plugin = self._workflow_plugin()
-        workflow, resolved_issue, _ = await self._workflow_by_ref(workflow_id=workflow_id, issue_number=issue_number)
-        if workflow is None or resolved_issue is None:
-            return {"ok": False, "error": "Workflow not found", "issue_number": resolved_issue}
+        workflow, resolved_issue, resolved_workflow_id = await self._workflow_by_ref(
+            workflow_id=workflow_id,
+            issue_number=issue_number,
+        )
+        if workflow is None:
+            return {
+                "ok": False,
+                "error": "Workflow not found",
+                "issue_number": resolved_issue,
+                "workflow_id": resolved_workflow_id,
+            }
+        # Recover issue_number from workflow metadata when only workflow_id was given.
+        if resolved_issue is None:
+            metadata = getattr(workflow, "metadata", None)
+            if isinstance(metadata, dict):
+                meta_issue = metadata.get("issue_number") or metadata.get("issue")
+                if meta_issue is not None:
+                    resolved_issue = str(meta_issue)
         if target_agent:
+            if resolved_issue is None:
+                return {
+                    "ok": False,
+                    "error": "Cannot reset workflow step: issue_number could not be resolved",
+                    "workflow_id": resolved_workflow_id,
+                }
             reset = getattr(plugin, "reset_to_agent_for_issue", None)
             if not callable(reset):
                 return {"ok": False, "error": "Workflow plugin does not support reset_to_agent_for_issue"}
             success = await _maybe_await(reset(str(resolved_issue), str(target_agent)))
             if not success:
-                return {"ok": False, "error": f"Could not reset workflow to agent '{target_agent}'"}
-        return await self.workflow_status(issue_number=resolved_issue)
+                return {
+                    "ok": False,
+                    "error": f"Could not reset workflow to agent '{target_agent}'",
+                    "issue_number": resolved_issue,
+                    "workflow_id": resolved_workflow_id,
+                }
+        return await self.workflow_status(workflow_id=resolved_workflow_id, issue_number=resolved_issue)
 
     async def retry_step(
         self,

--- a/nexus/core/command_bridge/operator.py
+++ b/nexus/core/command_bridge/operator.py
@@ -195,6 +195,77 @@ class BridgeOperatorService:
             "plugin_status": plugin_status,
         }
 
+    async def workflow_summary(
+        self,
+        *,
+        workflow_id: str | None = None,
+        issue_number: str | None = None,
+    ) -> dict[str, Any]:
+        payload = await self.workflow_status(workflow_id=workflow_id, issue_number=issue_number)
+        if not payload.get("ok"):
+            return payload
+
+        workflow = payload.get("workflow") if isinstance(payload.get("workflow"), dict) else {}
+        plugin_status = payload.get("plugin_status") if isinstance(payload.get("plugin_status"), dict) else {}
+        state = str(workflow.get("state") or "unknown")
+        current_step = workflow.get("current_step") if isinstance(workflow.get("current_step"), dict) else {}
+        next_step = workflow.get("next_step") if isinstance(workflow.get("next_step"), dict) else {}
+        last_completed = workflow.get("last_completed_step") if isinstance(workflow.get("last_completed_step"), dict) else {}
+
+        reason = None
+        actions: list[str] = []
+        if state == "failed":
+            reason = str(current_step.get("error") or "Workflow is in failed state")
+            actions = ["inspect recent failures", "retry-step", "refresh-state"]
+        elif state == "paused":
+            reason = "Workflow is paused and needs a continue/resume action"
+            actions = ["continue", "refresh-state"]
+        elif state == "cancelled":
+            reason = "Workflow has been cancelled"
+            actions = ["refresh-state"]
+        elif state == "completed":
+            reason = "Workflow completed successfully"
+            actions = ["inspect workflow status"]
+        elif current_step.get("status") == "running":
+            reason = f"Waiting for @{current_step.get('agent') or workflow.get('active_agent') or 'unknown'} to finish current step"
+            actions = ["inspect logs", "refresh-state"]
+        elif next_step.get("agent"):
+            reason = f"Next expected handoff is @{next_step.get('agent')}"
+            actions = ["continue", "refresh-state"]
+        else:
+            reason = "Workflow state is available but the next handoff is unclear"
+            actions = ["inspect workflow status", "refresh-state"]
+
+        summary_lines = [
+            f"Workflow {workflow.get('workflow_id') or workflow_id or ''}".strip(),
+            f"state={state}",
+        ]
+        if workflow.get("issue_number"):
+            summary_lines.append(f"issue=#{workflow.get('issue_number')}")
+        if workflow.get("project_key"):
+            summary_lines.append(f"project={workflow.get('project_key')}")
+        if current_step.get("name"):
+            summary_lines.append(
+                f"current_step={current_step.get('step_num')}:{current_step.get('name')}@{current_step.get('agent') or 'unknown'}"
+            )
+        if last_completed.get("name"):
+            summary_lines.append(
+                f"last_completed={last_completed.get('step_num')}:{last_completed.get('name')}@{last_completed.get('agent') or 'unknown'}"
+            )
+        if next_step.get("name"):
+            summary_lines.append(
+                f"next_step={next_step.get('step_num')}:{next_step.get('name')}@{next_step.get('agent') or 'unknown'}"
+            )
+
+        return {
+            "ok": True,
+            "workflow": workflow,
+            "plugin_status": plugin_status,
+            "reason": reason,
+            "suggested_actions": actions,
+            "summary": "; ".join(summary_lines),
+        }
+
     async def active_workflows(self, *, limit: int = 20) -> dict[str, Any]:
         engine = await self._engine()
         storage = getattr(engine, "storage", None)

--- a/nexus/core/command_bridge/operator.py
+++ b/nexus/core/command_bridge/operator.py
@@ -266,6 +266,55 @@ class BridgeOperatorService:
             "summary": "; ".join(summary_lines),
         }
 
+    async def workflow_diagnosis(
+        self,
+        *,
+        workflow_id: str | None = None,
+        issue_number: str | None = None,
+    ) -> dict[str, Any]:
+        payload = await self.workflow_summary(workflow_id=workflow_id, issue_number=issue_number)
+        if not payload.get("ok"):
+            return payload
+
+        workflow = payload.get("workflow") if isinstance(payload.get("workflow"), dict) else {}
+        state = str(workflow.get("state") or "unknown")
+        current_step = workflow.get("current_step") if isinstance(workflow.get("current_step"), dict) else {}
+        next_step = workflow.get("next_step") if isinstance(workflow.get("next_step"), dict) else {}
+        diagnosis = "unknown"
+        likely_cause = payload.get("reason")
+        actions = list(payload.get("suggested_actions") or [])
+
+        if state == "failed":
+            diagnosis = "step_failed"
+            likely_cause = current_step.get("error") or "Current step failed"
+        elif state == "paused":
+            diagnosis = "workflow_paused"
+            likely_cause = "Workflow is paused and waiting for operator action"
+        elif state == "cancelled":
+            diagnosis = "workflow_cancelled"
+            likely_cause = "Workflow was cancelled"
+        elif state == "completed":
+            diagnosis = "workflow_completed"
+            likely_cause = "Workflow already completed"
+        elif current_step.get("status") == "running":
+            diagnosis = "agent_running"
+            likely_cause = f"Current step is still running under @{current_step.get('agent') or workflow.get('active_agent') or 'unknown'}"
+        elif next_step.get("agent"):
+            diagnosis = "handoff_pending"
+            likely_cause = f"Next handoff should go to @{next_step.get('agent')}"
+        else:
+            diagnosis = "state_unclear"
+            likely_cause = "Workflow state exists but no clear next handoff was inferred"
+
+        return {
+            "ok": True,
+            "diagnosis": diagnosis,
+            "likely_cause": likely_cause,
+            "summary": payload.get("summary"),
+            "suggested_actions": actions,
+            "workflow": workflow,
+        }
+
     async def active_workflows(self, *, limit: int = 20) -> dict[str, Any]:
         engine = await self._engine()
         storage = getattr(engine, "storage", None)

--- a/nexus/core/command_bridge/operator.py
+++ b/nexus/core/command_bridge/operator.py
@@ -1,0 +1,401 @@
+from __future__ import annotations
+
+import inspect
+import os
+import shutil
+import subprocess
+from datetime import UTC, datetime
+from typing import Any
+
+from nexus.core.models import WorkflowState
+from nexus.core.orchestration.plugin_runtime import get_workflow_state_plugin
+from nexus.plugins.builtin.runtime_ops_plugin import RuntimeOpsPlugin
+
+
+def _iso(value: Any) -> str | None:
+    if value is None:
+        return None
+    if hasattr(value, "isoformat"):
+        return value.isoformat()
+    return str(value)
+
+
+async def _maybe_await(value: Any) -> Any:
+    if inspect.isawaitable(value):
+        return await value
+    return value
+
+
+def _config() -> tuple[dict[str, Any], str | None]:
+    try:
+        from nexus.core.config import PROJECT_CONFIG, get_default_project, get_repo
+
+        project_config = PROJECT_CONFIG if isinstance(PROJECT_CONFIG, dict) else {}
+        default_project = get_default_project()
+        default_repo = get_repo(default_project) if default_project else None
+        return project_config, default_repo
+    except Exception:
+        return {}, None
+
+
+def _resolve_tier(task_type: str) -> tuple[str | None, str | None]:
+    try:
+        from nexus.core.task_flow.helpers import get_sop_tier
+
+        tier_name, _, workflow_label = get_sop_tier(str(task_type or "feature"))
+        return tier_name, workflow_label
+    except Exception:
+        return None, None
+
+
+class BridgeOperatorService:
+    def __init__(self, *, workflow_state_plugin_kwargs: dict[str, Any] | None = None) -> None:
+        self.workflow_state_plugin_kwargs = dict(workflow_state_plugin_kwargs or {})
+
+    def _workflow_plugin(self):
+        return get_workflow_state_plugin(
+            **self.workflow_state_plugin_kwargs,
+            cache_key="workflow:state-engine:command-bridge:operator",
+        )
+
+    async def _engine(self):
+        plugin = self._workflow_plugin()
+        getter = getattr(plugin, "_get_engine", None)
+        if not callable(getter):
+            raise RuntimeError("Workflow state engine plugin does not expose an engine getter")
+        return await _maybe_await(getter())
+
+    async def _workflow_by_ref(
+        self,
+        *,
+        workflow_id: str | None = None,
+        issue_number: str | None = None,
+    ) -> tuple[Any | None, str | None, str | None]:
+        plugin = self._workflow_plugin()
+        resolved_issue = str(issue_number or "").strip() or None
+        resolved_workflow_id = str(workflow_id or "").strip() or None
+        if resolved_issue is None and resolved_workflow_id is None:
+            return None, None, None
+
+        if resolved_issue is None and resolved_workflow_id is not None:
+            finder = getattr(plugin, "_find_issue_for_workflow", None)
+            if callable(finder):
+                resolved_issue = await _maybe_await(finder(resolved_workflow_id))
+
+        if resolved_workflow_id is None and resolved_issue is not None:
+            resolver = getattr(plugin, "_resolve_workflow_id", None)
+            if callable(resolver):
+                resolved_workflow_id = str(await _maybe_await(resolver(resolved_issue)) or "").strip() or None
+
+        if resolved_workflow_id is None:
+            return None, resolved_issue, None
+
+        engine = await self._engine()
+        workflow = await _maybe_await(engine.get_workflow(resolved_workflow_id))
+        return workflow, resolved_issue, resolved_workflow_id
+
+    def _workflow_summary(self, workflow: Any, *, issue_number: str | None = None) -> dict[str, Any]:
+        metadata = getattr(workflow, "metadata", {}) or {}
+        current_step_num = int(getattr(workflow, "current_step", 0) or 0)
+        steps = list(getattr(workflow, "steps", []) or [])
+        current_step = None
+        for step in steps:
+            if int(getattr(step, "step_num", 0) or 0) == current_step_num:
+                current_step = step
+                break
+        if current_step is None:
+            for step in steps:
+                status_value = getattr(getattr(step, "status", None), "value", getattr(step, "status", None))
+                if str(status_value or "") == "running":
+                    current_step = step
+                    break
+
+        last_completed = None
+        for step in steps:
+            status_value = getattr(getattr(step, "status", None), "value", getattr(step, "status", None))
+            if str(status_value or "") == "completed":
+                if last_completed is None or int(getattr(step, "step_num", 0) or 0) > int(getattr(last_completed, "step_num", 0) or 0):
+                    last_completed = step
+
+        next_step = None
+        if current_step is not None:
+            for step in steps:
+                if int(getattr(step, "step_num", 0) or 0) > int(getattr(current_step, "step_num", 0) or 0):
+                    status_value = getattr(getattr(step, "status", None), "value", getattr(step, "status", None))
+                    if str(status_value or "") in {"pending", "running"}:
+                        next_step = step
+                        break
+
+        state_value = getattr(getattr(workflow, "state", None), "value", getattr(workflow, "state", None))
+        return {
+            "workflow_id": str(getattr(workflow, "id", "") or ""),
+            "issue_number": str(issue_number or metadata.get("issue_number") or "") or None,
+            "project_key": str(metadata.get("project") or "") or None,
+            "tier": str(metadata.get("tier") or "") or None,
+            "task_type": str(metadata.get("task_type") or "") or None,
+            "state": str(state_value or ""),
+            "active_agent": getattr(workflow, "active_agent_type", None),
+            "current_step": {
+                "step_num": getattr(current_step, "step_num", None),
+                "name": getattr(current_step, "name", None),
+                "agent": getattr(getattr(current_step, "agent", None), "name", None),
+                "status": getattr(getattr(current_step, "status", None), "value", getattr(current_step, "status", None)),
+                "error": getattr(current_step, "error", None),
+            }
+            if current_step is not None
+            else None,
+            "last_completed_step": {
+                "step_num": getattr(last_completed, "step_num", None),
+                "name": getattr(last_completed, "name", None),
+                "agent": getattr(getattr(last_completed, "agent", None), "name", None),
+                "completed_at": _iso(getattr(last_completed, "completed_at", None)),
+            }
+            if last_completed is not None
+            else None,
+            "next_step": {
+                "step_num": getattr(next_step, "step_num", None),
+                "name": getattr(next_step, "name", None),
+                "agent": getattr(getattr(next_step, "agent", None), "name", None),
+                "status": getattr(getattr(next_step, "status", None), "value", getattr(next_step, "status", None)),
+            }
+            if next_step is not None
+            else None,
+            "created_at": _iso(getattr(workflow, "created_at", None)),
+            "updated_at": _iso(getattr(workflow, "updated_at", None)),
+            "completed_at": _iso(getattr(workflow, "completed_at", None)),
+        }
+
+    async def workflow_status(
+        self,
+        *,
+        workflow_id: str | None = None,
+        issue_number: str | None = None,
+    ) -> dict[str, Any]:
+        workflow, resolved_issue, resolved_workflow_id = await self._workflow_by_ref(
+            workflow_id=workflow_id,
+            issue_number=issue_number,
+        )
+        if workflow is None:
+            return {
+                "ok": False,
+                "error": "Workflow not found",
+                "workflow_id": resolved_workflow_id,
+                "issue_number": resolved_issue,
+            }
+        plugin = self._workflow_plugin()
+        plugin_status = None
+        if resolved_issue:
+            try:
+                plugin_status = await _maybe_await(plugin.get_workflow_status(resolved_issue))
+            except Exception:
+                plugin_status = None
+        return {
+            "ok": True,
+            "workflow": self._workflow_summary(workflow, issue_number=resolved_issue),
+            "plugin_status": plugin_status,
+        }
+
+    async def active_workflows(self, *, limit: int = 20) -> dict[str, Any]:
+        engine = await self._engine()
+        storage = getattr(engine, "storage", None)
+        if storage is None or not hasattr(storage, "list_workflows"):
+            return {"ok": False, "error": "Workflow storage backend does not support listing workflows"}
+        running = await _maybe_await(storage.list_workflows(WorkflowState.RUNNING, int(limit)))
+        paused = await _maybe_await(storage.list_workflows(WorkflowState.PAUSED, int(limit)))
+        items = [self._workflow_summary(wf) for wf in list(running or []) + list(paused or [])]
+        items.sort(key=lambda item: str(item.get("updated_at") or ""), reverse=True)
+        return {"ok": True, "items": items[: int(limit)], "count": len(items[: int(limit)])}
+
+    async def recent_failures(self, *, limit: int = 20) -> dict[str, Any]:
+        engine = await self._engine()
+        storage = getattr(engine, "storage", None)
+        if storage is None or not hasattr(storage, "list_workflows"):
+            return {"ok": False, "error": "Workflow storage backend does not support listing workflows"}
+        failed = await _maybe_await(storage.list_workflows(WorkflowState.FAILED, int(limit)))
+        cancelled = await _maybe_await(storage.list_workflows(WorkflowState.CANCELLED, int(limit)))
+        items = [self._workflow_summary(wf) for wf in list(failed or []) + list(cancelled or [])]
+        items.sort(key=lambda item: str(item.get("updated_at") or ""), reverse=True)
+        return {"ok": True, "items": items[: int(limit)], "count": len(items[: int(limit)])}
+
+    async def runtime_health(self) -> dict[str, Any]:
+        engine = await self._engine()
+        storage = getattr(engine, "storage", None)
+        storage_name = type(storage).__name__ if storage is not None else None
+        runtime_ops = RuntimeOpsPlugin()
+        active = await self.active_workflows(limit=100)
+        failures = await self.recent_failures(limit=20)
+        return {
+            "ok": True,
+            "timestamp": datetime.now(UTC).isoformat(),
+            "runtime_mode": str(os.getenv("NEXUS_RUNTIME_MODE") or "").strip() or None,
+            "storage_backend": storage_name,
+            "bridge": {
+                "command_bridge_auth_configured": bool(str(os.getenv("NEXUS_COMMAND_BRIDGE_AUTH_TOKEN") or "").strip()),
+                "openclaw_bridge_url": bool(str(os.getenv("NEXUS_OPENCLAW_BRIDGE_URL") or "").strip()),
+                "openclaw_bridge_token": bool(str(os.getenv("NEXUS_OPENCLAW_BRIDGE_TOKEN") or "").strip()),
+                "openclaw_session_key": bool(str(os.getenv("NEXUS_OPENCLAW_SESSION_KEY") or "").strip()),
+            },
+            "tooling": {
+                "gh": shutil.which("gh") is not None,
+                "glab": shutil.which("glab") is not None,
+                "pgrep": runtime_ops._pgrep_path is not None,
+            },
+            "active_workflow_count": int(active.get("count") or 0) if active.get("ok") else None,
+            "recent_failure_count": int(failures.get("count") or 0) if failures.get("ok") else None,
+        }
+
+    def _cli_identity(self, cli_name: str, args: list[str]) -> dict[str, Any]:
+        if shutil.which(cli_name) is None:
+            return {"installed": False, "authenticated": None, "summary": None}
+        try:
+            proc = subprocess.run(
+                [cli_name, *args],
+                text=True,
+                capture_output=True,
+                timeout=15,
+                check=False,
+            )
+        except Exception as exc:
+            return {"installed": True, "authenticated": None, "summary": f"{type(exc).__name__}: {exc}"}
+        stdout = str(proc.stdout or "").strip()
+        stderr = str(proc.stderr or "").strip()
+        combined = "\n".join(part for part in (stdout, stderr) if part).strip()
+        authenticated = proc.returncode == 0
+        return {
+            "installed": True,
+            "authenticated": authenticated,
+            "summary": combined.splitlines()[:6],
+        }
+
+    async def git_identity_status(self) -> dict[str, Any]:
+        github = self._cli_identity("gh", ["auth", "status"])
+        gitlab = self._cli_identity("glab", ["auth", "status"])
+        env_presence = {
+            "github": {
+                "NEXUS_AUTOMATION_GITHUB_TOKEN": bool(str(os.getenv("NEXUS_AUTOMATION_GITHUB_TOKEN") or "").strip()),
+                "NEXUS_AUTOMATION_GIT_TOKEN": bool(str(os.getenv("NEXUS_AUTOMATION_GIT_TOKEN") or "").strip()),
+                "GH_TOKEN": bool(str(os.getenv("GH_TOKEN") or "").strip()),
+                "GITHUB_TOKEN": bool(str(os.getenv("GITHUB_TOKEN") or "").strip()),
+            },
+            "gitlab": {
+                "NEXUS_AUTOMATION_GITLAB_TOKEN": bool(str(os.getenv("NEXUS_AUTOMATION_GITLAB_TOKEN") or "").strip()),
+                "NEXUS_AUTOMATION_GIT_TOKEN": bool(str(os.getenv("NEXUS_AUTOMATION_GIT_TOKEN") or "").strip()),
+                "GLAB_TOKEN": bool(str(os.getenv("GLAB_TOKEN") or "").strip()),
+                "GITLAB_TOKEN": bool(str(os.getenv("GITLAB_TOKEN") or "").strip()),
+            },
+        }
+        return {"ok": True, "github": github, "gitlab": gitlab, "env_presence": env_presence}
+
+    async def routing_explain(
+        self,
+        *,
+        project_key: str,
+        task_type: str = "feature",
+        workflow_id: str | None = None,
+        issue_number: str | None = None,
+        agent_name: str | None = None,
+    ) -> dict[str, Any]:
+        project_key = str(project_key or "").strip()
+        if not project_key:
+            return {"ok": False, "error": "project_key is required"}
+        project_config, fallback_default_repo = _config()
+        cfg = project_config.get(project_key)
+        if not isinstance(cfg, dict):
+            return {"ok": False, "error": f"Unknown project '{project_key}'"}
+        tier_name, workflow_label = _resolve_tier(str(task_type or "feature"))
+        workflow_path = cfg.get("workflow_definition_path")
+        default_repo = cfg.get("git_repo") or fallback_default_repo
+        repos = list(cfg.get("git_repos") or ([] if not default_repo else [default_repo]))
+        branches = dict(cfg.get("git_branches") or {})
+        ai_prefs = dict(cfg.get("ai_tool_preferences") or {})
+        model_profiles = dict(cfg.get("model_profiles") or {})
+        provider_priority = dict(cfg.get("profile_provider_priority") or {})
+        chosen_agent = str(agent_name or "").strip() or None
+        if not chosen_agent and workflow_id:
+            workflow, _, _ = await self._workflow_by_ref(workflow_id=workflow_id, issue_number=issue_number)
+            if workflow is not None:
+                chosen_agent = getattr(workflow, "active_agent_type", None)
+        agent_pref = ai_prefs.get(chosen_agent or "") if chosen_agent else None
+        profile_name = agent_pref.get("profile") if isinstance(agent_pref, dict) else None
+        provider_name = agent_pref.get("provider") if isinstance(agent_pref, dict) else None
+        return {
+            "ok": True,
+            "project_key": project_key,
+            "task_type": task_type,
+            "tier_name": tier_name,
+            "workflow_label": workflow_label,
+            "workflow_definition_path": workflow_path,
+            "default_repo": default_repo,
+            "repos": repos,
+            "default_branch": branches.get("default"),
+            "git_platform": cfg.get("git_platform"),
+            "workspace": cfg.get("workspace"),
+            "active_agent": chosen_agent,
+            "agent_preference": agent_pref,
+            "resolved_profile": {
+                "name": profile_name,
+                "models": model_profiles.get(profile_name) if profile_name else None,
+                "provider_priority": provider_priority.get(profile_name) if profile_name else None,
+                "provider": provider_name,
+            },
+        }
+
+    async def continue_workflow(
+        self,
+        *,
+        workflow_id: str | None = None,
+        issue_number: str | None = None,
+        target_agent: str | None = None,
+    ) -> dict[str, Any]:
+        plugin = self._workflow_plugin()
+        workflow, resolved_issue, _ = await self._workflow_by_ref(workflow_id=workflow_id, issue_number=issue_number)
+        if workflow is None or resolved_issue is None:
+            return {"ok": False, "error": "Workflow not found", "issue_number": resolved_issue}
+        if target_agent:
+            reset = getattr(plugin, "reset_to_agent_for_issue", None)
+            if not callable(reset):
+                return {"ok": False, "error": "Workflow plugin does not support reset_to_agent_for_issue"}
+            success = await _maybe_await(reset(str(resolved_issue), str(target_agent)))
+            if not success:
+                return {"ok": False, "error": f"Could not reset workflow to agent '{target_agent}'"}
+        return await self.workflow_status(issue_number=resolved_issue)
+
+    async def retry_step(
+        self,
+        *,
+        workflow_id: str | None = None,
+        issue_number: str | None = None,
+        target_agent: str,
+    ) -> dict[str, Any]:
+        return await self.continue_workflow(
+            workflow_id=workflow_id,
+            issue_number=issue_number,
+            target_agent=target_agent,
+        )
+
+    async def cancel_workflow(
+        self,
+        *,
+        workflow_id: str | None = None,
+        issue_number: str | None = None,
+    ) -> dict[str, Any]:
+        workflow, resolved_issue, resolved_workflow_id = await self._workflow_by_ref(
+            workflow_id=workflow_id,
+            issue_number=issue_number,
+        )
+        if workflow is None or resolved_workflow_id is None:
+            return {"ok": False, "error": "Workflow not found"}
+        engine = await self._engine()
+        try:
+            await _maybe_await(engine.cancel_workflow(resolved_workflow_id))
+        except Exception as exc:
+            return {"ok": False, "error": str(exc), "workflow_id": resolved_workflow_id}
+        return await self.workflow_status(workflow_id=resolved_workflow_id, issue_number=resolved_issue)
+
+    async def refresh_state(
+        self,
+        *,
+        workflow_id: str | None = None,
+        issue_number: str | None = None,
+    ) -> dict[str, Any]:
+        return await self.workflow_status(workflow_id=workflow_id, issue_number=issue_number)

--- a/nexus/core/command_bridge/router.py
+++ b/nexus/core/command_bridge/router.py
@@ -23,6 +23,7 @@ from nexus.core.command_bridge.models import (
     UiPayload,
     WorkflowRef,
 )
+from nexus.core.command_bridge.operator import BridgeOperatorService
 from nexus.core.command_bridge.usage import (
     collect_bridge_usage_payload,
     usage_payload_from_bridge_event,
@@ -279,6 +280,9 @@ class CommandRouter:
             )
         )
         self._override_requester_builders()
+        self.operator_service = BridgeOperatorService(
+            workflow_state_plugin_kwargs=self.workflow_deps.workflow_state_plugin_kwargs,
+        )
         self._register_default_commands()
 
     def _build_requester_context_builder(self, platform_name: str) -> Callable[[int], dict[str, Any]]:
@@ -515,29 +519,99 @@ class CommandRouter:
         workflow_id = str(workflow_id or "").strip()
         if not workflow_id:
             return {"ok": False, "error": "workflow_id is required"}
-        issue_number = self._issue_number_for_workflow_id(workflow_id)
-        if not issue_number:
-            return {"ok": False, "error": f"Unknown workflow_id '{workflow_id}'"}
-        workflow_plugin = get_workflow_state_plugin(
-            **self.workflow_deps.workflow_state_plugin_kwargs,
-            cache_key="workflow:state-engine:command-bridge:http",
-        )
-        status = await _maybe_await(workflow_plugin.get_workflow_status(issue_number))
-        project_key = self._project_key_from_workflow_id(workflow_id)
+        payload = await self.operator_service.workflow_status(workflow_id=workflow_id)
+        if not payload.get("ok"):
+            return payload
+        workflow = payload.get("workflow") if isinstance(payload.get("workflow"), dict) else {}
+        issue_number = workflow.get("issue_number")
+        project_key = workflow.get("project_key")
         usage = await collect_bridge_usage_payload(
             project_key=project_key,
             issue_number=issue_number,
             workflow_id=workflow_id,
         )
-        payload = {
-            "ok": True,
-            "workflow_id": workflow_id,
-            "issue_number": issue_number,
-            "project_key": project_key,
-            "status": status if isinstance(status, dict) else {"raw": status},
-            "usage": usage.to_dict() if usage is not None else {},
-        }
+        payload["workflow_id"] = workflow_id
+        payload["issue_number"] = issue_number
+        payload["project_key"] = project_key
+        payload["usage"] = usage.to_dict() if usage is not None else {}
         return payload
+
+    async def get_runtime_health(self) -> dict[str, Any]:
+        return await self.operator_service.runtime_health()
+
+    async def get_active_workflows(self, *, limit: int = 20) -> dict[str, Any]:
+        return await self.operator_service.active_workflows(limit=limit)
+
+    async def get_recent_failures(self, *, limit: int = 20) -> dict[str, Any]:
+        return await self.operator_service.recent_failures(limit=limit)
+
+    async def get_git_identity_status(self) -> dict[str, Any]:
+        return await self.operator_service.git_identity_status()
+
+    async def explain_routing(
+        self,
+        *,
+        project_key: str,
+        task_type: str = "feature",
+        workflow_id: str | None = None,
+        issue_number: str | None = None,
+        agent_name: str | None = None,
+    ) -> dict[str, Any]:
+        return await self.operator_service.routing_explain(
+            project_key=project_key,
+            task_type=task_type,
+            workflow_id=workflow_id,
+            issue_number=issue_number,
+            agent_name=agent_name,
+        )
+
+    async def continue_workflow(
+        self,
+        *,
+        workflow_id: str | None = None,
+        issue_number: str | None = None,
+        target_agent: str | None = None,
+    ) -> dict[str, Any]:
+        return await self.operator_service.continue_workflow(
+            workflow_id=workflow_id,
+            issue_number=issue_number,
+            target_agent=target_agent,
+        )
+
+    async def retry_workflow_step(
+        self,
+        *,
+        workflow_id: str | None = None,
+        issue_number: str | None = None,
+        target_agent: str,
+    ) -> dict[str, Any]:
+        return await self.operator_service.retry_step(
+            workflow_id=workflow_id,
+            issue_number=issue_number,
+            target_agent=target_agent,
+        )
+
+    async def cancel_workflow(
+        self,
+        *,
+        workflow_id: str | None = None,
+        issue_number: str | None = None,
+    ) -> dict[str, Any]:
+        return await self.operator_service.cancel_workflow(
+            workflow_id=workflow_id,
+            issue_number=issue_number,
+        )
+
+    async def refresh_workflow_state(
+        self,
+        *,
+        workflow_id: str | None = None,
+        issue_number: str | None = None,
+    ) -> dict[str, Any]:
+        return await self.operator_service.refresh_state(
+            workflow_id=workflow_id,
+            issue_number=issue_number,
+        )
 
     async def receive_reply(self, reply: ReplyRequest) -> CommandResult:
         """Accept an inbound reply forwarded by an OpenClaw plugin."""

--- a/nexus/core/command_bridge/router.py
+++ b/nexus/core/command_bridge/router.py
@@ -390,6 +390,7 @@ class CommandRouter:
         plugin.register_command("audit", self._plugin_callback(plugin, "audit"))
         plugin.register_command("direct", self._plugin_callback(plugin, "direct"))
         plugin.register_command("stats", self._plugin_callback(plugin, "stats"))
+        plugin.register_command("summary", self._plugin_callback(plugin, "summary"))
         plugin.register_command("continue", self._plugin_callback(plugin, "continue"))
         plugin.register_command("forget", self._plugin_callback(plugin, "forget"))
         plugin.register_command("kill", self._plugin_callback(plugin, "kill"))
@@ -546,6 +547,17 @@ class CommandRouter:
         issue_number: str | None = None,
     ) -> dict[str, Any]:
         return await self.operator_service.workflow_summary(
+            workflow_id=workflow_id,
+            issue_number=issue_number,
+        )
+
+    async def get_workflow_diagnosis(
+        self,
+        *,
+        workflow_id: str | None = None,
+        issue_number: str | None = None,
+    ) -> dict[str, Any]:
+        return await self.operator_service.workflow_diagnosis(
             workflow_id=workflow_id,
             issue_number=issue_number,
         )
@@ -707,6 +719,7 @@ class CommandRouter:
         self.register_command("audit", self._wrap_command_handler(audit_handler, self.ops_deps))
         self.register_command("direct", self._wrap_command_handler(direct_handler, self.ops_deps), bridge_enabled=False)
         self.register_command("stats", self._wrap_command_handler(stats_handler, self.ops_deps))
+        self.register_command("summary", self._summary_callback())
         self.register_command("continue", self._wrap_command_handler(continue_handler, self.workflow_deps))
         self.register_command("forget", self._wrap_command_handler(forget_handler, self.workflow_deps), bridge_enabled=False)
         self.register_command("kill", self._wrap_command_handler(kill_handler, self.workflow_deps))
@@ -786,6 +799,50 @@ class CommandRouter:
                 attachments=attachments,
             )
             await chat_menu_handler(ctx)
+
+        return _callback
+
+    def _summary_callback(self) -> Callable[..., Awaitable[None]]:
+        async def _callback(
+            *,
+            client: InteractiveClientPlugin,
+            user_id: str,
+            text: str,
+            args: list[str] | None = None,
+            raw_event: Any = None,
+            attachments: list[Any] | None = None,
+            user_state: dict[str, Any] | None = None,
+        ) -> None:
+            del text, attachments, user_state
+            ctx = self.build_context(
+                client=client,
+                user_id=user_id,
+                text="summary",
+                args=args,
+                raw_event=raw_event,
+            )
+            normalized_args = self._normalize_arg_tokens(ctx.args or [])
+            project_key, issue_number = self._extract_project_and_issue("summary", normalized_args)
+            workflow_id = None
+            if not issue_number and len(normalized_args) == 1:
+                token = str(normalized_args[0] or "").strip()
+                if token and not _ISSUE_REF_RE.fullmatch(token) and not _ISSUE_TOKEN_RE.fullmatch(token):
+                    workflow_id = token
+            if not workflow_id and issue_number:
+                workflow_id = self._lookup_workflow_id(issue_number) or None
+
+            payload = await self.get_workflow_summary(workflow_id=workflow_id, issue_number=issue_number)
+            if not payload.get("ok"):
+                await ctx.reply_text(str(payload.get("error") or "Workflow summary unavailable"), parse_mode=None)
+                return
+            diagnosis = await self.get_workflow_diagnosis(workflow_id=workflow_id, issue_number=issue_number)
+            lines = [str(payload.get("summary") or "Workflow summary unavailable")]
+            if diagnosis.get("likely_cause"):
+                lines.append(f"Likely cause: {diagnosis.get('likely_cause')}")
+            actions = diagnosis.get("suggested_actions") or payload.get("suggested_actions") or []
+            if actions:
+                lines.append("Suggested actions: " + ", ".join(str(item) for item in actions))
+            await ctx.reply_text("\n".join(lines), parse_mode=None)
 
         return _callback
 
@@ -983,7 +1040,9 @@ class CommandRouter:
 
         lowered = text.lower()
         command = ""
-        if "workflow state" in lowered or "wfstate" in lowered:
+        if re.search(r"\b(summary|summarize|summarise)\b.*\bworkflow\b", lowered) or re.search(r"\bworkflow\b.*\b(summary|summarize|summarise)\b", lowered) or re.search(r"\bwhy\b.*\bstuck\b", lowered):
+            command = "summary"
+        elif "workflow state" in lowered or "wfstate" in lowered:
             command = "wfstate"
         elif re.search(r"\bshow\b.*\blogs\b", lowered) or re.search(r"\blogs\b", lowered):
             command = "logs"

--- a/nexus/core/command_bridge/router.py
+++ b/nexus/core/command_bridge/router.py
@@ -539,6 +539,17 @@ class CommandRouter:
     async def get_runtime_health(self) -> dict[str, Any]:
         return await self.operator_service.runtime_health()
 
+    async def get_workflow_summary(
+        self,
+        *,
+        workflow_id: str | None = None,
+        issue_number: str | None = None,
+    ) -> dict[str, Any]:
+        return await self.operator_service.workflow_summary(
+            workflow_id=workflow_id,
+            issue_number=issue_number,
+        )
+
     async def get_active_workflows(self, *, limit: int = 20) -> dict[str, Any]:
         return await self.operator_service.active_workflows(limit=limit)
 

--- a/nexus/core/command_bridge/router.py
+++ b/nexus/core/command_bridge/router.py
@@ -62,7 +62,12 @@ from nexus.core.handlers.monitoring_command_handlers import (
     tail_handler,
     tailstop_handler,
 )
-from nexus.core.handlers.ops_command_handlers import agents_handler, audit_handler, direct_handler, stats_handler
+from nexus.core.handlers.ops_command_handlers import (
+    agents_handler,
+    audit_handler,
+    direct_handler,
+    stats_handler,
+)
 from nexus.core.handlers.workflow_command_handlers import (
     continue_handler,
     forget_handler,
@@ -75,7 +80,6 @@ from nexus.core.handlers.workflow_command_handlers import (
     wfstate_handler,
 )
 from nexus.core.integrations.workflow_state_factory import get_workflow_state
-from nexus.core.orchestration.plugin_runtime import get_workflow_state_plugin
 from nexus.core.project.catalog import get_project_label, iter_project_keys, single_key
 from nexus.core.telegram.telegram_issue_selection_service import parse_project_issue_args
 from nexus.core.user_manager import get_user_manager

--- a/nexus/core/command_bridge/router.py
+++ b/nexus/core/command_bridge/router.py
@@ -539,6 +539,11 @@ class CommandRouter:
         payload["issue_number"] = issue_number
         payload["project_key"] = project_key
         payload["usage"] = usage.to_dict() if usage is not None else {}
+        # Preserve backwards compatibility: ensure legacy "status" key is present.
+        if "status" not in payload:
+            plugin_status = payload.get("plugin_status")
+            if isinstance(plugin_status, dict):
+                payload["status"] = plugin_status
         return payload
 
     async def get_runtime_health(self) -> dict[str, Any]:

--- a/nexus/core/command_contract.py
+++ b/nexus/core/command_contract.py
@@ -144,6 +144,7 @@ OPENCLAW_BRIDGE_COMMANDS: set[str] = {
     "stats",
     "status",
     "stop",
+    "summary",
     "track",
     "tracked",
     "untrack",

--- a/nexus/core/issue_finalize.py
+++ b/nexus/core/issue_finalize.py
@@ -17,7 +17,6 @@ _GITHUB_PR_URL_RE = re.compile(r"github\.com/[^/]+/[^/]+/pull/([0-9]+)", re.IGNO
 _GITLAB_MR_URL_RE = re.compile(r"/-/merge_requests/([0-9]+)", re.IGNORECASE)
 
 
->>>>>>> 008bd2c (refactor(auth): extract shared automation git token helper; platform-aware token selection)
 def _run_sync(awaitable_factory):
     def _close_awaitable_if_needed(candidate: object | None) -> None:
         if candidate is None or not inspect.isawaitable(candidate):
@@ -103,15 +102,6 @@ def get_git_platform(
     )
 
 
-<<<<<<< HEAD
-def _get_project_platform(project_name: str) -> str | None:
-    """Return the VCS platform for a project (``github`` or ``gitlab``), or None on failure."""
-    try:
-        from nexus.core.config import get_project_platform
-
-        return get_project_platform(project_name)
-    except (ImportError, KeyError, ValueError):
-=======
 def _detect_project_platform(project_name: str | None) -> str | None:
     """Return 'github' or 'gitlab' for the given project, or None if unresolvable."""
     try:
@@ -120,6 +110,11 @@ def _detect_project_platform(project_name: str | None) -> str | None:
         return get_project_platform(project_name) or None
     except Exception:
         return None
+
+
+def _get_project_platform(project_name: str | None) -> str | None:
+    """Backward-compatible alias for project platform detection."""
+    return _detect_project_platform(project_name)
 
 
 def _is_git_repo(path: str) -> bool:

--- a/nexus/core/runtime/nexus_agent_runtime.py
+++ b/nexus/core/runtime/nexus_agent_runtime.py
@@ -47,25 +47,6 @@ _ISSUE_OPEN_ERROR_LOG_COOLDOWN_SECONDS = 300
 _last_issue_open_error_log_at: dict[tuple[str, str], float] = {}
 
 
-<<<<<<< HEAD
-def _runtime_token_override(platform: str | None = None) -> str | None:
-    """Return the best automation token for the given git platform using env vars.
-
-    Preference order (from environment variables only):
-    - Platform-specific automation token (NEXUS_AUTOMATION_GITHUB_TOKEN / NEXUS_AUTOMATION_GITLAB_TOKEN)
-    - Legacy generic automation token (NEXUS_AUTOMATION_GIT_TOKEN)
-    - Platform-specific write/service tokens (e.g. NEXUS_GITHUB_WRITE_TOKEN, GITHUB_TOKEN, GH_TOKEN,
-      GITLAB_TOKEN, GLAB_TOKEN)
-
-    When platform is None or unknown, all token env vars are tried in the order above.
-    """
-    from nexus.adapters.git.utils import resolve_automation_token_for_platform
-
-    return resolve_automation_token_for_platform(platform)
-
-=======
->>>>>>> 008bd2c (refactor(auth): extract shared automation git token helper; platform-aware token selection)
-
 def _resolve_project_name_for_repo(repo: str) -> str | None:
     try:
         from nexus.core.config import PROJECT_CONFIG, get_default_project, get_repo, get_repos

--- a/nexus/plugins/builtin/ai_runtime/provider_invokers/codex_invoker.py
+++ b/nexus/plugins/builtin/ai_runtime/provider_invokers/codex_invoker.py
@@ -196,7 +196,6 @@ def invoke_codex_cli(
         effective_env.get("NEXUS_CODEX_ALLOW_DANGER_SANDBOX") or ""
     ).strip().lower()
     allow_danger_sandbox = raw_allow_danger_sandbox in {"1", "true", "on", "yes"}
-<<<<<<< HEAD
     if not allow_danger_sandbox and raw_allow_danger_sandbox:
         logger.info(
             "NEXUS_CODEX_ALLOW_DANGER_SANDBOX=%r is not a recognised truthy value; "
@@ -204,8 +203,6 @@ def invoke_codex_cli(
             "Set to '1' or 'true' to enable.",
             raw_allow_danger_sandbox,
         )
-=======
->>>>>>> 257ccfc (feat: address PR review – security and reliability hardening for OpenClaw command bridge)
     sandbox_modes = ["workspace-write", "danger-full-access"] if allow_danger_sandbox else ["workspace-write"]
 
     timestamp = time.strftime("%Y%m%d_%H%M%S")

--- a/tests/test_command_bridge_http.py
+++ b/tests/test_command_bridge_http.py
@@ -63,6 +63,9 @@ class _FakeRouter:
     async def get_git_identity_status(self):
         return {"ok": True, "github": {"installed": True}}
 
+    async def get_workflow_summary(self, *, workflow_id=None, issue_number=None):
+        return {"ok": True, "summary": "demo summary", "workflow_id": workflow_id, "issue_number": issue_number}
+
     async def explain_routing(self, **kwargs):
         return {"ok": True, **kwargs}
 
@@ -520,3 +523,21 @@ def test_operator_routing_explain_endpoint_returns_payload():
 
     assert status.startswith("200")
     assert payload["project_key"] == "nexus"
+
+
+def test_operator_workflow_summary_endpoint_returns_payload():
+    app = create_command_bridge_app(
+        _FakeRouter(),
+        config=CommandBridgeConfig(auth_token="secret"),
+    )
+
+    status, payload = _call_app(
+        app,
+        method="GET",
+        path="/api/v1/operator/workflows/summary",
+        auth="Bearer secret",
+        extra_headers={"QUERY_STRING": "workflow_id=demo-42-full"},
+    )
+
+    assert status.startswith("200")
+    assert payload["summary"] == "demo summary"

--- a/tests/test_command_bridge_http.py
+++ b/tests/test_command_bridge_http.py
@@ -562,3 +562,73 @@ def test_operator_workflow_why_stuck_endpoint_returns_payload():
 
     assert status.startswith("200")
     assert payload["diagnosis"] == "agent_running"
+
+
+def test_operator_workflow_status_returns_400_when_no_ref():
+    app = create_command_bridge_app(
+        _FakeRouter(),
+        config=CommandBridgeConfig(auth_token="secret"),
+    )
+
+    status, payload = _call_app(
+        app,
+        method="GET",
+        path="/api/v1/operator/workflows/status",
+        auth="Bearer secret",
+    )
+
+    assert status.startswith("400")
+    assert payload["ok"] is False
+    assert "workflow_id" in payload["error"] or "issue_number" in payload["error"]
+
+
+def test_operator_workflow_summary_returns_400_when_no_ref():
+    app = create_command_bridge_app(
+        _FakeRouter(),
+        config=CommandBridgeConfig(auth_token="secret"),
+    )
+
+    status, payload = _call_app(
+        app,
+        method="GET",
+        path="/api/v1/operator/workflows/summary",
+        auth="Bearer secret",
+    )
+
+    assert status.startswith("400")
+    assert payload["ok"] is False
+
+
+def test_operator_workflow_why_stuck_returns_400_when_no_ref():
+    app = create_command_bridge_app(
+        _FakeRouter(),
+        config=CommandBridgeConfig(auth_token="secret"),
+    )
+
+    status, payload = _call_app(
+        app,
+        method="GET",
+        path="/api/v1/operator/workflows/why-stuck",
+        auth="Bearer secret",
+    )
+
+    assert status.startswith("400")
+    assert payload["ok"] is False
+
+
+def test_operator_retry_step_returns_400_when_target_agent_missing():
+    app = create_command_bridge_app(
+        _FakeRouter(),
+        config=CommandBridgeConfig(auth_token="secret"),
+    )
+
+    status, payload = _call_app(
+        app,
+        method="POST",
+        path="/api/v1/operator/workflows/retry-step",
+        auth="Bearer secret",
+        payload={"workflow_id": "demo-42-full"},
+    )
+
+    assert status.startswith("400")
+    assert "target_agent" in payload["error"].lower()

--- a/tests/test_command_bridge_http.py
+++ b/tests/test_command_bridge_http.py
@@ -8,7 +8,23 @@ from nexus.core.command_bridge.http import CommandBridgeConfig, create_command_b
 from nexus.core.command_bridge.models import CommandResult, ReplyRequest
 
 
+class _FakeOperatorService:
+    async def workflow_status(self, *, workflow_id=None, issue_number=None):
+        return {
+            "ok": True,
+            "workflow": {
+                "workflow_id": workflow_id or "demo-42-full",
+                "issue_number": issue_number or "42",
+                "project_key": "demo",
+                "state": "running",
+            },
+        }
+
+
 class _FakeRouter:
+    def __init__(self):
+        self.operator_service = _FakeOperatorService()
+
     def get_capabilities(self):
         return {
             "ok": True,
@@ -34,6 +50,33 @@ class _FakeRouter:
         if workflow_id == "demo-42-full":
             return {"ok": True, "workflow_id": workflow_id, "status": {"state": "running"}}
         return {"ok": False, "error": "missing"}
+
+    async def get_runtime_health(self):
+        return {"ok": True, "runtime_mode": "openclaw"}
+
+    async def get_active_workflows(self, *, limit: int = 20):
+        return {"ok": True, "count": 1, "items": [{"workflow_id": "demo-42-full"}], "limit": limit}
+
+    async def get_recent_failures(self, *, limit: int = 20):
+        return {"ok": True, "count": 1, "items": [{"workflow_id": "demo-99-full"}], "limit": limit}
+
+    async def get_git_identity_status(self):
+        return {"ok": True, "github": {"installed": True}}
+
+    async def explain_routing(self, **kwargs):
+        return {"ok": True, **kwargs}
+
+    async def continue_workflow(self, **kwargs):
+        return {"ok": True, "action": "continue", **kwargs}
+
+    async def retry_workflow_step(self, **kwargs):
+        return {"ok": True, "action": "retry-step", **kwargs}
+
+    async def cancel_workflow(self, **kwargs):
+        return {"ok": True, "action": "cancel", **kwargs}
+
+    async def refresh_workflow_state(self, **kwargs):
+        return {"ok": True, "action": "refresh-state", **kwargs}
 
     async def receive_reply(self, reply: ReplyRequest):
         return CommandResult(
@@ -405,3 +448,75 @@ def test_reply_endpoint_requires_auth():
     )
 
     assert status.startswith("401")
+
+
+def test_operator_runtime_health_endpoint_returns_payload():
+    app = create_command_bridge_app(
+        _FakeRouter(),
+        config=CommandBridgeConfig(auth_token="secret"),
+    )
+
+    status, payload = _call_app(
+        app,
+        method="GET",
+        path="/api/v1/operator/runtime-health",
+        auth="Bearer secret",
+    )
+
+    assert status.startswith("200")
+    assert payload["runtime_mode"] == "openclaw"
+
+
+def test_operator_active_workflows_endpoint_returns_payload():
+    app = create_command_bridge_app(
+        _FakeRouter(),
+        config=CommandBridgeConfig(auth_token="secret"),
+    )
+
+    status, payload = _call_app(
+        app,
+        method="GET",
+        path="/api/v1/operator/workflows/active",
+        auth="Bearer secret",
+        extra_headers={"QUERY_STRING": "limit=5"},
+    )
+
+    assert status.startswith("200")
+    assert payload["count"] == 1
+
+
+def test_operator_continue_endpoint_returns_payload():
+    app = create_command_bridge_app(
+        _FakeRouter(),
+        config=CommandBridgeConfig(auth_token="secret"),
+    )
+
+    status, payload = _call_app(
+        app,
+        method="POST",
+        path="/api/v1/operator/workflows/continue",
+        auth="Bearer secret",
+        payload={"issue_number": "42", "target_agent": "developer"},
+    )
+
+    assert status.startswith("200")
+    assert payload["action"] == "continue"
+    assert payload["issue_number"] == "42"
+
+
+def test_operator_routing_explain_endpoint_returns_payload():
+    app = create_command_bridge_app(
+        _FakeRouter(),
+        config=CommandBridgeConfig(auth_token="secret"),
+    )
+
+    status, payload = _call_app(
+        app,
+        method="GET",
+        path="/api/v1/operator/routing/explain",
+        auth="Bearer secret",
+        extra_headers={"QUERY_STRING": "project_key=nexus&task_type=feature"},
+    )
+
+    assert status.startswith("200")
+    assert payload["project_key"] == "nexus"

--- a/tests/test_command_bridge_http.py
+++ b/tests/test_command_bridge_http.py
@@ -66,6 +66,9 @@ class _FakeRouter:
     async def get_workflow_summary(self, *, workflow_id=None, issue_number=None):
         return {"ok": True, "summary": "demo summary", "workflow_id": workflow_id, "issue_number": issue_number}
 
+    async def get_workflow_diagnosis(self, *, workflow_id=None, issue_number=None):
+        return {"ok": True, "diagnosis": "agent_running", "likely_cause": "demo cause", "workflow_id": workflow_id, "issue_number": issue_number}
+
     async def explain_routing(self, **kwargs):
         return {"ok": True, **kwargs}
 
@@ -541,3 +544,21 @@ def test_operator_workflow_summary_endpoint_returns_payload():
 
     assert status.startswith("200")
     assert payload["summary"] == "demo summary"
+
+
+def test_operator_workflow_why_stuck_endpoint_returns_payload():
+    app = create_command_bridge_app(
+        _FakeRouter(),
+        config=CommandBridgeConfig(auth_token="secret"),
+    )
+
+    status, payload = _call_app(
+        app,
+        method="GET",
+        path="/api/v1/operator/workflows/why-stuck",
+        auth="Bearer secret",
+        extra_headers={"QUERY_STRING": "workflow_id=demo-42-full"},
+    )
+
+    assert status.startswith("200")
+    assert payload["diagnosis"] == "agent_running"

--- a/tests/test_command_bridge_http.py
+++ b/tests/test_command_bridge_http.py
@@ -579,7 +579,7 @@ def test_operator_workflow_status_returns_400_when_no_ref():
 
     assert status.startswith("400")
     assert payload["ok"] is False
-    assert "workflow_id" in payload["error"] or "issue_number" in payload["error"]
+    assert payload["error"] == "Missing query parameter: provide 'workflow_id' or 'issue_number'."
 
 
 def test_operator_workflow_summary_returns_400_when_no_ref():
@@ -597,6 +597,7 @@ def test_operator_workflow_summary_returns_400_when_no_ref():
 
     assert status.startswith("400")
     assert payload["ok"] is False
+    assert payload["error"] == "Missing query parameter: provide 'workflow_id' or 'issue_number'."
 
 
 def test_operator_workflow_why_stuck_returns_400_when_no_ref():
@@ -614,6 +615,7 @@ def test_operator_workflow_why_stuck_returns_400_when_no_ref():
 
     assert status.startswith("400")
     assert payload["ok"] is False
+    assert payload["error"] == "Missing query parameter: provide 'workflow_id' or 'issue_number'."
 
 
 def test_operator_retry_step_returns_400_when_target_agent_missing():
@@ -631,4 +633,4 @@ def test_operator_retry_step_returns_400_when_target_agent_missing():
     )
 
     assert status.startswith("400")
-    assert "target_agent" in payload["error"].lower()
+    assert payload["error"] == "target_agent is required for retry-step requests"

--- a/tests/test_command_bridge_router.py
+++ b/tests/test_command_bridge_router.py
@@ -476,3 +476,31 @@ async def test_route_maps_workflow_summary_request_to_summary(router: CommandRou
 
     assert result.status == "success"
     assert result.message == "Workflow summary"
+
+
+@pytest.mark.asyncio
+async def test_get_workflow_status_includes_backwards_compat_status_key(
+    router: CommandRouter, monkeypatch: pytest.MonkeyPatch
+):
+    async def _fake_usage(*, project_key=None, issue_number=None, workflow_id=None):
+        del project_key, issue_number, workflow_id
+        return None
+
+    monkeypatch.setattr("nexus.core.command_bridge.router.collect_bridge_usage_payload", _fake_usage)
+
+    class _FakeOperatorService:
+        async def workflow_status(self, *, workflow_id=None, issue_number=None):
+            return {
+                "ok": True,
+                "workflow": {"workflow_id": "demo-42-full", "issue_number": "42", "project_key": None},
+                "plugin_status": {"state": "running", "phase": "executing"},
+            }
+
+    router.operator_service = _FakeOperatorService()
+
+    payload = await router.get_workflow_status("demo-42-full")
+
+    assert payload["ok"] is True
+    # The legacy "status" key must be present and mirror plugin_status.
+    assert "status" in payload
+    assert payload["status"] == {"state": "running", "phase": "executing"}

--- a/tests/test_command_bridge_router.py
+++ b/tests/test_command_bridge_router.py
@@ -259,21 +259,27 @@ async def test_get_workflow_status_includes_usage(
         )
 
     monkeypatch.setattr("nexus.core.command_bridge.router.collect_bridge_usage_payload", _fake_usage)
-    router.workflow_deps.workflow_state_plugin_kwargs = {}
 
-    class _WorkflowPlugin:
-        async def get_workflow_status(self, issue_number):
-            assert issue_number == "42"
-            return {"state": "running"}
+    class _FakeOperatorService:
+        async def workflow_status(self, *, workflow_id=None, issue_number=None):
+            assert workflow_id == "demo-42-full"
+            assert issue_number is None
+            return {
+                "ok": True,
+                "workflow": {
+                    "workflow_id": "demo-42-full",
+                    "issue_number": "42",
+                    "project_key": None,
+                },
+                "plugin_status": {"state": "running"},
+            }
 
-    monkeypatch.setattr(
-        "nexus.core.command_bridge.router.get_workflow_state_plugin",
-        lambda **_kwargs: _WorkflowPlugin(),
-    )
+    router.operator_service = _FakeOperatorService()
 
     payload = await router.get_workflow_status("demo-42-full")
 
     assert payload["ok"] is True
+    assert payload["plugin_status"] == {"state": "running"}
     assert payload["usage"]["provider"] == "openai"
     assert payload["usage"]["input_tokens"] == 90
 
@@ -377,3 +383,46 @@ async def test_route_maps_spend_request_to_usage(
     assert result.status == "success"
     assert result.usage is not None
     assert result.usage.provider == "openai"
+
+
+@pytest.mark.asyncio
+async def test_router_operator_helpers_delegate_to_service(router: CommandRouter):
+    class _FakeOperatorService:
+        async def runtime_health(self):
+            return {"ok": True, "runtime": "ok"}
+
+        async def active_workflows(self, *, limit: int = 20):
+            return {"ok": True, "limit": limit}
+
+        async def recent_failures(self, *, limit: int = 20):
+            return {"ok": True, "limit": limit}
+
+        async def git_identity_status(self):
+            return {"ok": True, "github": {"installed": True}}
+
+        async def routing_explain(self, **kwargs):
+            return {"ok": True, **kwargs}
+
+        async def continue_workflow(self, **kwargs):
+            return {"ok": True, "action": "continue", **kwargs}
+
+        async def retry_step(self, **kwargs):
+            return {"ok": True, "action": "retry", **kwargs}
+
+        async def cancel_workflow(self, **kwargs):
+            return {"ok": True, "action": "cancel", **kwargs}
+
+        async def refresh_state(self, **kwargs):
+            return {"ok": True, "action": "refresh", **kwargs}
+
+    router.operator_service = _FakeOperatorService()
+
+    assert (await router.get_runtime_health())["runtime"] == "ok"
+    assert (await router.get_active_workflows(limit=5))["limit"] == 5
+    assert (await router.get_recent_failures(limit=3))["limit"] == 3
+    assert (await router.get_git_identity_status())["github"]["installed"] is True
+    assert (await router.explain_routing(project_key="nexus"))["project_key"] == "nexus"
+    assert (await router.continue_workflow(issue_number="42"))["action"] == "continue"
+    assert (await router.retry_workflow_step(issue_number="42", target_agent="developer"))["action"] == "retry"
+    assert (await router.cancel_workflow(issue_number="42"))["action"] == "cancel"
+    assert (await router.refresh_workflow_state(issue_number="42"))["action"] == "refresh"

--- a/tests/test_command_bridge_router.py
+++ b/tests/test_command_bridge_router.py
@@ -441,3 +441,38 @@ async def test_router_workflow_summary_helper_delegates_to_service(router: Comma
     assert payload["ok"] is True
     assert payload["summary"] == "demo"
     assert payload["workflow_id"] == "demo-42-full"
+
+
+@pytest.mark.asyncio
+async def test_router_workflow_diagnosis_helper_delegates_to_service(router: CommandRouter):
+    class _FakeOperatorService:
+        async def workflow_diagnosis(self, **kwargs):
+            return {"ok": True, "diagnosis": "handoff_pending", **kwargs}
+
+    router.operator_service = _FakeOperatorService()
+
+    payload = await router.get_workflow_diagnosis(workflow_id="demo-42-full")
+
+    assert payload["ok"] is True
+    assert payload["diagnosis"] == "handoff_pending"
+    assert payload["workflow_id"] == "demo-42-full"
+
+
+@pytest.mark.asyncio
+async def test_route_maps_workflow_summary_request_to_summary(router: CommandRouter):
+    async def _summary_handler(*, client, user_id, text, args, raw_event=None, attachments=None):
+        del user_id, text, raw_event, attachments
+        ctx = router.build_context(client=client, user_id="alice", text="summary", args=args)
+        await ctx.reply_text("Workflow summary")
+
+    router.register_command("summary", _summary_handler)
+
+    result = await router.route(
+        CommandRequest(
+            raw_text="why is workflow demo#42 stuck?",
+            requester=RequesterContext(source_platform="openclaw", sender_id="alice"),
+        )
+    )
+
+    assert result.status == "success"
+    assert result.message == "Workflow summary"

--- a/tests/test_command_bridge_router.py
+++ b/tests/test_command_bridge_router.py
@@ -426,3 +426,18 @@ async def test_router_operator_helpers_delegate_to_service(router: CommandRouter
     assert (await router.retry_workflow_step(issue_number="42", target_agent="developer"))["action"] == "retry"
     assert (await router.cancel_workflow(issue_number="42"))["action"] == "cancel"
     assert (await router.refresh_workflow_state(issue_number="42"))["action"] == "refresh"
+
+
+@pytest.mark.asyncio
+async def test_router_workflow_summary_helper_delegates_to_service(router: CommandRouter):
+    class _FakeOperatorService:
+        async def workflow_summary(self, **kwargs):
+            return {"ok": True, "summary": "demo", **kwargs}
+
+    router.operator_service = _FakeOperatorService()
+
+    payload = await router.get_workflow_summary(workflow_id="demo-42-full")
+
+    assert payload["ok"] is True
+    assert payload["summary"] == "demo"
+    assert payload["workflow_id"] == "demo-42-full"


### PR DESCRIPTION
- [x] Investigated CI/code at @Ghabs95's request
- [x] Fixed ruff linting issues
- [x] Applied all code review feedback (6 items from reviewer + 3 from code_review tool):
  - [x] `operator.py`: extract `_issue_from_metadata()` helper to avoid duplication between `workflow_status()` and `continue_workflow()`
  - [x] `operator.py`: recover `issue_number` from workflow metadata in `workflow_status()` when only `workflow_id` is provided
  - [x] `operator.py`: recover `issue_number` from workflow metadata in `continue_workflow()` when only `workflow_id` is provided; return structured error if issue can't be resolved for reset
  - [x] `operator.py`: use `asyncio.to_thread()` + `asyncio.gather()` for blocking subprocess calls in `git_identity_status()` to prevent event-loop stalls
  - [x] `router.py`: preserve backwards-compat `status` key in `get_workflow_status()` (aliases `plugin_status`)
  - [x] `http.py`: validate `workflow_id`/`issue_number` for status/summary/why-stuck endpoints (return 400 if neither provided)
  - [x] `http.py`: validate `target_agent` is non-empty for retry-step (return 400 if missing)
  - [x] Tests: tightened assertions to check exact error messages
  - [x] Added 5 new tests covering all new validations (41 tests total, all passing)

<!-- START COPILOT CODING AGENT TIPS -->
---

⌨️ Start Copilot coding agent tasks without leaving your editor — available in [VS Code](https://gh.io/cca-vs-code-docs), [Visual Studio](https://gh.io/cca-visual-studio-docs), [JetBrains IDEs](https://gh.io/cca-jetbrains-docs) and [Eclipse](https://gh.io/cca-eclipse-docs).
