### PR TITLE
Persist OpenClaw affinity and correlation state

### DIFF
--- a/docs/OPENCLAW_OPERATOR_SURFACE.md
+++ b/docs/OPENCLAW_OPERATOR_SURFACE.md
@@ -261,6 +261,9 @@ Current payload shape (first concrete runtime slice):
 Current behavior:
 - text remains concise and mobile-friendly for chat delivery
 - session affinity defaults to deterministic workflow-bound keys like `nexus:<project>:workflow:<workflow_id>` when no explicit session key is configured
+- workflow ↔ session affinity and latest correlation token are now persisted under `NEXUS_CORE_STORAGE_DIR/openclaw/affinity_state.json` so restart/redeploy recovery can reuse prior bindings
+- startup recovery repairs missing persisted bindings from workflow mappings and records lifecycle status for created/repaired/drifted bindings
+- configured session-key drift is surfaced in routing metadata (`binding_status`, `binding_source`, `lifecycle_reason`) for operator inspection
 - action hints are advisory metadata today; they are not yet a full authenticated reply-button flow
 
 This keeps Nexus as workflow truth while giving OpenClaw stronger workflow context for notification rendering and future reply routing.

--- a/examples/nexus-bot/src/inbox_processor.py
+++ b/examples/nexus-bot/src/inbox_processor.py
@@ -216,11 +216,7 @@ from nexus.core.runtime.agent_launcher import (
 from nexus.core.runtime_mode import is_issue_process_running, is_postgres_backend
 from nexus.core.startup_recovery import (
     build_startup_workflow_payload_loader as _build_startup_workflow_payload_loader,
-)
-from nexus.core.startup_recovery import (
     reconcile_completion_signals_on_startup as _startup_reconcile_completion_signals,
-)
-from nexus.core.startup_recovery import (
     reconcile_openclaw_affinity_on_startup as _startup_reconcile_openclaw_affinity,
 )
 from nexus.core.state_manager import HostStateManager

--- a/examples/nexus-bot/src/inbox_processor.py
+++ b/examples/nexus-bot/src/inbox_processor.py
@@ -220,6 +220,9 @@ from nexus.core.startup_recovery import (
 from nexus.core.startup_recovery import (
     reconcile_completion_signals_on_startup as _startup_reconcile_completion_signals,
 )
+from nexus.core.startup_recovery import (
+    reconcile_openclaw_affinity_on_startup as _startup_reconcile_openclaw_affinity,
+)
 from nexus.core.state_manager import HostStateManager
 from nexus.core.task_archive import (
     archive_closed_task_files as _svc_archive_closed_task_files,
@@ -551,10 +554,11 @@ def reconcile_completion_signals_on_startup() -> None:
     Safe startup check only: emits alerts when signals diverge, does not mutate
     workflow state or completion files.
     """
+    mappings_loader = lambda: _get_wf_state().load_all_mappings()
     _startup_reconcile_completion_signals(
         logger=logger,
         emit_alert=emit_alert,
-        get_workflow_state_mappings=lambda: _get_wf_state().load_all_mappings(),
+        get_workflow_state_mappings=mappings_loader,
         nexus_core_storage_dir=NEXUS_CORE_STORAGE_DIR,
         load_workflow_payload=_build_startup_workflow_payload_loader(
             db_only_task_mode=lambda: is_postgres_backend(NEXUS_STORAGE_BACKEND),
@@ -569,6 +573,12 @@ def reconcile_completion_signals_on_startup() -> None:
         is_terminal_agent_reference=_is_terminal_agent_reference,
         complete_step_for_issue=complete_step_for_issue,
         local_completions_enabled=lambda: not is_postgres_backend(NEXUS_STORAGE_BACKEND),
+    )
+    _startup_reconcile_openclaw_affinity(
+        logger=logger,
+        emit_alert=emit_alert,
+        get_workflow_state_mappings=mappings_loader,
+        nexus_core_storage_dir=NEXUS_CORE_STORAGE_DIR,
     )
 
 

--- a/examples/nexus-bot/tests/test_openclaw_affinity_state.py
+++ b/examples/nexus-bot/tests/test_openclaw_affinity_state.py
@@ -68,14 +68,12 @@ def test_resolve_affinity_binding_marks_configured_drift(tmp_path):
 
 def test_scan_and_repair_affinity_state_restores_missing_session_key(tmp_path):
     store = OpenClawAffinityStateStore(base_dir=tmp_path)
-    store.upsert(
-        resolve_affinity_binding(
-            workflow_id="nexus-50-full",
-            project_key="nexus",
-            issue_number="50",
-            correlation_token="ocwf-50",
-            store=store,
-        )
+    resolve_affinity_binding(
+        workflow_id="nexus-50-full",
+        project_key="nexus",
+        issue_number="50",
+        correlation_token="ocwf-50",
+        store=store,
     )
     records = store.load_all()
     records["nexus-50-full"].session_key = ""

--- a/examples/nexus-bot/tests/test_openclaw_affinity_state.py
+++ b/examples/nexus-bot/tests/test_openclaw_affinity_state.py
@@ -1,0 +1,107 @@
+import json
+
+from nexus.core.openclaw_affinity_state import (
+    OpenClawAffinityStateStore,
+    deterministic_session_key,
+    resolve_affinity_binding,
+    scan_and_repair_affinity_state,
+)
+from nexus.core.startup_recovery import reconcile_openclaw_affinity_on_startup
+
+
+def test_resolve_affinity_binding_persists_and_reuses_existing_state(tmp_path):
+    store = OpenClawAffinityStateStore(base_dir=tmp_path)
+
+    created = resolve_affinity_binding(
+        workflow_id="nexus-42-full",
+        project_key="nexus",
+        issue_number="42",
+        correlation_token="ocwf-first",
+        event_type="workflow_started",
+        store=store,
+    )
+
+    assert created.session_key == deterministic_session_key("nexus-42-full", "nexus", issue_number="42")
+    assert created.binding_status == "created"
+    assert created.correlation_token == "ocwf-first"
+
+    reused = resolve_affinity_binding(
+        workflow_id="nexus-42-full",
+        project_key="nexus",
+        issue_number="42",
+        event_type="workflow_progressed",
+        store=store,
+    )
+
+    assert reused.session_key == created.session_key
+    assert reused.correlation_token == "ocwf-first"
+    payload = json.loads((tmp_path / "openclaw" / "affinity_state.json").read_text())
+    assert payload["workflows"]["nexus-42-full"]["session_key"] == created.session_key
+
+
+def test_resolve_affinity_binding_marks_configured_drift(tmp_path):
+    store = OpenClawAffinityStateStore(base_dir=tmp_path)
+    resolve_affinity_binding(
+        workflow_id="nexus-43-full",
+        project_key="nexus",
+        issue_number="43",
+        correlation_token="ocwf-1",
+        store=store,
+    )
+
+    drifted = resolve_affinity_binding(
+        workflow_id="nexus-43-full",
+        project_key="nexus",
+        issue_number="43",
+        configured_session_key="telegram:chat:abc",
+        correlation_token="ocwf-2",
+        event_type="workflow_progressed",
+        store=store,
+    )
+
+    assert drifted.binding_status == "drifted"
+    assert drifted.binding_source == "configured"
+    assert drifted.lifecycle_reason == "configured_session_key_mismatch"
+    assert drifted.session_key == "telegram:chat:abc"
+    assert drifted.history
+
+
+def test_scan_and_repair_affinity_state_restores_missing_session_key(tmp_path):
+    store = OpenClawAffinityStateStore(base_dir=tmp_path)
+    store.upsert(
+        resolve_affinity_binding(
+            workflow_id="nexus-50-full",
+            project_key="nexus",
+            issue_number="50",
+            correlation_token="ocwf-50",
+            store=store,
+        )
+    )
+    records = store.load_all()
+    records["nexus-50-full"].session_key = ""
+    store.save_all(records)
+
+    repaired = scan_and_repair_affinity_state(
+        workflow_mappings={"50": "nexus-50-full"},
+        store=store,
+    )
+
+    assert len(repaired) == 1
+    assert repaired[0].binding_status == "repaired"
+    assert repaired[0].lifecycle_reason == "missing_persisted_session_key"
+    assert repaired[0].session_key == deterministic_session_key("nexus-50-full", "nexus", issue_number="50")
+
+
+def test_reconcile_openclaw_affinity_on_startup_emits_restored_alert(tmp_path):
+    alerts = []
+
+    reconcile_openclaw_affinity_on_startup(
+        logger=type("L", (), {"debug": lambda *args, **kwargs: None})(),
+        emit_alert=lambda msg, **kwargs: alerts.append((msg, kwargs)),
+        get_workflow_state_mappings=lambda: {"42": "nexus-42-full"},
+        nexus_core_storage_dir=str(tmp_path),
+    )
+
+    # default store uses configured core storage dir; this function should still report repair activity
+    assert alerts
+    assert "Restored OpenClaw affinity" in alerts[0][0]

--- a/nexus/adapters/notifications/openclaw.py
+++ b/nexus/adapters/notifications/openclaw.py
@@ -34,6 +34,7 @@ from typing import Any
 from nexus.adapters.notifications.base import Message, NotificationChannel
 from nexus.core.models import Severity
 from nexus.core.openclaw_affinity_state import (
+    OpenClawAffinityRecord,
     OpenClawAffinityStateStore,
     resolve_affinity_binding,
 )
@@ -297,15 +298,41 @@ class OpenClawNotificationChannel(NotificationChannel):
         """Send a rich workflow notification envelope to OpenClaw."""
         resolved_project = _infer_project_key(workflow_id, project_key)
         resolved_issue = str(issue_number or "").strip() or _extract_issue_number(workflow_id)
-        affinity = resolve_affinity_binding(
-            workflow_id=str(workflow_id or "").strip(),
-            project_key=resolved_project,
-            issue_number=resolved_issue,
-            configured_session_key=session_key or self._session_key,
-            correlation_token=str(correlation_token or "").strip() or f"ocwf-{uuid.uuid4().hex}",
-            event_type=_normalize_event_type(event_type),
-            store=self._affinity_store,
-        )
+        affinity_store = getattr(self, "_affinity_store", None) or OpenClawAffinityStateStore()
+        try:
+            affinity = resolve_affinity_binding(
+                workflow_id=str(workflow_id or "").strip(),
+                project_key=resolved_project,
+                issue_number=resolved_issue,
+                configured_session_key=session_key or self._session_key,
+                correlation_token=str(correlation_token or "").strip() or f"ocwf-{uuid.uuid4().hex}",
+                event_type=_normalize_event_type(event_type),
+                store=affinity_store,
+            )
+        except Exception as exc:  # pragma: no cover - defensive fallback for I/O failures
+            logger.warning(
+                "Failed to resolve OpenClaw affinity binding; "
+                "falling back to deterministic session key and generated correlation token",
+                exc_info=exc,
+            )
+            fallback_session_key_raw = session_key or getattr(self, "_session_key", "") or ""
+            fallback_session_key = str(fallback_session_key_raw).strip()
+            if not fallback_session_key:
+                fallback_session_key = _resolve_session_key(
+                    str(workflow_id or "").strip(),
+                    resolved_project,
+                    issue_number=resolved_issue,
+                )
+            affinity = OpenClawAffinityRecord(
+                workflow_id=str(workflow_id or "").strip(),
+                project_key=resolved_project,
+                issue_number=resolved_issue,
+                session_key=fallback_session_key,
+                correlation_token=str(correlation_token or "").strip() or f"ocwf-{uuid.uuid4().hex}",
+                binding_status="ephemeral",
+                binding_source="fallback",
+                lifecycle_reason="persistence_failure",
+            )
         payload_model = WorkflowNotificationPayload(
             event_type=_normalize_event_type(event_type),
             workflow_id=str(workflow_id or "").strip(),

--- a/nexus/adapters/notifications/openclaw.py
+++ b/nexus/adapters/notifications/openclaw.py
@@ -33,6 +33,10 @@ from typing import Any
 
 from nexus.adapters.notifications.base import Message, NotificationChannel
 from nexus.core.models import Severity
+from nexus.core.openclaw_affinity_state import (
+    OpenClawAffinityStateStore,
+    resolve_affinity_binding,
+)
 
 try:
     import aiohttp
@@ -77,6 +81,9 @@ class WorkflowNotificationPayload:
     suggested_actions: list[str] = field(default_factory=list)
     session_key: str = ""
     correlation_token: str = field(default_factory=lambda: f"ocwf-{uuid.uuid4().hex}")
+    binding_status: str = "active"
+    binding_source: str = "deterministic"
+    lifecycle_reason: str = ""
     timestamp_utc: str = field(default_factory=lambda: datetime.now(UTC).isoformat())
 
     def to_metadata(self) -> dict[str, Any]:
@@ -118,6 +125,9 @@ class WorkflowNotificationPayload:
             "routing": {
                 "session_key": self.session_key,
                 "correlation_token": self.correlation_token,
+                "binding_status": self.binding_status,
+                "binding_source": self.binding_source,
+                "lifecycle_reason": self.lifecycle_reason,
                 "reply_hint": {
                     "workflow_id": self.workflow_id,
                     "session_key": self.session_key,
@@ -223,6 +233,7 @@ class OpenClawNotificationChannel(NotificationChannel):
         self._session_key = session_key or os.getenv("NEXUS_OPENCLAW_SESSION_KEY") or ""
         self._timeout_seconds = timeout
         self._sessions_by_loop: dict[object, aiohttp.ClientSession] = {}
+        self._affinity_store = OpenClawAffinityStateStore()
 
     @property
     def name(self) -> str:
@@ -286,11 +297,14 @@ class OpenClawNotificationChannel(NotificationChannel):
         """Send a rich workflow notification envelope to OpenClaw."""
         resolved_project = _infer_project_key(workflow_id, project_key)
         resolved_issue = str(issue_number or "").strip() or _extract_issue_number(workflow_id)
-        resolved_session_key = _resolve_session_key(
-            workflow_id,
-            resolved_project,
-            configured_session_key=session_key or self._session_key,
+        affinity = resolve_affinity_binding(
+            workflow_id=str(workflow_id or "").strip(),
+            project_key=resolved_project,
             issue_number=resolved_issue,
+            configured_session_key=session_key or self._session_key,
+            correlation_token=str(correlation_token or "").strip() or f"ocwf-{uuid.uuid4().hex}",
+            event_type=_normalize_event_type(event_type),
+            store=self._affinity_store,
         )
         payload_model = WorkflowNotificationPayload(
             event_type=_normalize_event_type(event_type),
@@ -313,16 +327,18 @@ class OpenClawNotificationChannel(NotificationChannel):
             suggested_actions=[
                 str(item).strip() for item in (suggested_actions or []) if str(item).strip()
             ],
-            session_key=resolved_session_key,
-            correlation_token=str(correlation_token or "").strip()
-            or f"ocwf-{uuid.uuid4().hex}",
+            session_key=affinity.session_key,
+            correlation_token=affinity.correlation_token,
+            binding_status=affinity.binding_status,
+            binding_source=affinity.binding_source,
+            lifecycle_reason=affinity.lifecycle_reason,
         )
         text = self._render_workflow_notification(payload_model)
         payload = self._build_payload(
             text,
             target_user=target_user or self._sender_id,
             metadata=payload_model.to_metadata(),
-            session_key=resolved_session_key,
+            session_key=affinity.session_key,
         )
         return await self._post(payload)
 

--- a/nexus/core/openclaw_affinity_state.py
+++ b/nexus/core/openclaw_affinity_state.py
@@ -16,6 +16,13 @@ from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
 
+try:
+    import fcntl as _fcntl
+
+    _HAS_FCNTL = True
+except ImportError:  # pragma: no cover - Windows
+    _HAS_FCNTL = False
+
 logger = logging.getLogger(__name__)
 
 _STATE_DIRNAME = "openclaw"
@@ -82,7 +89,20 @@ class OpenClawAffinityStateStore:
             with open(self.state_file, encoding="utf-8") as handle:
                 payload = json.load(handle)
         except Exception as exc:
-            logger.warning("Failed to load OpenClaw affinity state: %s", exc)
+            logger.error("Failed to load OpenClaw affinity state from %s: %s", self.state_file, exc)
+            try:
+                backup_suffix = datetime.now(UTC).isoformat().replace(":", "-")
+                backup_path = self.state_file.with_suffix(
+                    f"{self.state_file.suffix}.corrupt-{backup_suffix}"
+                )
+                os.replace(self.state_file, backup_path)
+                logger.error("Backed up corrupt OpenClaw affinity state file to %s", backup_path)
+            except Exception as backup_exc:  # pragma: no cover - best-effort backup
+                logger.error(
+                    "Failed to back up corrupt OpenClaw affinity state file %s: %s",
+                    self.state_file,
+                    backup_exc,
+                )
             return {}
         workflows = payload.get("workflows", {}) if isinstance(payload, dict) else {}
         if not isinstance(workflows, dict):
@@ -111,9 +131,18 @@ class OpenClawAffinityStateStore:
         workflow_id = str(record.workflow_id or "").strip()
         if not workflow_id:
             raise ValueError("workflow_id is required for OpenClaw affinity persistence")
-        records = self.load_all()
-        records[workflow_id] = record
-        self.save_all(records)
+        self._ensure_dir()
+        lock_path = self.state_file.with_suffix(".json.lock")
+        with open(lock_path, "w") as lock_handle:
+            if _HAS_FCNTL:
+                _fcntl.flock(lock_handle, _fcntl.LOCK_EX)
+            try:
+                records = self.load_all()
+                records[workflow_id] = record
+                self.save_all(records)
+            finally:
+                if _HAS_FCNTL:
+                    _fcntl.flock(lock_handle, _fcntl.LOCK_UN)
         return record
 
 
@@ -129,6 +158,19 @@ def deterministic_session_key(
     if str(issue_number or "").strip():
         prefix = f"nexus:{project_key}:issue" if str(project_key or "").strip() else "nexus:issue"
         return f"{prefix}:{str(issue_number).strip()}"
+    return ""
+
+
+def _infer_project_key(workflow_id: str) -> str:
+    """Infer a project key from a workflow ID by splitting on the first dash.
+
+    Mirrors the same heuristic used by the OpenClaw notification adapter so
+    that session keys produced during startup reconciliation match those used
+    during normal notification delivery (e.g. ``nexus-50-full`` → ``nexus``).
+    """
+    candidate = str(workflow_id or "").strip()
+    if candidate and "-" in candidate:
+        return candidate.split("-", 1)[0]
     return ""
 
 
@@ -228,6 +270,7 @@ def scan_and_repair_affinity_state(
             repaired.append(
                 resolve_affinity_binding(
                     workflow_id=workflow_id,
+                    project_key=_infer_project_key(workflow_id),
                     issue_number=issue_number,
                     store=store,
                     event_type="startup.reconcile",

--- a/nexus/core/openclaw_affinity_state.py
+++ b/nexus/core/openclaw_affinity_state.py
@@ -1,0 +1,257 @@
+"""Persistent workflow ↔ OpenClaw affinity and correlation state.
+
+This first runtime slice keeps a small durable routing ledger under
+``NEXUS_CORE_STORAGE_DIR`` so workflow-bound OpenClaw session affinity survives
+restart/redeploy and so the latest correlation token can be recovered for
+operator inspection and reply-routing follow-up work.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+from dataclasses import asdict, dataclass, field
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+_STATE_DIRNAME = "openclaw"
+_STATE_FILENAME = "affinity_state.json"
+
+
+@dataclass
+class OpenClawAffinityRecord:
+    workflow_id: str = ""
+    issue_number: str = ""
+    project_key: str = ""
+    session_key: str = ""
+    correlation_token: str = ""
+    binding_status: str = "active"
+    binding_source: str = "deterministic"
+    lifecycle_reason: str = ""
+    last_event_type: str = ""
+    updated_at: str = field(default_factory=lambda: datetime.now(UTC).isoformat())
+    repaired_at: str = ""
+    history: list[dict[str, Any]] = field(default_factory=list)
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+    @classmethod
+    def from_dict(cls, payload: dict[str, Any] | None) -> "OpenClawAffinityRecord":
+        data = payload if isinstance(payload, dict) else {}
+        history = data.get("history", [])
+        return cls(
+            workflow_id=str(data.get("workflow_id", "") or ""),
+            issue_number=str(data.get("issue_number", "") or ""),
+            project_key=str(data.get("project_key", "") or ""),
+            session_key=str(data.get("session_key", "") or ""),
+            correlation_token=str(data.get("correlation_token", "") or ""),
+            binding_status=str(data.get("binding_status", "active") or "active"),
+            binding_source=str(data.get("binding_source", "deterministic") or "deterministic"),
+            lifecycle_reason=str(data.get("lifecycle_reason", "") or ""),
+            last_event_type=str(data.get("last_event_type", "") or ""),
+            updated_at=str(data.get("updated_at", "") or datetime.now(UTC).isoformat()),
+            repaired_at=str(data.get("repaired_at", "") or ""),
+            history=list(history) if isinstance(history, list) else [],
+        )
+
+
+def _default_base_dir() -> Path:
+    runtime_dir = os.getenv("NEXUS_RUNTIME_DIR", "/var/lib/nexus")
+    configured = os.getenv("NEXUS_CORE_STORAGE_DIR") or os.path.join(runtime_dir, "nexus-arc")
+    return Path(configured)
+
+
+class OpenClawAffinityStateStore:
+    def __init__(self, base_dir: str | Path | None = None):
+        self.base_dir = Path(base_dir) if base_dir is not None else _default_base_dir()
+        self.state_dir = self.base_dir / _STATE_DIRNAME
+        self.state_file = self.state_dir / _STATE_FILENAME
+
+    def _ensure_dir(self) -> None:
+        self.state_dir.mkdir(parents=True, exist_ok=True)
+
+    def load_all(self) -> dict[str, OpenClawAffinityRecord]:
+        if not self.state_file.exists():
+            return {}
+        try:
+            with open(self.state_file, encoding="utf-8") as handle:
+                payload = json.load(handle)
+        except Exception as exc:
+            logger.warning("Failed to load OpenClaw affinity state: %s", exc)
+            return {}
+        workflows = payload.get("workflows", {}) if isinstance(payload, dict) else {}
+        if not isinstance(workflows, dict):
+            return {}
+        return {
+            str(workflow_id): OpenClawAffinityRecord.from_dict(record)
+            for workflow_id, record in workflows.items()
+        }
+
+    def save_all(self, records: dict[str, OpenClawAffinityRecord]) -> None:
+        self._ensure_dir()
+        payload = {
+            "version": 1,
+            "updated_at": datetime.now(UTC).isoformat(),
+            "workflows": {workflow_id: record.to_dict() for workflow_id, record in records.items()},
+        }
+        tmp_path = self.state_file.with_suffix(".json.tmp")
+        with open(tmp_path, "w", encoding="utf-8") as handle:
+            json.dump(payload, handle, indent=2, sort_keys=True)
+        os.replace(tmp_path, self.state_file)
+
+    def get(self, workflow_id: str) -> OpenClawAffinityRecord | None:
+        return self.load_all().get(str(workflow_id or ""))
+
+    def upsert(self, record: OpenClawAffinityRecord) -> OpenClawAffinityRecord:
+        workflow_id = str(record.workflow_id or "").strip()
+        if not workflow_id:
+            raise ValueError("workflow_id is required for OpenClaw affinity persistence")
+        records = self.load_all()
+        records[workflow_id] = record
+        self.save_all(records)
+        return record
+
+
+def deterministic_session_key(
+    workflow_id: str,
+    project_key: str = "",
+    *,
+    issue_number: str = "",
+) -> str:
+    if str(workflow_id or "").strip():
+        prefix = f"nexus:{project_key}:workflow" if str(project_key or "").strip() else "nexus:workflow"
+        return f"{prefix}:{str(workflow_id).strip()}"
+    if str(issue_number or "").strip():
+        prefix = f"nexus:{project_key}:issue" if str(project_key or "").strip() else "nexus:issue"
+        return f"{prefix}:{str(issue_number).strip()}"
+    return ""
+
+
+def resolve_affinity_binding(
+    *,
+    workflow_id: str,
+    project_key: str = "",
+    issue_number: str = "",
+    configured_session_key: str = "",
+    correlation_token: str = "",
+    event_type: str = "",
+    store: OpenClawAffinityStateStore | None = None,
+) -> OpenClawAffinityRecord:
+    workflow_id = str(workflow_id or "").strip()
+    if not workflow_id:
+        raise ValueError("workflow_id is required for OpenClaw affinity binding")
+
+    store = store or OpenClawAffinityStateStore()
+    existing = store.get(workflow_id)
+    configured_session_key = str(configured_session_key or "").strip()
+    project_key = str(project_key or "").strip()
+    issue_number = str(issue_number or "").strip()
+    correlation_token = str(correlation_token or "").strip()
+    event_type = str(event_type or "").strip()
+
+    derived_session_key = deterministic_session_key(
+        workflow_id,
+        project_key,
+        issue_number=issue_number,
+    )
+    resolved_session_key = configured_session_key or (existing.session_key if existing else "") or derived_session_key
+
+    binding_source = "configured" if configured_session_key else "persisted" if existing and existing.session_key else "deterministic"
+    binding_status = "active"
+    lifecycle_reason = ""
+    repaired_at = existing.repaired_at if existing else ""
+    history = list(existing.history) if existing else []
+
+    if existing and existing.session_key and configured_session_key and existing.session_key != configured_session_key:
+        binding_status = "drifted"
+        lifecycle_reason = "configured_session_key_mismatch"
+        repaired_at = datetime.now(UTC).isoformat()
+        history.append(
+            {
+                "at": repaired_at,
+                "reason": lifecycle_reason,
+                "previous_session_key": existing.session_key,
+                "new_session_key": configured_session_key,
+            }
+        )
+    elif existing and not existing.session_key and resolved_session_key:
+        binding_status = "repaired"
+        lifecycle_reason = "missing_persisted_session_key"
+        repaired_at = datetime.now(UTC).isoformat()
+    elif not existing and resolved_session_key:
+        binding_status = "created"
+        lifecycle_reason = "initialized_from_runtime"
+
+    resolved_correlation = (
+        correlation_token
+        or (existing.correlation_token if existing else "")
+    )
+
+    record = OpenClawAffinityRecord(
+        workflow_id=workflow_id,
+        issue_number=issue_number or (existing.issue_number if existing else ""),
+        project_key=project_key or (existing.project_key if existing else ""),
+        session_key=resolved_session_key,
+        correlation_token=resolved_correlation,
+        binding_status=binding_status,
+        binding_source=binding_source,
+        lifecycle_reason=lifecycle_reason,
+        last_event_type=event_type or (existing.last_event_type if existing else ""),
+        updated_at=datetime.now(UTC).isoformat(),
+        repaired_at=repaired_at,
+        history=history[-20:],
+    )
+    return store.upsert(record)
+
+
+def scan_and_repair_affinity_state(
+    *,
+    workflow_mappings: dict[str, Any],
+    store: OpenClawAffinityStateStore | None = None,
+) -> list[OpenClawAffinityRecord]:
+    store = store or OpenClawAffinityStateStore()
+    repaired: list[OpenClawAffinityRecord] = []
+    records = store.load_all()
+
+    for issue_number, workflow_id in (workflow_mappings or {}).items():
+        workflow_id = str(workflow_id or "").strip()
+        issue_number = str(issue_number or "").strip()
+        if not workflow_id:
+            continue
+        record = records.get(workflow_id)
+        if record is None:
+            repaired.append(
+                resolve_affinity_binding(
+                    workflow_id=workflow_id,
+                    issue_number=issue_number,
+                    store=store,
+                    event_type="startup.reconcile",
+                )
+            )
+            continue
+        changed = False
+        if not str(record.issue_number or "").strip() and issue_number:
+            record.issue_number = issue_number
+            record.binding_status = "repaired"
+            record.lifecycle_reason = "missing_issue_number"
+            record.repaired_at = datetime.now(UTC).isoformat()
+            changed = True
+        if not str(record.session_key or "").strip():
+            record.session_key = deterministic_session_key(
+                workflow_id,
+                record.project_key,
+                issue_number=issue_number,
+            )
+            record.binding_status = "repaired"
+            record.lifecycle_reason = "missing_persisted_session_key"
+            record.repaired_at = datetime.now(UTC).isoformat()
+            changed = True
+        if changed:
+            record.updated_at = datetime.now(UTC).isoformat()
+            repaired.append(store.upsert(record))
+    return repaired

--- a/nexus/core/startup_recovery.py
+++ b/nexus/core/startup_recovery.py
@@ -6,6 +6,8 @@ import os
 from collections.abc import Callable
 from typing import Any
 
+from nexus.core.openclaw_affinity_state import OpenClawAffinityStateStore, scan_and_repair_affinity_state
+
 _INSTRUCTION_TEMPLATE_MARKERS = (
     "<agent_type from workflow steps",
     "<step name>",
@@ -87,6 +89,37 @@ def build_startup_workflow_payload_loader(
         return payload if isinstance(payload, dict) else None
 
     return _load_startup_workflow_payload
+
+
+def reconcile_openclaw_affinity_on_startup(
+    *,
+    logger,
+    emit_alert: Callable[..., Any],
+    get_workflow_state_mappings: Callable[[], dict[str, Any]],
+    nexus_core_storage_dir: str | None = None,
+) -> None:
+    """Repair missing persisted OpenClaw affinity state from workflow mappings."""
+    try:
+        repaired = scan_and_repair_affinity_state(
+            workflow_mappings=get_workflow_state_mappings() or {},
+            store=OpenClawAffinityStateStore(base_dir=nexus_core_storage_dir) if nexus_core_storage_dir else None,
+        )
+    except Exception as exc:
+        logger.debug("OpenClaw affinity startup reconciliation failed: %s", exc)
+        return
+
+    for record in repaired:
+        emit_alert(
+            (
+                f"ℹ️ Restored OpenClaw affinity for workflow `{record.workflow_id}`"
+                f" (issue #{record.issue_number or 'n/a'}, session `{record.session_key or 'n/a'}`)"
+            ),
+            severity="info",
+            source="openclaw-affinity-startup",
+            workflow_id=record.workflow_id,
+            issue_number=record.issue_number or None,
+            project_key=record.project_key or None,
+        )
 
 
 def reconcile_completion_signals_on_startup(

--- a/tests/test_openclaw_affinity_state.py
+++ b/tests/test_openclaw_affinity_state.py
@@ -1,0 +1,323 @@
+"""Unit tests for nexus.core.openclaw_affinity_state.
+
+Covers the core affinity/correlation persistence layer so that CI runs in the
+top-level ``tests/`` collection path (configured as ``testpaths = ["tests"]`` in
+``pyproject.toml``) exercise this framework module.
+"""
+
+import json
+import os
+
+import pytest
+
+from nexus.core.openclaw_affinity_state import (
+    OpenClawAffinityRecord,
+    OpenClawAffinityStateStore,
+    _infer_project_key,
+    deterministic_session_key,
+    resolve_affinity_binding,
+    scan_and_repair_affinity_state,
+)
+
+
+# ---------------------------------------------------------------------------
+# deterministic_session_key
+# ---------------------------------------------------------------------------
+
+
+def test_deterministic_session_key_with_project():
+    key = deterministic_session_key("nexus-42-full", "nexus")
+    assert key == "nexus:nexus:workflow:nexus-42-full"
+
+
+def test_deterministic_session_key_without_project():
+    key = deterministic_session_key("nexus-42-full")
+    assert key == "nexus:workflow:nexus-42-full"
+
+
+def test_deterministic_session_key_falls_back_to_issue():
+    key = deterministic_session_key("", "nexus", issue_number="10")
+    assert key == "nexus:nexus:issue:10"
+
+
+def test_deterministic_session_key_empty_returns_empty():
+    assert deterministic_session_key("") == ""
+
+
+# ---------------------------------------------------------------------------
+# _infer_project_key
+# ---------------------------------------------------------------------------
+
+
+def test_infer_project_key_splits_on_first_dash():
+    assert _infer_project_key("nexus-50-full") == "nexus"
+
+
+def test_infer_project_key_no_dash_returns_empty():
+    assert _infer_project_key("singleword") == ""
+
+
+def test_infer_project_key_empty_returns_empty():
+    assert _infer_project_key("") == ""
+
+
+# ---------------------------------------------------------------------------
+# OpenClawAffinityStateStore
+# ---------------------------------------------------------------------------
+
+
+def test_store_load_all_returns_empty_when_file_missing(tmp_path):
+    store = OpenClawAffinityStateStore(base_dir=tmp_path)
+    assert store.load_all() == {}
+
+
+def test_store_upsert_persists_and_retrieves(tmp_path):
+    store = OpenClawAffinityStateStore(base_dir=tmp_path)
+    record = OpenClawAffinityRecord(
+        workflow_id="nexus-1-full",
+        session_key="nexus:nexus:workflow:nexus-1-full",
+        correlation_token="ocwf-abc",
+    )
+    store.upsert(record)
+    loaded = store.get("nexus-1-full")
+    assert loaded is not None
+    assert loaded.session_key == "nexus:nexus:workflow:nexus-1-full"
+    assert loaded.correlation_token == "ocwf-abc"
+
+
+def test_store_upsert_raises_without_workflow_id(tmp_path):
+    store = OpenClawAffinityStateStore(base_dir=tmp_path)
+    with pytest.raises(ValueError, match="workflow_id is required"):
+        store.upsert(OpenClawAffinityRecord(workflow_id=""))
+
+
+def test_store_upsert_creates_lock_file(tmp_path):
+    store = OpenClawAffinityStateStore(base_dir=tmp_path)
+    store.upsert(OpenClawAffinityRecord(workflow_id="wf-lock-test"))
+    assert (tmp_path / "openclaw" / "affinity_state.json.lock").exists()
+
+
+def test_store_load_all_backs_up_corrupt_file(tmp_path):
+    store = OpenClawAffinityStateStore(base_dir=tmp_path)
+    store._ensure_dir()
+    store.state_file.write_text("{ not valid json !!!", encoding="utf-8")
+
+    result = store.load_all()
+
+    assert result == {}
+    # Original file should have been renamed to a backup
+    assert not store.state_file.exists()
+    backups = list(store.state_dir.glob("affinity_state.json.corrupt-*"))
+    assert len(backups) == 1
+
+
+def test_store_save_all_and_load_all_roundtrip(tmp_path):
+    store = OpenClawAffinityStateStore(base_dir=tmp_path)
+    records = {
+        "wf-1": OpenClawAffinityRecord(workflow_id="wf-1", session_key="sk-1"),
+        "wf-2": OpenClawAffinityRecord(workflow_id="wf-2", session_key="sk-2"),
+    }
+    store.save_all(records)
+    loaded = store.load_all()
+    assert set(loaded.keys()) == {"wf-1", "wf-2"}
+    assert loaded["wf-1"].session_key == "sk-1"
+
+
+# ---------------------------------------------------------------------------
+# resolve_affinity_binding
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_affinity_binding_creates_new_record(tmp_path):
+    store = OpenClawAffinityStateStore(base_dir=tmp_path)
+    rec = resolve_affinity_binding(
+        workflow_id="nexus-42-full",
+        project_key="nexus",
+        issue_number="42",
+        correlation_token="ocwf-first",
+        event_type="workflow_started",
+        store=store,
+    )
+    assert rec.binding_status == "created"
+    assert rec.session_key == "nexus:nexus:workflow:nexus-42-full"
+    assert rec.correlation_token == "ocwf-first"
+    assert rec.lifecycle_reason == "initialized_from_runtime"
+
+
+def test_resolve_affinity_binding_reuses_existing_state(tmp_path):
+    store = OpenClawAffinityStateStore(base_dir=tmp_path)
+    resolve_affinity_binding(
+        workflow_id="nexus-42-full",
+        project_key="nexus",
+        issue_number="42",
+        correlation_token="ocwf-first",
+        store=store,
+    )
+    reused = resolve_affinity_binding(
+        workflow_id="nexus-42-full",
+        project_key="nexus",
+        issue_number="42",
+        event_type="workflow_progressed",
+        store=store,
+    )
+    assert reused.session_key == "nexus:nexus:workflow:nexus-42-full"
+    assert reused.correlation_token == "ocwf-first"
+
+
+def test_resolve_affinity_binding_detects_drift(tmp_path):
+    store = OpenClawAffinityStateStore(base_dir=tmp_path)
+    resolve_affinity_binding(workflow_id="nexus-43-full", store=store)
+
+    drifted = resolve_affinity_binding(
+        workflow_id="nexus-43-full",
+        configured_session_key="telegram:chat:999",
+        store=store,
+    )
+    assert drifted.binding_status == "drifted"
+    assert drifted.lifecycle_reason == "configured_session_key_mismatch"
+    assert drifted.session_key == "telegram:chat:999"
+    assert drifted.history
+
+
+def test_resolve_affinity_binding_repairs_missing_session_key(tmp_path):
+    store = OpenClawAffinityStateStore(base_dir=tmp_path)
+    resolve_affinity_binding(workflow_id="nexus-44-full", store=store)
+    records = store.load_all()
+    records["nexus-44-full"].session_key = ""
+    store.save_all(records)
+
+    repaired = resolve_affinity_binding(
+        workflow_id="nexus-44-full",
+        store=store,
+    )
+    assert repaired.binding_status == "repaired"
+    assert repaired.lifecycle_reason == "missing_persisted_session_key"
+    assert repaired.session_key
+
+
+def test_resolve_affinity_binding_raises_without_workflow_id():
+    with pytest.raises(ValueError, match="workflow_id is required"):
+        resolve_affinity_binding(workflow_id="")
+
+
+def test_resolve_affinity_binding_persists_to_json_file(tmp_path):
+    store = OpenClawAffinityStateStore(base_dir=tmp_path)
+    resolve_affinity_binding(
+        workflow_id="nexus-45-full",
+        project_key="nexus",
+        issue_number="45",
+        store=store,
+    )
+    payload = json.loads((tmp_path / "openclaw" / "affinity_state.json").read_text())
+    assert "nexus-45-full" in payload["workflows"]
+
+
+# ---------------------------------------------------------------------------
+# scan_and_repair_affinity_state
+# ---------------------------------------------------------------------------
+
+
+def test_scan_and_repair_creates_missing_affinity_record(tmp_path):
+    store = OpenClawAffinityStateStore(base_dir=tmp_path)
+    repaired = scan_and_repair_affinity_state(
+        workflow_mappings={"55": "nexus-55-full"},
+        store=store,
+    )
+    assert len(repaired) == 1
+    rec = repaired[0]
+    assert rec.workflow_id == "nexus-55-full"
+    # project_key should be inferred from workflow_id
+    assert rec.project_key == "nexus"
+    assert rec.session_key == "nexus:nexus:workflow:nexus-55-full"
+
+
+def test_scan_and_repair_infers_project_key_from_workflow_id(tmp_path):
+    """Recovered affinity should use the same session key format as notifications."""
+    store = OpenClawAffinityStateStore(base_dir=tmp_path)
+    repaired = scan_and_repair_affinity_state(
+        workflow_mappings={"60": "myproject-60-full"},
+        store=store,
+    )
+    assert len(repaired) == 1
+    assert repaired[0].session_key == "nexus:myproject:workflow:myproject-60-full"
+
+
+def test_scan_and_repair_restores_missing_session_key(tmp_path):
+    store = OpenClawAffinityStateStore(base_dir=tmp_path)
+    resolve_affinity_binding(
+        workflow_id="nexus-50-full",
+        project_key="nexus",
+        issue_number="50",
+        correlation_token="ocwf-50",
+        store=store,
+    )
+    records = store.load_all()
+    records["nexus-50-full"].session_key = ""
+    store.save_all(records)
+
+    repaired = scan_and_repair_affinity_state(
+        workflow_mappings={"50": "nexus-50-full"},
+        store=store,
+    )
+    assert len(repaired) == 1
+    assert repaired[0].binding_status == "repaired"
+    assert repaired[0].lifecycle_reason == "missing_persisted_session_key"
+    assert repaired[0].session_key == deterministic_session_key(
+        "nexus-50-full", "nexus", issue_number="50"
+    )
+
+
+def test_scan_and_repair_no_changes_for_healthy_records(tmp_path):
+    store = OpenClawAffinityStateStore(base_dir=tmp_path)
+    resolve_affinity_binding(
+        workflow_id="nexus-51-full",
+        project_key="nexus",
+        issue_number="51",
+        store=store,
+    )
+    repaired = scan_and_repair_affinity_state(
+        workflow_mappings={"51": "nexus-51-full"},
+        store=store,
+    )
+    assert repaired == []
+
+
+def test_scan_and_repair_skips_empty_workflow_id(tmp_path):
+    store = OpenClawAffinityStateStore(base_dir=tmp_path)
+    repaired = scan_and_repair_affinity_state(
+        workflow_mappings={"1": "", "2": "  "},
+        store=store,
+    )
+    assert repaired == []
+
+
+# ---------------------------------------------------------------------------
+# OpenClawAffinityRecord helpers
+# ---------------------------------------------------------------------------
+
+
+def test_affinity_record_from_dict_handles_missing_keys():
+    rec = OpenClawAffinityRecord.from_dict({})
+    assert rec.workflow_id == ""
+    assert rec.binding_status == "active"
+    assert rec.history == []
+
+
+def test_affinity_record_from_dict_handles_none():
+    rec = OpenClawAffinityRecord.from_dict(None)  # type: ignore[arg-type]
+    assert rec.workflow_id == ""
+    assert rec.binding_status == "active"
+    assert rec.history == []
+
+
+def test_affinity_record_to_dict_roundtrip():
+    rec = OpenClawAffinityRecord(
+        workflow_id="wf-rt",
+        session_key="sk-rt",
+        correlation_token="ct-rt",
+    )
+    d = rec.to_dict()
+    restored = OpenClawAffinityRecord.from_dict(d)
+    assert restored.workflow_id == "wf-rt"
+    assert restored.session_key == "sk-rt"
+    assert restored.correlation_token == "ct-rt"


### PR DESCRIPTION
- [x] 1. `inbox_processor.py`: consolidate 3 `startup_recovery` import blocks into one
- [x] 2. `test_openclaw_affinity_state.py` (examples): remove redundant `store.upsert()` wrapper
- [x] 3a. `openclaw.py`: lazy-init `_affinity_store` via `getattr` when `__init__` is bypassed
- [x] 3b. `openclaw.py`: wrap `resolve_affinity_binding()` in try/except with `OpenClawAffinityRecord` fallback (binding_status=ephemeral, binding_source=fallback, lifecycle_reason=persistence_failure)
- [x] 4a. `openclaw_affinity_state.py`: add `fcntl.flock` exclusive locking to `upsert()` via `.json.lock` sidecar to prevent concurrent lost-update races
- [x] 4b. `openclaw_affinity_state.py`: back up corrupt state file to `affinity_state.json.corrupt-<timestamp>` on JSON parse failure, log at ERROR level
- [x] 4c. `openclaw_affinity_state.py`: add `_infer_project_key()` helper; use it in `scan_and_repair_affinity_state()` so recovered records use `nexus:<project>:workflow:<id>` format matching normal delivery
- [x] 5. Add 26 unit tests under top-level `tests/test_openclaw_affinity_state.py` (collected by pytest `testpaths=["tests"]`)
- [x] All 43 tests pass, 0 CodeQL alerts

**Security Summary:** No vulnerabilities found or introduced. CodeQL returned 0 alerts.

<!-- START COPILOT CODING AGENT TIPS -->
---

🔒 GitHub Advanced Security automatically protects Copilot coding agent pull requests. You can protect all pull requests by enabling Advanced Security for your repositories. [Learn more about Advanced Security.](https://gh.io/cca-advanced-security)