### PR TITLE
Harden OpenClaw reply correlation and control flow

### DIFF
--- a/nexus/adapters/notifications/openclaw.py
+++ b/nexus/adapters/notifications/openclaw.py
@@ -31,6 +31,8 @@ from dataclasses import dataclass, field
 from datetime import UTC, datetime
 from typing import Any
 
+from nexus.core.command_bridge.reply_security import issue_reply_token
+
 from nexus.adapters.notifications.base import Message, NotificationChannel
 from nexus.core.models import Severity
 
@@ -77,6 +79,8 @@ class WorkflowNotificationPayload:
     suggested_actions: list[str] = field(default_factory=list)
     session_key: str = ""
     correlation_token: str = field(default_factory=lambda: f"ocwf-{uuid.uuid4().hex}")
+    reply_token: str = ""
+    reply_token_expires_at_utc: str = ""
     timestamp_utc: str = field(default_factory=lambda: datetime.now(UTC).isoformat())
 
     def to_metadata(self) -> dict[str, Any]:
@@ -124,6 +128,9 @@ class WorkflowNotificationPayload:
                     "event_type": self.event_type,
                     "current_step": self.current_step,
                     "correlation_token": self.correlation_token,
+                    "reply_token": self.reply_token,
+                    "reply_token_expires_at_utc": self.reply_token_expires_at_utc,
+                    "allowed_actions": list(self.suggested_actions or []),
                 },
             },
         }
@@ -222,6 +229,8 @@ class OpenClawNotificationChannel(NotificationChannel):
         self._channel = channel or os.getenv("NEXUS_OPENCLAW_CHANNEL") or "telegram"
         self._session_key = session_key or os.getenv("NEXUS_OPENCLAW_SESSION_KEY") or ""
         self._timeout_seconds = timeout
+        self._reply_secret = os.getenv("NEXUS_OPENCLAW_REPLY_SECRET") or self._auth_token
+        self._reply_ttl_seconds = int(os.getenv("NEXUS_OPENCLAW_REPLY_TTL_SECONDS") or "900")
         self._sessions_by_loop: dict[object, aiohttp.ClientSession] = {}
 
     @property
@@ -292,6 +301,21 @@ class OpenClawNotificationChannel(NotificationChannel):
             configured_session_key=session_key or self._session_key,
             issue_number=resolved_issue,
         )
+        correlation_value = str(correlation_token or "").strip() or f"ocwf-{uuid.uuid4().hex}"
+        allowed_actions = [str(item).strip() for item in (suggested_actions or []) if str(item).strip()]
+        reply_token = ""
+        reply_token_expiry = ""
+        if self._reply_secret and correlation_value:
+            reply_token, claims = issue_reply_token(
+                secret=self._reply_secret,
+                correlation_id=correlation_value,
+                workflow_id=str(workflow_id or "").strip(),
+                session_key=resolved_session_key,
+                sender_id=str(target_user or self._sender_id or "").strip(),
+                allowed_actions=allowed_actions,
+                ttl_seconds=self._reply_ttl_seconds,
+            )
+            reply_token_expiry = datetime.fromtimestamp(claims.expires_at, UTC).isoformat()
         payload_model = WorkflowNotificationPayload(
             event_type=_normalize_event_type(event_type),
             workflow_id=str(workflow_id or "").strip(),
@@ -310,12 +334,11 @@ class OpenClawNotificationChannel(NotificationChannel):
             summary=str(summary or "").strip(),
             blocked_reason=str(blocked_reason or "").strip(),
             key_findings=[str(item).strip() for item in (key_findings or []) if str(item).strip()],
-            suggested_actions=[
-                str(item).strip() for item in (suggested_actions or []) if str(item).strip()
-            ],
+            suggested_actions=allowed_actions,
             session_key=resolved_session_key,
-            correlation_token=str(correlation_token or "").strip()
-            or f"ocwf-{uuid.uuid4().hex}",
+            correlation_token=correlation_value,
+            reply_token=reply_token,
+            reply_token_expires_at_utc=reply_token_expiry,
         )
         text = self._render_workflow_notification(payload_model)
         payload = self._build_payload(

--- a/nexus/core/command_bridge/http.py
+++ b/nexus/core/command_bridge/http.py
@@ -13,7 +13,7 @@ from urllib.parse import parse_qs
 from wsgiref.simple_server import make_server
 
 from nexus.core.command_bridge.models import CommandRequest, CommandResult, ReplyRequest
-from nexus.core.command_bridge.reply_security import ReplyTokenError
+from nexus.core.command_bridge.reply_security import ReplyTokenError, validate_reply_token
 from nexus.core.command_bridge.router import CommandRouter
 
 _logger = logging.getLogger(__name__)
@@ -352,6 +352,16 @@ def create_command_bridge_app(
                 payload = _load_json_body(environ)
                 _validate_reply_payload(payload)
                 reply = ReplyRequest.from_dict(payload)
+                _secret = str(config.reply_token_secret or config.auth_token or "").strip()
+                validate_reply_token(
+                    reply.reply_token,
+                    secret=_secret,
+                    correlation_id=str(reply.correlation_id or ""),
+                    workflow_id=str(reply.workflow_id or ""),
+                    session_id=str(reply.session_id or ""),
+                    sender_id=str(reply.sender_id or ""),
+                    action=str(reply.action or ""),
+                )
                 result = asyncio.run(router.receive_reply(reply))
                 return _command_result_response(start_response, result)
 

--- a/nexus/core/command_bridge/http.py
+++ b/nexus/core/command_bridge/http.py
@@ -13,6 +13,7 @@ from urllib.parse import parse_qs
 from wsgiref.simple_server import make_server
 
 from nexus.core.command_bridge.models import CommandRequest, CommandResult, ReplyRequest
+from nexus.core.command_bridge.reply_security import ReplyTokenError
 from nexus.core.command_bridge.router import CommandRouter
 
 _logger = logging.getLogger(__name__)
@@ -32,6 +33,7 @@ class CommandBridgeConfig:
     require_tls: bool = False
     replay_protection_enabled: bool = False
     replay_window_seconds: int = _DEFAULT_REPLAY_WINDOW
+    reply_token_secret: str = ""
 
 
 class _NonceCache:
@@ -354,6 +356,12 @@ def create_command_bridge_app(
                 return _command_result_response(start_response, result)
 
             return _json_response(start_response, 404, {"error": "Not found"})
+        except ReplyTokenError as exc:
+            error_code = getattr(exc, "code", "invalid_reply_token")
+            status_code = 410 if error_code in {"reply_token_expired", "reply_replay_detected"} else 409
+            return _json_response(
+                start_response, status_code, {"error": str(exc), "error_code": error_code}
+            )
         except ValueError as exc:
             return _json_response(
                 start_response, 400, {"error": str(exc), "error_code": "invalid_request"}
@@ -501,6 +509,9 @@ def _validate_reply_payload(payload: dict[str, Any]) -> None:
     sender_id = payload.get("sender_id")
     if sender_id is not None and not isinstance(sender_id, str):
         raise ValueError("Reply payload 'sender_id' must be a string")
+    reply_token = str(payload.get("reply_token") or "").strip()
+    if not reply_token:
+        raise ValueError("Reply payload must include a non-empty 'reply_token'")
 
 
 def _load_json_body(environ: dict[str, Any]) -> dict[str, Any]:

--- a/nexus/core/command_bridge/models.py
+++ b/nexus/core/command_bridge/models.py
@@ -352,6 +352,11 @@ class ReplyRequest:
     content: str = ""
     sender_id: str = ""
     session_id: str = ""
+    workflow_id: str = ""
+    issue_number: str = ""
+    project_key: str = ""
+    action: str = ""
+    reply_token: str = ""
     status: str = "ok"
     metadata: dict[str, Any] = field(default_factory=dict)
 
@@ -363,6 +368,11 @@ class ReplyRequest:
             content=str(data.get("content", "") or ""),
             sender_id=str(data.get("sender_id", "") or ""),
             session_id=str(data.get("session_id", "") or ""),
+            workflow_id=str(data.get("workflow_id", "") or ""),
+            issue_number=str(data.get("issue_number", "") or ""),
+            project_key=str(data.get("project_key", "") or ""),
+            action=str(data.get("action", "") or ""),
+            reply_token=str(data.get("reply_token", "") or ""),
             status=str(data.get("status", "ok") or "ok"),
             metadata=dict(data.get("metadata", {}) or {}),
         )
@@ -373,6 +383,11 @@ class ReplyRequest:
             "content": self.content,
             "sender_id": self.sender_id,
             "session_id": self.session_id,
+            "workflow_id": self.workflow_id,
+            "issue_number": self.issue_number,
+            "project_key": self.project_key,
+            "action": self.action,
+            "reply_token": self.reply_token,
             "status": self.status,
             "metadata": dict(self.metadata or {}),
         }

--- a/nexus/core/command_bridge/reply_security.py
+++ b/nexus/core/command_bridge/reply_security.py
@@ -1,0 +1,204 @@
+"""Security helpers for Nexus ↔ OpenClaw reply/control loop tokens."""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import hmac
+import json
+import threading
+import time
+import uuid
+from dataclasses import dataclass, field
+from typing import Any
+
+_DEFAULT_TTL_SECONDS = 15 * 60
+
+
+class ReplyTokenError(ValueError):
+    """Raised when a reply token is missing, invalid, stale, or replayed."""
+
+    def __init__(self, message: str, *, code: str) -> None:
+        super().__init__(message)
+        self.code = code
+
+
+@dataclass
+class ReplyTokenClaims:
+    correlation_id: str
+    workflow_id: str = ""
+    session_id: str = ""
+    session_key: str = ""
+    sender_id: str = ""
+    allowed_actions: list[str] = field(default_factory=list)
+    issued_at: int = 0
+    expires_at: int = 0
+    nonce: str = ""
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "correlation_id": self.correlation_id,
+            "workflow_id": self.workflow_id,
+            "session_id": self.session_id,
+            "session_key": self.session_key,
+            "sender_id": self.sender_id,
+            "allowed_actions": list(self.allowed_actions or []),
+            "iat": int(self.issued_at or 0),
+            "exp": int(self.expires_at or 0),
+            "nonce": self.nonce,
+        }
+
+    @classmethod
+    def from_dict(cls, payload: dict[str, Any] | None) -> "ReplyTokenClaims":
+        data = payload if isinstance(payload, dict) else {}
+        allowed_actions = data.get("allowed_actions", [])
+        return cls(
+            correlation_id=str(data.get("correlation_id") or ""),
+            workflow_id=str(data.get("workflow_id") or ""),
+            session_id=str(data.get("session_id") or ""),
+            session_key=str(data.get("session_key") or ""),
+            sender_id=str(data.get("sender_id") or ""),
+            allowed_actions=[str(item or "").strip() for item in allowed_actions if str(item or "").strip()]
+            if isinstance(allowed_actions, list)
+            else [],
+            issued_at=int(data.get("iat") or 0),
+            expires_at=int(data.get("exp") or 0),
+            nonce=str(data.get("nonce") or ""),
+        )
+
+
+class _ReplyNonceCache:
+    _CLEANUP_THRESHOLD = 500
+
+    def __init__(self) -> None:
+        self._lock = threading.Lock()
+        self._seen: dict[str, float] = {}
+
+    def check_and_add(self, nonce: str, expiry: float) -> bool:
+        now = time.time()
+        with self._lock:
+            if len(self._seen) >= self._CLEANUP_THRESHOLD:
+                expired = [key for key, value in self._seen.items() if value < now]
+                for key in expired:
+                    del self._seen[key]
+            if nonce in self._seen:
+                return False
+            self._seen[nonce] = expiry
+            return True
+
+
+_USED_REPLY_NONCES = _ReplyNonceCache()
+
+
+def _b64url_encode(raw: bytes) -> str:
+    return base64.urlsafe_b64encode(raw).decode("ascii").rstrip("=")
+
+
+def _b64url_decode(value: str) -> bytes:
+    padded = value + ("=" * ((4 - len(value) % 4) % 4))
+    return base64.urlsafe_b64decode(padded.encode("ascii"))
+
+
+def _json_dumps(payload: dict[str, Any]) -> bytes:
+    return json.dumps(payload, separators=(",", ":"), sort_keys=True).encode("utf-8")
+
+
+def _normalize_actions(actions: list[str] | None) -> list[str]:
+    return [str(item or "").strip().lower() for item in (actions or []) if str(item or "").strip()]
+
+
+def issue_reply_token(
+    *,
+    secret: str,
+    correlation_id: str,
+    workflow_id: str = "",
+    session_id: str = "",
+    session_key: str = "",
+    sender_id: str = "",
+    allowed_actions: list[str] | None = None,
+    ttl_seconds: int = _DEFAULT_TTL_SECONDS,
+    now: int | None = None,
+) -> tuple[str, ReplyTokenClaims]:
+    normalized_secret = str(secret or "").strip()
+    if not normalized_secret:
+        raise ReplyTokenError("Reply token secret is not configured", code="reply_secret_not_configured")
+    normalized_correlation_id = str(correlation_id or "").strip()
+    if not normalized_correlation_id:
+        raise ReplyTokenError("Reply correlation id is required", code="missing_correlation_id")
+    issued_at = int(now if now is not None else time.time())
+    expires_at = issued_at + max(1, int(ttl_seconds or _DEFAULT_TTL_SECONDS))
+    claims = ReplyTokenClaims(
+        correlation_id=normalized_correlation_id,
+        workflow_id=str(workflow_id or "").strip(),
+        session_id=str(session_id or "").strip(),
+        session_key=str(session_key or "").strip(),
+        sender_id=str(sender_id or "").strip(),
+        allowed_actions=_normalize_actions(allowed_actions),
+        issued_at=issued_at,
+        expires_at=expires_at,
+        nonce=uuid.uuid4().hex,
+    )
+    payload_bytes = _json_dumps(claims.to_dict())
+    body = _b64url_encode(payload_bytes)
+    signature = hmac.new(normalized_secret.encode("utf-8"), body.encode("ascii"), hashlib.sha256).digest()
+    return f"{body}.{_b64url_encode(signature)}", claims
+
+
+def validate_reply_token(
+    token: str,
+    *,
+    secret: str,
+    correlation_id: str,
+    workflow_id: str = "",
+    session_id: str = "",
+    sender_id: str = "",
+    action: str = "",
+    now: int | None = None,
+) -> ReplyTokenClaims:
+    normalized_secret = str(secret or "").strip()
+    if not normalized_secret:
+        raise ReplyTokenError("Reply token secret is not configured", code="reply_secret_not_configured")
+    normalized_token = str(token or "").strip()
+    if not normalized_token or "." not in normalized_token:
+        raise ReplyTokenError("Reply token is missing or malformed", code="invalid_reply_token")
+    body, signature = normalized_token.split(".", 1)
+    expected = hmac.new(normalized_secret.encode("utf-8"), body.encode("ascii"), hashlib.sha256).digest()
+    try:
+        actual = _b64url_decode(signature)
+    except Exception as exc:  # pragma: no cover - defensive parse guard
+        raise ReplyTokenError("Reply token signature is malformed", code="invalid_reply_token") from exc
+    if not hmac.compare_digest(expected, actual):
+        raise ReplyTokenError("Reply token signature is invalid", code="invalid_reply_token")
+    try:
+        payload = json.loads(_b64url_decode(body).decode("utf-8"))
+    except Exception as exc:  # pragma: no cover - defensive parse guard
+        raise ReplyTokenError("Reply token payload is malformed", code="invalid_reply_token") from exc
+    claims = ReplyTokenClaims.from_dict(payload)
+    current_time = int(now if now is not None else time.time())
+    if not claims.correlation_id:
+        raise ReplyTokenError("Reply token is missing a correlation id", code="invalid_reply_token")
+    if claims.correlation_id != str(correlation_id or "").strip():
+        raise ReplyTokenError("Reply correlation does not match the issued token", code="reply_correlation_mismatch")
+    if claims.expires_at and current_time > claims.expires_at:
+        raise ReplyTokenError("Reply token expired; request a fresh workflow update before acting", code="reply_token_expired")
+    normalized_workflow_id = str(workflow_id or "").strip()
+    if normalized_workflow_id and claims.workflow_id and claims.workflow_id != normalized_workflow_id:
+        raise ReplyTokenError("Reply workflow does not match the issued token", code="reply_workflow_mismatch")
+    normalized_session_id = str(session_id or "").strip()
+    if normalized_session_id and claims.session_id and claims.session_id != normalized_session_id:
+        raise ReplyTokenError("Reply session does not match the issued token", code="reply_session_mismatch")
+    normalized_sender_id = str(sender_id or "").strip()
+    if normalized_sender_id and claims.sender_id and claims.sender_id != normalized_sender_id:
+        raise ReplyTokenError("Reply sender does not match the issued token", code="reply_sender_mismatch")
+    normalized_action = str(action or "").strip().lower()
+    if normalized_action and claims.allowed_actions and normalized_action not in claims.allowed_actions:
+        raise ReplyTokenError(
+            f"Reply action '{normalized_action}' is not allowed for this token",
+            code="reply_action_not_allowed",
+        )
+    nonce = str(claims.nonce or "").strip()
+    if not nonce:
+        raise ReplyTokenError("Reply token is missing a nonce", code="invalid_reply_token")
+    if not _USED_REPLY_NONCES.check_and_add(nonce, float(claims.expires_at or (current_time + _DEFAULT_TTL_SECONDS))):
+        raise ReplyTokenError("Reply token has already been used", code="reply_replay_detected")
+    return claims

--- a/nexus/core/command_bridge/reply_security.py
+++ b/nexus/core/command_bridge/reply_security.py
@@ -68,6 +68,15 @@ class ReplyTokenClaims:
 
 
 class _ReplyNonceCache:
+    """In-process nonce store for reply-token replay detection.
+
+    .. note::
+        This cache is per-process. In multi-worker deployments (e.g. multiple WSGI
+        workers or containers behind a load balancer), a token could be replayed
+        against a different worker and still be accepted.  For full replay protection
+        across workers, replace this with a shared store (Redis, memcached, etc.) and
+        override ``_USED_REPLY_NONCES`` before starting the server.
+    """
     _CLEANUP_THRESHOLD = 500
 
     def __init__(self) -> None:

--- a/nexus/core/command_bridge/router.py
+++ b/nexus/core/command_bridge/router.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import inspect
 import logging
+import os
 import re
 from collections.abc import Awaitable, Callable
 from dataclasses import dataclass
@@ -23,6 +24,7 @@ from nexus.core.command_bridge.models import (
     UiPayload,
     WorkflowRef,
 )
+from nexus.core.command_bridge.reply_security import validate_reply_token
 from nexus.core.command_bridge.operator import BridgeOperatorService
 from nexus.core.command_bridge.usage import (
     collect_bridge_usage_payload,
@@ -709,21 +711,89 @@ class CommandRouter:
             issue_number=issue_number,
         )
 
+    def _reply_secret(self) -> str:
+        return str(os.getenv("NEXUS_OPENCLAW_REPLY_SECRET") or os.getenv("NEXUS_COMMAND_BRIDGE_REPLY_SECRET") or os.getenv("NEXUS_COMMAND_BRIDGE_AUTH_TOKEN") or "").strip()
+
+    async def _reply_action_result(self, reply: ReplyRequest) -> tuple[str, dict[str, Any]]:
+        action = str(reply.action or "").strip().lower()
+        workflow_id = str(reply.workflow_id or "").strip() or None
+        issue_number = str(reply.issue_number or "").strip() or None
+        if not action:
+            return "ack", {"ok": True, "message": "Reply received", "received": True}
+        if action == "show_status":
+            payload = await self.operator_service.workflow_status(workflow_id=workflow_id, issue_number=issue_number)
+            return "status", payload
+        if action == "show_logs":
+            payload = await self.operator_service.workflow_logs_context(workflow_id=workflow_id, issue_number=issue_number)
+            return "logs", payload
+        if action == "continue":
+            payload = await self.continue_workflow(workflow_id=workflow_id, issue_number=issue_number)
+            return "continue", payload
+        if action == "cancel":
+            payload = await self.cancel_workflow(workflow_id=workflow_id, issue_number=issue_number)
+            return "cancel", payload
+        if action == "refresh_state":
+            payload = await self.refresh_workflow_state(workflow_id=workflow_id, issue_number=issue_number)
+            return "refresh_state", payload
+        raise ValueError(
+            f"Reply action '{action}' is not supported by the current Nexus bridge slice; request a fresh workflow status and use an explicit command instead."
+        )
+
     async def receive_reply(self, reply: ReplyRequest) -> CommandResult:
         """Accept an inbound reply forwarded by an OpenClaw plugin."""
-        correlation_id = reply.correlation_id
+        correlation_id = str(reply.correlation_id or "").strip()
         logger.info(
-            "Received OpenClaw reply: correlation_id=%r sender_id=%r content_len=%d",
+            "Received OpenClaw reply: correlation_id=%r sender_id=%r content_len=%d action=%r workflow_id=%r",
             correlation_id,
             reply.sender_id,
             len(reply.content),
+            reply.action,
+            reply.workflow_id,
         )
+        claims = validate_reply_token(
+            reply.reply_token,
+            secret=self._reply_secret(),
+            correlation_id=correlation_id,
+            workflow_id=str(reply.workflow_id or "").strip(),
+            session_id=str(reply.session_id or "").strip(),
+            sender_id=str(reply.sender_id or "").strip(),
+            action=str(reply.action or "").strip(),
+        )
+        action_name, action_payload = await self._reply_action_result(reply)
+        if isinstance(action_payload, dict) and action_payload.get("ok") is False:
+            message = str(action_payload.get("error") or "Reply action could not be completed")
+            return CommandResult(
+                status="error",
+                message=message,
+                workflow_id=str(action_payload.get("workflow_id") or reply.workflow_id or claims.workflow_id or "") or None,
+                issue_number=str(action_payload.get("issue_number") or reply.issue_number or "") or None,
+                project_key=str(action_payload.get("project_key") or reply.project_key or "") or None,
+                data={
+                    "correlation_id": correlation_id,
+                    "reply_action": action_name,
+                    "received": False,
+                    "reason": action_payload,
+                },
+            )
+        message = "Reply received" if action_name == "ack" else f"Reply action '{action_name}' accepted"
         return CommandResult(
             status="success",
-            message="Reply received",
+            message=message,
+            workflow_id=str(reply.workflow_id or claims.workflow_id or action_payload.get("workflow_id") or "") or None if isinstance(action_payload, dict) else None,
+            issue_number=str(reply.issue_number or (action_payload.get("issue_number") if isinstance(action_payload, dict) else "") or "") or None,
+            project_key=str(reply.project_key or (action_payload.get("project_key") if isinstance(action_payload, dict) else "") or "") or None,
             data={
                 "correlation_id": correlation_id,
                 "received": True,
+                "reply_action": action_name,
+                "reply_context": {
+                    "workflow_id": claims.workflow_id or reply.workflow_id,
+                    "session_id": claims.session_id or reply.session_id,
+                    "session_key": claims.session_key,
+                    "allowed_actions": claims.allowed_actions,
+                    "expires_at": claims.expires_at,
+                },
+                "result": action_payload,
             },
         )
 

--- a/nexus/core/command_bridge/router.py
+++ b/nexus/core/command_bridge/router.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import inspect
 import logging
-import os
 import re
 from collections.abc import Awaitable, Callable
 from dataclasses import dataclass
@@ -24,7 +23,6 @@ from nexus.core.command_bridge.models import (
     UiPayload,
     WorkflowRef,
 )
-from nexus.core.command_bridge.reply_security import validate_reply_token
 from nexus.core.command_bridge.operator import BridgeOperatorService
 from nexus.core.command_bridge.usage import (
     collect_bridge_usage_payload,
@@ -711,8 +709,50 @@ class CommandRouter:
             issue_number=issue_number,
         )
 
-    def _reply_secret(self) -> str:
-        return str(os.getenv("NEXUS_OPENCLAW_REPLY_SECRET") or os.getenv("NEXUS_COMMAND_BRIDGE_REPLY_SECRET") or os.getenv("NEXUS_COMMAND_BRIDGE_AUTH_TOKEN") or "").strip()
+    async def receive_reply(self, reply: ReplyRequest) -> CommandResult:
+        """Accept an inbound reply forwarded by an OpenClaw plugin.
+
+        Token validation is performed by the HTTP layer before this method is called.
+        """
+        correlation_id = str(reply.correlation_id or "").strip()
+        logger.info(
+            "Received OpenClaw reply: correlation_id=%r sender_id=%r content_len=%d action=%r workflow_id=%r",
+            correlation_id,
+            reply.sender_id,
+            len(reply.content),
+            reply.action,
+            reply.workflow_id,
+        )
+        action_name, action_payload = await self._reply_action_result(reply)
+        if isinstance(action_payload, dict) and action_payload.get("ok") is False:
+            message = str(action_payload.get("error") or "Reply action could not be completed")
+            return CommandResult(
+                status="error",
+                message=message,
+                workflow_id=str(action_payload.get("workflow_id") or reply.workflow_id or "") or None,
+                issue_number=str(action_payload.get("issue_number") or reply.issue_number or "") or None,
+                project_key=str(action_payload.get("project_key") or reply.project_key or "") or None,
+                data={
+                    "correlation_id": correlation_id,
+                    "reply_action": action_name,
+                    "received": False,
+                    "reason": action_payload,
+                },
+            )
+        message = "Reply received" if action_name == "ack" else f"Reply action '{action_name}' accepted"
+        return CommandResult(
+            status="success",
+            message=message,
+            workflow_id=str(reply.workflow_id or (action_payload.get("workflow_id") if isinstance(action_payload, dict) else "") or "") or None,
+            issue_number=str(reply.issue_number or (action_payload.get("issue_number") if isinstance(action_payload, dict) else "") or "") or None,
+            project_key=str(reply.project_key or (action_payload.get("project_key") if isinstance(action_payload, dict) else "") or "") or None,
+            data={
+                "correlation_id": correlation_id,
+                "received": True,
+                "reply_action": action_name,
+                "result": action_payload,
+            },
+        )
 
     async def _reply_action_result(self, reply: ReplyRequest) -> tuple[str, dict[str, Any]]:
         action = str(reply.action or "").strip().lower()
@@ -737,64 +777,6 @@ class CommandRouter:
             return "refresh_state", payload
         raise ValueError(
             f"Reply action '{action}' is not supported by the current Nexus bridge slice; request a fresh workflow status and use an explicit command instead."
-        )
-
-    async def receive_reply(self, reply: ReplyRequest) -> CommandResult:
-        """Accept an inbound reply forwarded by an OpenClaw plugin."""
-        correlation_id = str(reply.correlation_id or "").strip()
-        logger.info(
-            "Received OpenClaw reply: correlation_id=%r sender_id=%r content_len=%d action=%r workflow_id=%r",
-            correlation_id,
-            reply.sender_id,
-            len(reply.content),
-            reply.action,
-            reply.workflow_id,
-        )
-        claims = validate_reply_token(
-            reply.reply_token,
-            secret=self._reply_secret(),
-            correlation_id=correlation_id,
-            workflow_id=str(reply.workflow_id or "").strip(),
-            session_id=str(reply.session_id or "").strip(),
-            sender_id=str(reply.sender_id or "").strip(),
-            action=str(reply.action or "").strip(),
-        )
-        action_name, action_payload = await self._reply_action_result(reply)
-        if isinstance(action_payload, dict) and action_payload.get("ok") is False:
-            message = str(action_payload.get("error") or "Reply action could not be completed")
-            return CommandResult(
-                status="error",
-                message=message,
-                workflow_id=str(action_payload.get("workflow_id") or reply.workflow_id or claims.workflow_id or "") or None,
-                issue_number=str(action_payload.get("issue_number") or reply.issue_number or "") or None,
-                project_key=str(action_payload.get("project_key") or reply.project_key or "") or None,
-                data={
-                    "correlation_id": correlation_id,
-                    "reply_action": action_name,
-                    "received": False,
-                    "reason": action_payload,
-                },
-            )
-        message = "Reply received" if action_name == "ack" else f"Reply action '{action_name}' accepted"
-        return CommandResult(
-            status="success",
-            message=message,
-            workflow_id=str(reply.workflow_id or claims.workflow_id or action_payload.get("workflow_id") or "") or None if isinstance(action_payload, dict) else None,
-            issue_number=str(reply.issue_number or (action_payload.get("issue_number") if isinstance(action_payload, dict) else "") or "") or None,
-            project_key=str(reply.project_key or (action_payload.get("project_key") if isinstance(action_payload, dict) else "") or "") or None,
-            data={
-                "correlation_id": correlation_id,
-                "received": True,
-                "reply_action": action_name,
-                "reply_context": {
-                    "workflow_id": claims.workflow_id or reply.workflow_id,
-                    "session_id": claims.session_id or reply.session_id,
-                    "session_key": claims.session_key,
-                    "allowed_actions": claims.allowed_actions,
-                    "expires_at": claims.expires_at,
-                },
-                "result": action_payload,
-            },
         )
 
     def get_capabilities(self) -> dict[str, Any]:

--- a/nexus/core/command_bridge/schemas.py
+++ b/nexus/core/command_bridge/schemas.py
@@ -134,5 +134,10 @@ class BridgeReplyRequestPayload(TypedDict, total=False):
     content: str
     sender_id: str
     session_id: str
+    workflow_id: str
+    issue_number: str
+    project_key: str
+    action: str
+    reply_token: str
     status: str
     metadata: dict[str, Any]

--- a/packages/nexus-arc/README.md
+++ b/packages/nexus-arc/README.md
@@ -90,9 +90,7 @@ Examples:
 - `/nexus wfstate demo-42-full`
 - `/nexus show me the workflow state for demo#42`
 
-The plugin now forwards richer bridge metadata with each request and signs each bridge call with per-request replay headers (`X-Nexus-Timestamp`, `X-Nexus-Nonce`) so the bridge can enforce freshness/non-reuse when replay protection is enabled.
-
-The plugin now forwards richer bridge metadata with each request:
+The plugin now adds per-request replay headers (`X-Nexus-Timestamp`, `X-Nexus-Nonce`) to each bridge call so the bridge can enforce freshness/non-reuse when replay protection is enabled, and forwards richer bridge metadata with each request:
 
 - requester identity: `operator_id`, `session_id`, `roles`
 - requester metadata: raw args, message id, thread id, attachment summaries

--- a/packages/nexus-arc/README.md
+++ b/packages/nexus-arc/README.md
@@ -90,6 +90,8 @@ Examples:
 - `/nexus wfstate demo-42-full`
 - `/nexus show me the workflow state for demo#42`
 
+The plugin now forwards richer bridge metadata with each request and signs each bridge call with per-request replay headers (`X-Nexus-Timestamp`, `X-Nexus-Nonce`) so the bridge can enforce freshness/non-reuse when replay protection is enabled.
+
 The plugin now forwards richer bridge metadata with each request:
 
 - requester identity: `operator_id`, `session_id`, `roles`
@@ -123,6 +125,17 @@ When the Nexus bridge returns `usage` metadata, the plugin renders provider,
 model, token, and estimated cost details directly in the OpenClaw response.
 The bridge now fills that field on a best-effort basis from recent completion
 storage or the latest agent log for the referenced issue/workflow.
+
+## Hardened reply/control slice
+
+The first issue #6 hardening slice now adds a safer Nexus-side reply/control contract:
+
+- Nexus → OpenClaw workflow notifications include a short-lived signed `reply_token`
+- the reply token is bound to the emitted `correlation_token`, workflow id, target sender, and allowed actions
+- inbound `/api/v1/bridge/openclaw/reply` calls must include both `correlation_id` and `reply_token`
+- stale or replayed reply tokens are rejected explicitly instead of being accepted ambiguously
+- supported reply actions in this slice are: `show_status`, `show_logs`, `continue`, `cancel`, `refresh_state`
+- unsupported actions fail closed with a clear operator-facing message so OpenClaw can fall back to an explicit `/nexus ...` command
 
 Additional bridge-aware behavior:
 

--- a/packages/nexus-arc/src/index.ts
+++ b/packages/nexus-arc/src/index.ts
@@ -236,10 +236,26 @@ const pendingConfirmations = new Map<string, PendingConfirmation>();
 
 function buildRequestReplayHeaders(): Record<string, string> {
     const timestamp = String(Math.floor(Date.now() / 1000));
-    const nonce =
-        typeof crypto !== "undefined" && typeof crypto.randomUUID === "function"
-            ? crypto.randomUUID()
-            : `${Date.now()}-${Math.random().toString(16).slice(2)}`;
+    let nonce: string;
+    const webCrypto =
+        typeof globalThis !== "undefined" &&
+        globalThis.crypto &&
+        typeof (globalThis.crypto as Crypto).getRandomValues === "function"
+            ? (globalThis.crypto as Crypto)
+            : typeof crypto !== "undefined" && typeof (crypto as Crypto).getRandomValues === "function"
+              ? (crypto as Crypto)
+              : null;
+    if (webCrypto) {
+        const buf = new Uint8Array(16);
+        webCrypto.getRandomValues(buf);
+        nonce = Array.from(buf)
+            .map((b) => b.toString(16).padStart(2, "0"))
+            .join("");
+    } else if (typeof crypto !== "undefined" && typeof (crypto as { randomUUID?: () => string }).randomUUID === "function") {
+        nonce = (crypto as { randomUUID: () => string }).randomUUID().replace(/-/g, "");
+    } else {
+        nonce = `${Date.now()}-${Math.random().toString(16).slice(2)}`;
+    }
     return {
         "x-nexus-timestamp": timestamp,
         "x-nexus-nonce": nonce

--- a/packages/nexus-arc/src/index.ts
+++ b/packages/nexus-arc/src/index.ts
@@ -234,6 +234,18 @@ const sessionStateStore = new Map<string, SessionState>();
 const workflowSessionBindings = new Map<string, SessionAffinityBinding>();
 const pendingConfirmations = new Map<string, PendingConfirmation>();
 
+function buildRequestReplayHeaders(): Record<string, string> {
+    const timestamp = String(Math.floor(Date.now() / 1000));
+    const nonce =
+        typeof crypto !== "undefined" && typeof crypto.randomUUID === "function"
+            ? crypto.randomUUID()
+            : `${Date.now()}-${Math.random().toString(16).slice(2)}`;
+    return {
+        "x-nexus-timestamp": timestamp,
+        "x-nexus-nonce": nonce
+    };
+}
+
 function isRecord(value: unknown): value is Record<string, unknown> {
     return typeof value === "object" && value !== null;
 }
@@ -893,6 +905,7 @@ async function fetchJson(
         if (config.authToken) {
             headers.authorization = `Bearer ${config.authToken}`;
         }
+        Object.assign(headers, buildRequestReplayHeaders());
         let response: Response;
         try {
             response = await fetch(`${config.bridgeUrl}${path}`, {

--- a/tests/test_command_bridge_http.py
+++ b/tests/test_command_bridge_http.py
@@ -6,6 +6,7 @@ import time
 
 from nexus.core.command_bridge.http import CommandBridgeConfig, create_command_bridge_app
 from nexus.core.command_bridge.models import CommandResult, ReplyRequest
+from nexus.core.command_bridge.reply_security import issue_reply_token
 
 
 class _FakeOperatorService:
@@ -421,6 +422,13 @@ def test_reply_endpoint_accepts_valid_payload():
         _FakeRouter(),
         config=CommandBridgeConfig(auth_token="secret"),
     )
+    reply_token, _claims = issue_reply_token(
+        secret="secret",
+        correlation_id="corr-001",
+        workflow_id="demo-42-full",
+        sender_id="alice",
+        allowed_actions=["show_status"],
+    )
 
     status, payload = _call_app(
         app,
@@ -431,6 +439,9 @@ def test_reply_endpoint_accepts_valid_payload():
             "correlation_id": "corr-001",
             "content": "Done!",
             "sender_id": "alice",
+            "workflow_id": "demo-42-full",
+            "action": "show_status",
+            "reply_token": reply_token,
         },
     )
 
@@ -438,6 +449,7 @@ def test_reply_endpoint_accepts_valid_payload():
     assert payload["status"] == "success"
     assert payload["data"]["correlation_id"] == "corr-001"
     assert payload["data"]["received"] is True
+    assert payload["data"]["reply_action"] == "status"
 
 
 def test_reply_endpoint_rejects_missing_correlation_id():
@@ -451,7 +463,7 @@ def test_reply_endpoint_rejects_missing_correlation_id():
         method="POST",
         path="/api/v1/bridge/openclaw/reply",
         auth="Bearer secret",
-        payload={"content": "No correlation id here"},
+        payload={"content": "No correlation id here", "reply_token": "dummy"},
     )
 
     assert status.startswith("400")
@@ -468,10 +480,84 @@ def test_reply_endpoint_requires_auth():
         app,
         method="POST",
         path="/api/v1/bridge/openclaw/reply",
-        payload={"correlation_id": "corr-001", "content": "hi"},
+        payload={"correlation_id": "corr-001", "content": "hi", "reply_token": "dummy"},
     )
 
     assert status.startswith("401")
+
+
+def test_reply_endpoint_rejects_replayed_reply_token():
+    app = create_command_bridge_app(
+        _FakeRouter(),
+        config=CommandBridgeConfig(auth_token="secret"),
+    )
+    reply_token, _claims = issue_reply_token(
+        secret="secret",
+        correlation_id="corr-002",
+        workflow_id="demo-42-full",
+        sender_id="alice",
+        allowed_actions=["show_status"],
+    )
+    payload = {
+        "correlation_id": "corr-002",
+        "content": "status?",
+        "sender_id": "alice",
+        "workflow_id": "demo-42-full",
+        "action": "show_status",
+        "reply_token": reply_token,
+    }
+
+    first_status, first_payload = _call_app(
+        app,
+        method="POST",
+        path="/api/v1/bridge/openclaw/reply",
+        auth="Bearer secret",
+        payload=payload,
+    )
+    assert first_status.startswith("200")
+    assert first_payload["status"] == "success"
+
+    second_status, second_payload = _call_app(
+        app,
+        method="POST",
+        path="/api/v1/bridge/openclaw/reply",
+        auth="Bearer secret",
+        payload=payload,
+    )
+
+    assert second_status.startswith("410")
+    assert second_payload["error_code"] == "reply_replay_detected"
+
+
+def test_reply_endpoint_rejects_correlation_mismatch():
+    app = create_command_bridge_app(
+        _FakeRouter(),
+        config=CommandBridgeConfig(auth_token="secret"),
+    )
+    reply_token, _claims = issue_reply_token(
+        secret="secret",
+        correlation_id="corr-003",
+        workflow_id="demo-42-full",
+        sender_id="alice",
+        allowed_actions=["continue"],
+    )
+
+    status, payload = _call_app(
+        app,
+        method="POST",
+        path="/api/v1/bridge/openclaw/reply",
+        auth="Bearer secret",
+        payload={
+            "correlation_id": "corr-wrong",
+            "sender_id": "alice",
+            "workflow_id": "demo-42-full",
+            "action": "continue",
+            "reply_token": reply_token,
+        },
+    )
+
+    assert status.startswith("409")
+    assert payload["error_code"] == "reply_correlation_mismatch"
 
 
 def test_operator_runtime_health_endpoint_returns_payload():

--- a/tests/test_command_bridge_http.py
+++ b/tests/test_command_bridge_http.py
@@ -104,10 +104,19 @@ class _FakeRouter:
         return {"ok": True, "action": "refresh-state", **kwargs}
 
     async def receive_reply(self, reply: ReplyRequest):
+        action = str(reply.action or "").strip().lower()
+        action_name = {
+            "show_status": "status",
+            "show_logs": "logs",
+            "continue": "continue",
+            "cancel": "cancel",
+            "refresh_state": "refresh_state",
+        }.get(action, "ack")
+        message = "Reply received" if action_name == "ack" else f"Reply action '{action_name}' accepted"
         return CommandResult(
             status="success",
-            message="Reply received",
-            data={"correlation_id": reply.correlation_id, "received": True},
+            message=message,
+            data={"correlation_id": reply.correlation_id, "received": True, "reply_action": action_name},
         )
 
 


### PR DESCRIPTION
- [x] Understand all review comments
- [x] `http.py`: Move reply token validation to HTTP layer using `config.reply_token_secret` (fallback to `config.auth_token`) — `reply_token_secret` is now used; `validate_reply_token` imported and called before delegating to router
- [x] `router.py`: Remove `validate_reply_token` import, `os` import, and `_reply_secret()` method (dead code); `receive_reply` delegates directly to `_reply_action_result` without re-validating the token
- [x] `tests/test_command_bridge_http.py`: Update `_FakeRouter.receive_reply` to dispatch `reply_action` from action name; replay/correlation-mismatch tests pass via HTTP-layer validation — no duplicate nonce consumption
- [x] `packages/nexus-arc/src/index.ts`: Use `globalThis.crypto.getRandomValues` (Web Crypto API) as primary nonce source; `crypto.randomUUID()` as secondary; `Math.random` only as last resort — works in Node.js, browsers, Deno, edge runtimes
- [x] `packages/nexus-arc/README.md`: Remove duplicate paragraph; replace misleading "signs each bridge call" with "adds per-request replay headers"
- [x] `nexus/core/command_bridge/reply_security.py`: Added class docstring to `_ReplyNonceCache` documenting the in-memory/per-process limitation and guidance on shared-store replacement for multi-worker deployments
- [x] All 12 TypeScript tests pass; Python syntax clean; CodeQL 0 alerts

<!-- START COPILOT CODING AGENT TIPS -->
---

💬 Send tasks to Copilot coding agent from [Slack](https://gh.io/cca-slack-docs) and [Teams](https://gh.io/cca-teams-docs) to turn conversations into code. Copilot posts an update in your thread when it's finished.