### PR TITLE
feat: enrich Nexus → OpenClaw workflow notifications

### DIFF
--- a/docs/OPENCLAW_OPERATOR_SURFACE.md
+++ b/docs/OPENCLAW_OPERATOR_SURFACE.md
@@ -244,6 +244,27 @@ curl -s -X POST http://127.0.0.1:8091/api/v1/operator/workflows/refresh-state \
   -d '{"issue_number":"123"}'
 ```
 
+## Rich Nexus → OpenClaw Notifications (current runtime slice)
+
+The OpenClaw notification adapter now emits a richer workflow envelope alongside
+mobile-friendly text rendering for workflow events.
+
+Current payload shape (first concrete runtime slice):
+- `metadata.kind = workflow_notification`
+- `metadata.schema_version = workflow_notification.v1`
+- `metadata.event_type`
+- `metadata.workflow.{id, issue_number, project_key, state}`
+- `metadata.payload.{repo, pr_number, pr_url, current_step, step_id, step_num, step_name, workflow_phase, agent_type, severity, summary, blocked_reason, key_findings, suggested_actions, timestamp_utc}`
+- `metadata.actions[]` as action-oriented hints for clients/surfaces that can render them
+- `metadata.routing.{session_key, correlation_token, reply_hint}` for correlation-safe reply routing
+
+Current behavior:
+- text remains concise and mobile-friendly for chat delivery
+- session affinity defaults to deterministic workflow-bound keys like `nexus:<project>:workflow:<workflow_id>` when no explicit session key is configured
+- action hints are advisory metadata today; they are not yet a full authenticated reply-button flow
+
+This keeps Nexus as workflow truth while giving OpenClaw stronger workflow context for notification rendering and future reply routing.
+
 ## Notes
 
 - These endpoints are intentionally operator-oriented and best-effort.

--- a/nexus/adapters/notifications/openclaw.py
+++ b/nexus/adapters/notifications/openclaw.py
@@ -25,6 +25,10 @@ from __future__ import annotations
 
 import logging
 import os
+import re
+import uuid
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
 from typing import Any
 
 from nexus.adapters.notifications.base import Message, NotificationChannel
@@ -48,12 +52,141 @@ _SEVERITY_EMOJI = {
 }
 
 
+@dataclass
+class WorkflowNotificationPayload:
+    """Typed envelope for rich Nexus → OpenClaw workflow notifications."""
+
+    schema_version: str = "workflow_notification.v1"
+    event_type: str = "workflow_progressed"
+    workflow_id: str = ""
+    project_key: str = ""
+    repo: str = ""
+    issue_number: str = ""
+    pr_number: str = ""
+    pr_url: str = ""
+    current_step: str = ""
+    step_id: str = ""
+    step_num: int = 0
+    step_name: str = ""
+    workflow_phase: str = ""
+    agent_type: str = ""
+    severity: str = "info"
+    summary: str = ""
+    blocked_reason: str = ""
+    key_findings: list[str] = field(default_factory=list)
+    suggested_actions: list[str] = field(default_factory=list)
+    session_key: str = ""
+    correlation_token: str = field(default_factory=lambda: f"ocwf-{uuid.uuid4().hex}")
+    timestamp_utc: str = field(default_factory=lambda: datetime.now(UTC).isoformat())
+
+    def to_metadata(self) -> dict[str, Any]:
+        workflow_ref = {
+            "id": self.workflow_id or None,
+            "issue_number": self.issue_number or None,
+            "project_key": self.project_key or None,
+            "state": self.workflow_phase or None,
+        }
+        actions = [
+            {"name": action, "label": action.replace("_", " ").title()}
+            for action in self.suggested_actions
+            if str(action).strip()
+        ]
+        return {
+            "source": "nexus",
+            "kind": "workflow_notification",
+            "schema_version": self.schema_version,
+            "event_type": self.event_type,
+            "workflow": workflow_ref,
+            "payload": {
+                "repo": self.repo,
+                "pr_number": self.pr_number,
+                "pr_url": self.pr_url,
+                "current_step": self.current_step,
+                "step_id": self.step_id,
+                "step_num": self.step_num,
+                "step_name": self.step_name,
+                "workflow_phase": self.workflow_phase,
+                "agent_type": self.agent_type,
+                "severity": self.severity,
+                "summary": self.summary,
+                "blocked_reason": self.blocked_reason,
+                "key_findings": list(self.key_findings or []),
+                "suggested_actions": list(self.suggested_actions or []),
+                "timestamp_utc": self.timestamp_utc,
+            },
+            "actions": actions,
+            "routing": {
+                "session_key": self.session_key,
+                "correlation_token": self.correlation_token,
+                "reply_hint": {
+                    "workflow_id": self.workflow_id,
+                    "session_key": self.session_key,
+                    "event_type": self.event_type,
+                    "current_step": self.current_step,
+                    "correlation_token": self.correlation_token,
+                },
+            },
+        }
+
+
 def _require_aiohttp() -> None:
     if not _AIOHTTP_AVAILABLE:
         raise ImportError(
             "aiohttp is required for OpenClawNotificationChannel. "
             "Install it with: pip install aiohttp"
         )
+
+
+def _normalize_event_type(event_type: str) -> str:
+    mapping = {
+        "workflow.started": "workflow_started",
+        "workflow.completed": "workflow_completed",
+        "workflow.failed": "workflow_failed",
+        "workflow.cancelled": "workflow_blocked",
+        "workflow.approval_required": "workflow_waiting_human",
+        "step.completed": "workflow_progressed",
+        "step.failed": "workflow_blocked",
+        "system.alert": "workflow_blocked",
+        "agent.timeout": "workflow_blocked",
+    }
+    key = str(event_type or "").strip()
+    return mapping.get(key, key.replace(".", "_") or "workflow_progressed")
+
+
+def _extract_issue_number(value: str) -> str:
+    text = str(value or "")
+    match = re.search(r"(?:^|[^\d])(\d{1,10})(?:$|[^\d])", text)
+    return match.group(1) if match else ""
+
+
+def _infer_project_key(workflow_id: str, fallback: str = "") -> str:
+    raw = str(fallback or "").strip()
+    if raw:
+        return raw
+    candidate = str(workflow_id or "").strip()
+    if not candidate:
+        return ""
+    if "-" in candidate:
+        return candidate.split("-", 1)[0]
+    return ""
+
+
+def _resolve_session_key(
+    workflow_id: str,
+    project_key: str = "",
+    *,
+    configured_session_key: str = "",
+    issue_number: str = "",
+) -> str:
+    if str(configured_session_key or "").strip():
+        return str(configured_session_key).strip()
+    if str(workflow_id or "").strip():
+        prefix = f"nexus:{project_key}:workflow" if project_key else "nexus:workflow"
+        return f"{prefix}:{workflow_id}"
+    if str(issue_number or "").strip():
+        prefix = f"nexus:{project_key}:issue" if project_key else "nexus:issue"
+        return f"{prefix}:{issue_number}"
+    return ""
 
 
 class OpenClawNotificationChannel(NotificationChannel):
@@ -91,19 +224,11 @@ class OpenClawNotificationChannel(NotificationChannel):
         self._timeout_seconds = timeout
         self._sessions_by_loop: dict[object, aiohttp.ClientSession] = {}
 
-    # ------------------------------------------------------------------
-    # NotificationChannel interface
-    # ------------------------------------------------------------------
-
     @property
     def name(self) -> str:
         return "openclaw"
 
     async def send_message(self, user_id: str, message: Message) -> str:
-        """Send a notification message to the OpenClaw session.
-
-        Returns a synthetic message ID (``"openclaw:ok"``) on success, or an empty string on failure.
-        """
         emoji = _SEVERITY_EMOJI.get(message.severity, "ℹ️")
         text = f"{emoji} **[Nexus]** {message.text}"
         payload = self._build_payload(text, target_user=user_id or self._sender_id)
@@ -118,35 +243,97 @@ class OpenClawNotificationChannel(NotificationChannel):
         return "openclaw:ok"
 
     async def update_message(self, message_id: str, new_text: str) -> None:
-        """OpenClaw bridge does not support in-place message edits; sends a new message."""
         payload = self._build_payload(f"ℹ️ **[Nexus update]** {new_text}")
         await self._post(payload)
 
     async def send_alert(self, message: str, severity: Severity) -> None:
-        """Broadcast a system alert to the configured sender."""
         emoji = _SEVERITY_EMOJI.get(severity, "⚠️")
         text = f"{emoji} **[Nexus alert]** {message}"
         payload = self._build_payload(text)
         await self._post(payload)
 
     async def request_input(self, user_id: str, prompt: str) -> str:
-        """Send a prompt requesting human input.
-
-        Note: OpenClaw does not support synchronous reply-wait via the bridge;
-        this sends the prompt and returns an empty string.  The user's response
-        will arrive as a normal chat message handled by the OpenClaw agent.
-        """
         text = f"💬 **[Nexus needs input]** {prompt}"
         payload = self._build_payload(text, target_user=user_id or self._sender_id)
         await self._post(payload)
         return ""
 
-    # ------------------------------------------------------------------
-    # Internal helpers
-    # ------------------------------------------------------------------
+    async def send_workflow_notification(
+        self,
+        *,
+        event_type: str,
+        workflow_id: str,
+        summary: str,
+        severity: str = "info",
+        project_key: str = "",
+        repo: str = "",
+        issue_number: str = "",
+        pr_number: str = "",
+        pr_url: str = "",
+        current_step: str = "",
+        step_id: str = "",
+        step_num: int = 0,
+        step_name: str = "",
+        workflow_phase: str = "",
+        agent_type: str = "",
+        blocked_reason: str = "",
+        key_findings: list[str] | None = None,
+        suggested_actions: list[str] | None = None,
+        correlation_token: str | None = None,
+        session_key: str | None = None,
+        target_user: str | None = None,
+    ) -> bool:
+        """Send a rich workflow notification envelope to OpenClaw."""
+        resolved_project = _infer_project_key(workflow_id, project_key)
+        resolved_issue = str(issue_number or "").strip() or _extract_issue_number(workflow_id)
+        resolved_session_key = _resolve_session_key(
+            workflow_id,
+            resolved_project,
+            configured_session_key=session_key or self._session_key,
+            issue_number=resolved_issue,
+        )
+        payload_model = WorkflowNotificationPayload(
+            event_type=_normalize_event_type(event_type),
+            workflow_id=str(workflow_id or "").strip(),
+            project_key=resolved_project,
+            repo=str(repo or "").strip(),
+            issue_number=resolved_issue,
+            pr_number=str(pr_number or "").strip(),
+            pr_url=str(pr_url or "").strip(),
+            current_step=str(current_step or "").strip(),
+            step_id=str(step_id or "").strip(),
+            step_num=int(step_num or 0),
+            step_name=str(step_name or "").strip(),
+            workflow_phase=str(workflow_phase or "").strip(),
+            agent_type=str(agent_type or "").strip(),
+            severity=str(severity or "info").strip().lower() or "info",
+            summary=str(summary or "").strip(),
+            blocked_reason=str(blocked_reason or "").strip(),
+            key_findings=[str(item).strip() for item in (key_findings or []) if str(item).strip()],
+            suggested_actions=[
+                str(item).strip() for item in (suggested_actions or []) if str(item).strip()
+            ],
+            session_key=resolved_session_key,
+            correlation_token=str(correlation_token or "").strip()
+            or f"ocwf-{uuid.uuid4().hex}",
+        )
+        text = self._render_workflow_notification(payload_model)
+        payload = self._build_payload(
+            text,
+            target_user=target_user or self._sender_id,
+            metadata=payload_model.to_metadata(),
+            session_key=resolved_session_key,
+        )
+        return await self._post(payload)
 
-    def _build_payload(self, text: str, target_user: str | None = None) -> dict[str, Any]:
-        """Build a /hooks/agent payload that delivers a message to the OpenClaw session."""
+    def _build_payload(
+        self,
+        text: str,
+        target_user: str | None = None,
+        *,
+        metadata: dict[str, Any] | None = None,
+        session_key: str | None = None,
+    ) -> dict[str, Any]:
         payload: dict[str, Any] = {
             "message": text,
             "name": "Nexus",
@@ -154,14 +341,60 @@ class OpenClawNotificationChannel(NotificationChannel):
             "channel": self._channel or "telegram",
             "wakeMode": "now",
         }
-        # If a specific session key is set, pass it to route directly to that session
-        if self._session_key:
-            payload["sessionKey"] = self._session_key
-        # If a specific recipient is set, pass it as `to`
+        if metadata:
+            payload["metadata"] = metadata
+        resolved_session_key = str(session_key or self._session_key or "").strip()
+        if resolved_session_key:
+            payload["sessionKey"] = resolved_session_key
         recipient = target_user or self._sender_id
         if recipient:
             payload["to"] = recipient
         return payload
+
+    def _render_workflow_notification(self, item: WorkflowNotificationPayload) -> str:
+        icon = {
+            "workflow_started": "🚀",
+            "workflow_progressed": "🔄",
+            "workflow_waiting_human": "⏳",
+            "workflow_blocked": "⚠️",
+            "workflow_failed": "❌",
+            "workflow_completed": "✅",
+            "review_requested": "👀",
+            "deployment_succeeded": "🚀",
+            "deployment_failed": "💥",
+        }.get(item.event_type, "📌")
+        workflow_ref = f"#{item.issue_number}" if item.issue_number else item.workflow_id or "workflow"
+        status_ref = item.current_step or item.workflow_phase or item.event_type.replace("_", " ")
+        lines = [f"{icon} **Workflow {workflow_ref} · {status_ref}**"]
+        if item.summary:
+            lines.append(item.summary)
+        context_bits: list[str] = []
+        if item.project_key:
+            context_bits.append(f"Project: `{item.project_key}`")
+        if item.repo:
+            context_bits.append(f"Repo: `{item.repo}`")
+        if item.agent_type:
+            context_bits.append(f"Agent: `{item.agent_type}`")
+        if item.step_num or item.step_name:
+            step_label = item.step_name or item.current_step
+            if item.step_num and step_label:
+                context_bits.append(f"Step: `{item.step_num}` · {step_label}")
+            elif step_label:
+                context_bits.append(f"Step: {step_label}")
+        if item.pr_number:
+            context_bits.append(f"PR: `#{item.pr_number}`")
+        elif item.pr_url:
+            context_bits.append(f"PR: {item.pr_url}")
+        if context_bits:
+            lines.extend(context_bits)
+        if item.blocked_reason:
+            lines.append(f"Blocked: {item.blocked_reason}")
+        if item.key_findings:
+            lines.append("Findings: " + "; ".join(item.key_findings[:3]))
+        if item.suggested_actions:
+            action_labels = ", ".join(action.replace("_", " ") for action in item.suggested_actions[:4])
+            lines.append(f"Actions: {action_labels}")
+        return "\n".join(lines)
 
     def _headers(self) -> dict[str, str]:
         headers = {"Content-Type": "application/json"}
@@ -170,7 +403,6 @@ class OpenClawNotificationChannel(NotificationChannel):
         return headers
 
     def _get_session(self) -> "aiohttp.ClientSession":
-        """Return a shared aiohttp session for the current event loop, creating it on first use."""
         import asyncio
 
         current_loop = asyncio.get_running_loop()
@@ -187,14 +419,12 @@ class OpenClawNotificationChannel(NotificationChannel):
         return session
 
     async def aclose(self) -> None:
-        """Close all underlying aiohttp sessions."""
         for session in list(self._sessions_by_loop.values()):
             if not session.closed:
                 await session.close()
         self._sessions_by_loop = {}
 
     async def _post(self, payload: dict[str, Any]) -> bool:
-        # Use /hooks/agent to trigger an isolated agent delivery turn
         url = f"{self._bridge_url}/hooks/agent"
         try:
             session = self._get_session()

--- a/nexus/plugins/builtin/openclaw_event_handler_plugin.py
+++ b/nexus/plugins/builtin/openclaw_event_handler_plugin.py
@@ -12,9 +12,9 @@ Uses the existing :class:`OpenClawNotificationChannel` adapter.
 import logging
 from typing import Any
 
-from nexus.adapters.notifications.base import Message
 from nexus.core.events import (
     AgentTimeout,
+    ApprovalRequired,
     EventBus,
     NexusEvent,
     StepCompleted,
@@ -25,36 +25,78 @@ from nexus.core.events import (
     WorkflowFailed,
     WorkflowStarted,
 )
-from nexus.core.models import Severity
 from nexus.plugins.base import PluginHealthStatus
 
 logger = logging.getLogger(__name__)
 
-_EVENT_FORMAT: dict[str, tuple[str, str]] = {
-    "workflow.started": ("🚀", "Workflow Started"),
-    "workflow.completed": ("✅", "Workflow Completed"),
-    "workflow.failed": ("❌", "Workflow Failed"),
-    "workflow.cancelled": ("🛑", "Workflow Cancelled"),
-    "step.completed": ("✔️", "Step Completed"),
-    "step.failed": ("⚠️", "Step Failed"),
-    "agent.timeout": ("⏰", "Agent Timeout"),
-    "system.alert": ("🔔", "Alert"),
-}
 
-_SEVERITY_MAP: dict[str, Severity] = {
-    "info": Severity.INFO,
-    "warning": Severity.WARNING,
-    "error": Severity.ERROR,
-    "critical": Severity.ERROR,
-}
+def _safe_str(value: Any) -> str:
+    return str(value or "").strip()
+
+
+def _event_severity(event: NexusEvent) -> str:
+    if isinstance(event, SystemAlert):
+        return _safe_str(getattr(event, "severity", "info")).lower() or "info"
+    if isinstance(event, (WorkflowFailed, StepFailed)):
+        return "error"
+    if isinstance(event, (WorkflowCancelled, AgentTimeout, ApprovalRequired)):
+        return "warning"
+    return "info"
+
+
+def _event_summary(event: NexusEvent) -> str:
+    if isinstance(event, WorkflowStarted):
+        return "Workflow execution started in Nexus."
+    if isinstance(event, WorkflowCompleted):
+        return "Workflow completed successfully in Nexus."
+    if isinstance(event, WorkflowFailed):
+        return _safe_str(event.error) or "Workflow failed in Nexus."
+    if isinstance(event, WorkflowCancelled):
+        return "Workflow was cancelled."
+    if isinstance(event, StepCompleted):
+        return f"{event.step_name or 'step'} completed; workflow advanced."
+    if isinstance(event, StepFailed):
+        return _safe_str(event.error) or f"{event.step_name or 'step'} failed."
+    if isinstance(event, AgentTimeout):
+        agent = _safe_str(event.agent_name) or "agent"
+        return f"{agent} timed out; manual attention may be required."
+    if isinstance(event, ApprovalRequired):
+        step_name = _safe_str(event.step_name) or "workflow step"
+        return f"Human approval is required for {step_name}."
+    if isinstance(event, SystemAlert):
+        return _safe_str(event.message)
+    return event.event_type.replace(".", " ")
+
+
+def _event_findings(event: NexusEvent) -> list[str]:
+    findings: list[str] = []
+    if isinstance(event, StepFailed) and _safe_str(event.error):
+        findings.append(_safe_str(event.error))
+    if isinstance(event, WorkflowFailed) and _safe_str(event.error):
+        findings.append(_safe_str(event.error))
+    if isinstance(event, SystemAlert) and _safe_str(event.source):
+        findings.append(f"source={_safe_str(event.source)}")
+    if isinstance(event, ApprovalRequired) and event.approvers:
+        findings.append("approvers=" + ", ".join(str(a) for a in event.approvers if str(a).strip()))
+    return findings[:3]
+
+
+def _suggested_actions(event: NexusEvent) -> list[str]:
+    if isinstance(event, WorkflowCompleted):
+        return ["show_status", "open_issue"]
+    if isinstance(event, ApprovalRequired):
+        return ["approve", "reject", "show_logs"]
+    if isinstance(event, (WorkflowFailed, StepFailed, AgentTimeout, WorkflowCancelled)):
+        return ["show_status", "show_logs", "continue"]
+    if isinstance(event, SystemAlert):
+        sev = _safe_str(getattr(event, "severity", "info")).lower()
+        if sev in {"warning", "error", "critical"}:
+            return ["show_status", "show_logs"]
+    return ["show_status"]
 
 
 class OpenClawEventHandler:
-    """Sends workflow event notifications to OpenClaw via the hooks bridge.
-
-    Wraps :class:`OpenClawNotificationChannel` and subscribes to the EventBus
-    for reactive dispatch.  Implements ``PluginLifecycle`` for health checks.
-    """
+    """Sends workflow event notifications to OpenClaw via the hooks bridge."""
 
     def __init__(self, config: dict[str, Any]):
         from nexus.adapters.notifications.openclaw import OpenClawNotificationChannel
@@ -69,14 +111,12 @@ class OpenClawEventHandler:
         self._subscriptions: list[str] = []
         self._last_send_ok: bool = True
 
-    # -- EventBus wiring ---------------------------------------------------
-
     def attach(self, bus: EventBus) -> None:
-        """Subscribe to relevant events on *bus*."""
         self._subscriptions.append(bus.subscribe("workflow.started", self._handle))
         self._subscriptions.append(bus.subscribe("workflow.completed", self._handle))
         self._subscriptions.append(bus.subscribe("workflow.failed", self._handle))
         self._subscriptions.append(bus.subscribe("workflow.cancelled", self._handle))
+        self._subscriptions.append(bus.subscribe("workflow.approval_required", self._handle))
         self._subscriptions.append(bus.subscribe("step.completed", self._handle))
         self._subscriptions.append(bus.subscribe("step.failed", self._handle))
         self._subscriptions.append(bus.subscribe("agent.timeout", self._handle))
@@ -87,72 +127,65 @@ class OpenClawEventHandler:
         )
 
     def detach(self, bus: EventBus) -> None:
-        """Unsubscribe all subscriptions from *bus*."""
         for sub_id in self._subscriptions:
             bus.unsubscribe(sub_id)
         self._subscriptions.clear()
 
-    # -- Handler -----------------------------------------------------------
-
     async def _handle(self, event: NexusEvent) -> None:
-        emoji, label = _EVENT_FORMAT.get(event.event_type, ("📌", event.event_type))
-        lines: list[str] = []
-        severity = Severity.INFO
+        data = dict(getattr(event, "data", {}) or {})
+        workflow_id = _safe_str(getattr(event, "workflow_id", ""))
+        project_key = _safe_str(data.get("project_key") or data.get("project"))
+        issue_number = _safe_str(data.get("issue_number"))
+        repo = _safe_str(data.get("repo"))
+        pr_number = _safe_str(data.get("pr_number"))
+        pr_url = _safe_str(data.get("pr_url"))
+        workflow_phase = _safe_str(data.get("workflow_phase") or data.get("state"))
+        current_step = _safe_str(data.get("current_step"))
+        blocked_reason = _safe_str(data.get("blocked_reason"))
+        correlation_token = _safe_str(data.get("correlation_token"))
 
-        if isinstance(event, SystemAlert):
-            severity = _SEVERITY_MAP.get(str(event.severity or "info").lower(), Severity.INFO)
-            lines.append(event.message)
-            if event.source:
-                lines.append(f"Source: {event.source}")
-            if event.workflow_id:
-                lines.append(f"Workflow: `{event.workflow_id}`")
-            if event.project_key:
-                lines.append(f"Project: `{event.project_key}`")
-            if event.issue_number:
-                lines.append(f"Issue: `#{event.issue_number}`")
-        else:
-            if event.workflow_id:
-                lines.append(f"Workflow: `{event.workflow_id}`")
+        step_num = 0
+        step_name = ""
+        step_id = _safe_str(data.get("step_id"))
+        agent_type = _safe_str(data.get("agent_type"))
 
-            if isinstance(event, WorkflowStarted):
-                severity = Severity.INFO
-            elif isinstance(event, WorkflowCompleted):
-                severity = Severity.INFO
-            elif isinstance(event, WorkflowFailed):
-                lines.append(f"Error: {event.error}")
-                severity = Severity.ERROR
-            elif isinstance(event, WorkflowCancelled):
-                severity = Severity.WARNING
-            elif isinstance(event, StepCompleted):
-                lines.append(f"Step: {event.step_name} (#{event.step_num})")
-                severity = Severity.INFO
-            elif isinstance(event, StepFailed):
-                lines.append(f"Step: {event.step_name} (#{event.step_num})")
-                lines.append(f"Error: {event.error}")
-                severity = Severity.WARNING
-            elif isinstance(event, AgentTimeout):
-                lines.append(f"Agent: {event.agent_name}")
-                if event.pid:
-                    lines.append(f"PID: {event.pid}")
-                severity = Severity.WARNING
-
-            if event.data:
-                for k, v in event.data.items():
-                    lines.append(f"{k}: `{v}`")
-
-        description = "\n".join(lines) if lines else ""
-        text = f"{emoji} **{label}**"
-        if description:
-            text = f"{text}\n{description}"
+        if isinstance(event, (StepCompleted, StepFailed, ApprovalRequired)):
+            step_num = int(getattr(event, "step_num", 0) or 0)
+            step_name = _safe_str(getattr(event, "step_name", ""))
+            current_step = current_step or step_name
+        if isinstance(event, ApprovalRequired):
+            agent_type = agent_type or _safe_str(getattr(event, "agent", ""))
+        elif isinstance(event, (StepCompleted, StepFailed)):
+            agent_type = agent_type or _safe_str(getattr(event, "agent_type", ""))
+        elif isinstance(event, AgentTimeout):
+            agent_type = agent_type or _safe_str(getattr(event, "agent_name", ""))
 
         try:
-            await self._channel.send_alert(text, severity)
-            self._last_send_ok = True
+            ok = await self._channel.send_workflow_notification(
+                event_type=event.event_type,
+                workflow_id=workflow_id,
+                project_key=project_key,
+                repo=repo,
+                issue_number=issue_number,
+                pr_number=pr_number,
+                pr_url=pr_url,
+                current_step=current_step,
+                step_id=step_id,
+                step_num=step_num,
+                step_name=step_name,
+                workflow_phase=workflow_phase,
+                agent_type=agent_type,
+                severity=_event_severity(event),
+                summary=_event_summary(event),
+                blocked_reason=blocked_reason,
+                key_findings=_event_findings(event),
+                suggested_actions=_suggested_actions(event),
+                correlation_token=correlation_token or None,
+            )
+            self._last_send_ok = bool(ok)
         except Exception as exc:
             self._last_send_ok = False
             logger.error("OpenClawEventHandler send failed: %s", exc)
-
-    # -- PluginLifecycle ---------------------------------------------------
 
     async def on_load(self, registry: Any) -> None:
         logger.info("OpenClawEventHandler loaded")
@@ -169,11 +202,7 @@ class OpenClawEventHandler:
         )
 
 
-# -- Plugin registration ---------------------------------------------------
-
-
 def register_plugins(registry: Any) -> None:
-    """Register OpenClaw event handler plugin."""
     from nexus.plugins.base import PluginKind
 
     registry.register_factory(

--- a/nexus/plugins/builtin/openclaw_event_handler_plugin.py
+++ b/nexus/plugins/builtin/openclaw_event_handler_plugin.py
@@ -134,8 +134,23 @@ class OpenClawEventHandler:
     async def _handle(self, event: NexusEvent) -> None:
         data = dict(getattr(event, "data", {}) or {})
         workflow_id = _safe_str(getattr(event, "workflow_id", ""))
-        project_key = _safe_str(data.get("project_key") or data.get("project"))
-        issue_number = _safe_str(data.get("issue_number"))
+        project_key = _safe_str(
+            data.get("project_key")
+            or data.get("project")
+            or (
+                getattr(event, "project_key", "")
+                if isinstance(event, SystemAlert)
+                else ""
+            )
+        )
+        issue_number = _safe_str(
+            data.get("issue_number")
+            or (
+                getattr(event, "issue_number", "")
+                if isinstance(event, SystemAlert)
+                else ""
+            )
+        )
         repo = _safe_str(data.get("repo"))
         pr_number = _safe_str(data.get("pr_number"))
         pr_url = _safe_str(data.get("pr_url"))

--- a/tests/test_adapters.py
+++ b/tests/test_adapters.py
@@ -1812,6 +1812,16 @@ class TestOpenClawNotificationChannel:
         payload = channel._build_payload("Hi")
         assert payload["to"] == "12345"
 
+    def test_build_payload_includes_metadata_and_session_key_override(self):
+        channel = self._make_channel()
+        payload = channel._build_payload(
+            "Hi",
+            metadata={"source": "nexus", "kind": "workflow_notification"},
+            session_key="nexus:nexus:workflow:nexus-123-full",
+        )
+        assert payload["metadata"]["kind"] == "workflow_notification"
+        assert payload["sessionKey"] == "nexus:nexus:workflow:nexus-123-full"
+
     def test_build_payload_omits_to_when_no_recipient(self):
         channel = self._make_channel()
         channel._sender_id = ""
@@ -1872,6 +1882,36 @@ class TestOpenClawNotificationChannel:
         with patch.object(channel, "_post", new=AsyncMock(return_value=True)):
             result = await channel.request_input("user1", "Please confirm?")
         assert result == ""
+
+    async def test_send_workflow_notification_includes_rich_metadata(self):
+        channel = self._make_channel()
+        with patch.object(channel, "_post", new=AsyncMock(return_value=True)) as mock_post:
+            ok = await channel.send_workflow_notification(
+                event_type="step.failed",
+                workflow_id="nexus-123-full",
+                project_key="nexus",
+                repo="ghabs-org/nexus-arc",
+                issue_number="123",
+                current_step="reviewer waiting",
+                step_num=4,
+                step_name="reviewer",
+                agent_type="reviewer",
+                severity="warning",
+                summary="Review requested for OpenClaw notification payload updates.",
+                blocked_reason="Waiting on human review.",
+                suggested_actions=["approve", "show_logs"],
+                correlation_token="corr-123",
+            )
+        assert ok is True
+        payload = mock_post.call_args[0][0]
+        assert payload["sessionKey"] == "nexus:nexus:workflow:nexus-123-full"
+        assert payload["metadata"]["payload"]["summary"] == (
+            "Review requested for OpenClaw notification payload updates."
+        )
+        assert payload["metadata"]["routing"]["reply_hint"]["correlation_token"] == "corr-123"
+        assert payload["metadata"]["actions"][0]["name"] == "approve"
+        assert "Workflow #123" in payload["message"]
+        assert "Actions: approve, show logs" in payload["message"]
 
     def test_require_aiohttp_raises_when_unavailable(self):
         import nexus.adapters.notifications.openclaw as _mod

--- a/tests/test_openclaw_event_handler.py
+++ b/tests/test_openclaw_event_handler.py
@@ -1,0 +1,75 @@
+import pytest
+from unittest.mock import AsyncMock
+
+
+@pytest.mark.asyncio
+async def test_openclaw_event_handler_sends_rich_step_failed_notification(monkeypatch):
+    from nexus.core.events import StepFailed
+    from nexus.plugins.builtin.openclaw_event_handler_plugin import OpenClawEventHandler
+
+    handler = OpenClawEventHandler.__new__(OpenClawEventHandler)
+    handler._subscriptions = []
+    handler._last_send_ok = True
+    handler._channel = type("_FakeChannel", (), {})()
+    handler._channel.send_workflow_notification = AsyncMock(return_value=True)
+
+    event = StepFailed(
+        workflow_id="nexus-130-full",
+        step_num=5,
+        step_name="compliance",
+        agent_type="compliance",
+        error="Critical auth gap detected",
+        data={
+            "project_key": "nexus",
+            "issue_number": "130",
+            "repo": "ghabs-org/nexus-arc",
+            "current_step": "compliance blocked",
+            "blocked_reason": "Critical finding requires developer rework",
+            "correlation_token": "corr-130-step5",
+        },
+    )
+
+    await handler._handle(event)
+
+    call = handler._channel.send_workflow_notification.await_args.kwargs
+    assert call["event_type"] == "step.failed"
+    assert call["workflow_id"] == "nexus-130-full"
+    assert call["project_key"] == "nexus"
+    assert call["issue_number"] == "130"
+    assert call["step_num"] == 5
+    assert call["agent_type"] == "compliance"
+    assert call["severity"] == "error"
+    assert call["blocked_reason"] == "Critical finding requires developer rework"
+    assert call["correlation_token"] == "corr-130-step5"
+    assert "Critical auth gap detected" in call["key_findings"][0]
+    assert call["suggested_actions"] == ["show_status", "show_logs", "continue"]
+
+
+@pytest.mark.asyncio
+async def test_openclaw_event_handler_maps_approval_required_to_waiting_human(monkeypatch):
+    from nexus.core.events import ApprovalRequired
+    from nexus.plugins.builtin.openclaw_event_handler_plugin import OpenClawEventHandler
+
+    handler = OpenClawEventHandler.__new__(OpenClawEventHandler)
+    handler._subscriptions = []
+    handler._last_send_ok = True
+    handler._channel = type("_FakeChannel", (), {})()
+    handler._channel.send_workflow_notification = AsyncMock(return_value=True)
+
+    event = ApprovalRequired(
+        workflow_id="nexus-200-full",
+        step_num=6,
+        step_name="merge approval",
+        agent="deployer",
+        approvers=["gab"],
+        data={"project_key": "nexus", "issue_number": "200"},
+    )
+
+    await handler._handle(event)
+
+    call = handler._channel.send_workflow_notification.await_args.kwargs
+    assert call["event_type"] == "workflow.approval_required"
+    assert call["agent_type"] == "deployer"
+    assert call["severity"] == "warning"
+    assert call["suggested_actions"] == ["approve", "reject", "show_logs"]
+    assert "Human approval is required" in call["summary"]

--- a/tests/test_openclaw_event_handler.py
+++ b/tests/test_openclaw_event_handler.py
@@ -1,5 +1,6 @@
-import pytest
 from unittest.mock import AsyncMock
+
+import pytest
 
 
 @pytest.mark.asyncio
@@ -46,7 +47,7 @@ async def test_openclaw_event_handler_sends_rich_step_failed_notification(monkey
 
 
 @pytest.mark.asyncio
-async def test_openclaw_event_handler_maps_approval_required_to_waiting_human(monkeypatch):
+async def test_openclaw_event_handler_sends_approval_required_notification(monkeypatch):
     from nexus.core.events import ApprovalRequired
     from nexus.plugins.builtin.openclaw_event_handler_plugin import OpenClawEventHandler
 


### PR DESCRIPTION
- [x] Understand the two review comments to address
- [x] Fix `project_key`/`issue_number` extraction to fall back to `SystemAlert` event attributes when `data` entries are missing
- [x] Rename test `test_openclaw_event_handler_maps_approval_required_to_waiting_human` → `test_openclaw_event_handler_sends_approval_required_notification`
- [x] Run tests to validate changes (86 passed, 15 skipped)
- [x] Code review and CodeQL check (0 alerts)

<!-- START COPILOT CODING AGENT TIPS -->
---

⌨️ Start Copilot coding agent tasks without leaving your editor — available in [VS Code](https://gh.io/cca-vs-code-docs), [Visual Studio](https://gh.io/cca-visual-studio-docs), [JetBrains IDEs](https://gh.io/cca-jetbrains-docs) and [Eclipse](https://gh.io/cca-eclipse-docs).
