### PR TITLE
Handle merged and closed-unmerged PR lifecycle webhooks

### DIFF
--- a/examples/nexus-bot/tests/test_webhook_pr_service.py
+++ b/examples/nexus-bot/tests/test_webhook_pr_service.py
@@ -8,10 +8,13 @@ class _Policy:
         return "created"
 
     def should_notify_pr_merged(self, review_mode):
-        return review_mode == "auto"
+        return True
 
     def build_pr_merged_message(self, event, review_mode):
         return f"merged:{review_mode}"
+
+    def build_pr_closed_unmerged_message(self, event):
+        return f"closed:{event['number']}"
 
 
 def test_handle_pull_request_event_opened_notifies_and_autoqueues():
@@ -37,7 +40,7 @@ def test_handle_pull_request_event_opened_notifies_and_autoqueues():
     assert launches
 
 
-def test_handle_pull_request_event_merged_manual_skips_notification():
+def test_handle_pull_request_event_merged_manual_notifies():
     notifications = []
     cleanups = []
     closes = []
@@ -58,8 +61,8 @@ def test_handle_pull_request_event_merged_manual_skips_notification():
         cleanup_worktree_for_issue=lambda repo, issue: cleanups.append((repo, issue)) or True,
         close_issue_for_issue=lambda repo, issue: closes.append((repo, issue)) or True,
     )
-    assert result["status"] == "pr_merged_skipped_manual_review"
-    assert notifications == []
+    assert result["status"] == "pr_merged_notified"
+    assert notifications == ["merged:manual"]
     assert result["cleaned_issue_refs"] == ["42", "77"]
     assert result["closed_issue_refs"] == ["42", "77"]
     assert closes == [("acme/repo", "42"), ("acme/repo", "77")]
@@ -91,3 +94,33 @@ def test_handle_pull_request_event_merged_auto_notifies():
     assert result["cleaned_issue_refs"] == ["42"]
     assert result["closed_issue_refs"] == ["42"]
     assert closes == [("acme/repo", "42")]
+
+
+def test_handle_pull_request_event_closed_unmerged_notifies_without_cleanup():
+    notifications = []
+    cleanups = []
+    closes = []
+    result = handle_pull_request_event(
+        event={
+            "action": "closed",
+            "merged": False,
+            "number": 10,
+            "title": "Fix #42",
+            "repo": "acme/repo",
+            "author": "dev",
+            "closed_by": "maintainer",
+        },
+        logger=MagicMock(),
+        policy=_Policy(),
+        notify_lifecycle=lambda msg: notifications.append(msg) or True,
+        effective_review_mode=lambda _repo: "manual",
+        launch_next_agent=lambda *args, **kwargs: (None, None),
+        cleanup_worktree_for_issue=lambda repo, issue: cleanups.append((repo, issue)) or True,
+        close_issue_for_issue=lambda repo, issue: closes.append((repo, issue)) or True,
+    )
+    assert result["status"] == "pr_closed_unmerged_notified"
+    assert notifications == ["closed:10"]
+    assert result["cleaned_issue_refs"] == []
+    assert result["closed_issue_refs"] == []
+    assert closes == []
+    assert cleanups == []

--- a/examples/nexus-bot/tests/test_webhook_server_lifecycle.py
+++ b/examples/nexus-bot/tests/test_webhook_server_lifecycle.py
@@ -31,6 +31,7 @@ def _pr_payload(action: str, merged: bool = False) -> dict:
             "merged_by": {"login": "maintainer"},
         },
         "repository": {"full_name": "sample-org/nexus-arc"},
+        "sender": {"login": "closer"},
     }
 
 
@@ -60,16 +61,16 @@ def test_pr_opened_sends_notification(mock_notify):
 
 @patch("webhook_server._effective_review_mode", return_value="manual")
 @patch("webhook_server._notify_lifecycle", return_value=True)
-def test_pr_merged_skips_when_manual_review_policy(mock_notify, mock_policy):
+def test_pr_merged_notifies_even_when_manual_review_policy(mock_notify, mock_policy):
     from webhook_server import _get_webhook_policy, handle_pull_request
 
     payload = _pr_payload("closed", merged=True)
     event = _get_webhook_policy().parse_pull_request_event(payload)
     result = handle_pull_request(payload, event)
 
-    assert result["status"] == "pr_merged_skipped_manual_review"
+    assert result["status"] == "pr_merged_notified"
     mock_policy.assert_called_once()
-    mock_notify.assert_not_called()
+    mock_notify.assert_called_once()
 
 
 @patch("webhook_server._effective_review_mode", return_value="auto")
@@ -82,6 +83,20 @@ def test_pr_merged_notifies_when_policy_allows(mock_notify, mock_policy):
     result = handle_pull_request(payload, event)
 
     assert result["status"] == "pr_merged_notified"
+    mock_policy.assert_called_once()
+    mock_notify.assert_called_once()
+
+
+@patch("webhook_server._effective_review_mode", return_value="manual")
+@patch("webhook_server._notify_lifecycle", return_value=True)
+def test_pr_closed_unmerged_notifies_without_cleanup(mock_notify, mock_policy):
+    from webhook_server import _get_webhook_policy, handle_pull_request
+
+    payload = _pr_payload("closed", merged=False)
+    event = _get_webhook_policy().parse_pull_request_event(payload)
+    result = handle_pull_request(payload, event)
+
+    assert result["status"] == "pr_closed_unmerged_notified"
     mock_policy.assert_called_once()
     mock_notify.assert_called_once()
 

--- a/nexus/core/webhook/pr_service.py
+++ b/nexus/core/webhook/pr_service.py
@@ -20,6 +20,15 @@ def _extract_issue_numbers_from_text(text: str) -> list[str]:
     return ordered
 
 
+def _normalize_pr_action(action: Any, *, merged: bool) -> str:
+    normalized = str(action or "").strip().lower()
+    if normalized in {"merge", "merged"}:
+        return "merged"
+    if normalized in {"close", "closed"}:
+        return "merged" if merged else "closed"
+    return normalized
+
+
 def evaluate_issue_close_for_pr_merge(
     workflow_status: dict[str, Any] | None,
 ) -> tuple[bool, str]:
@@ -64,10 +73,17 @@ def handle_pull_request_event(
     pr_author = event.get("author", "")
     repo_name = event.get("repo", "unknown")
     merged = bool(event.get("merged"))
+    normalized_action = _normalize_pr_action(action, merged=merged)
 
-    logger.info("🔀 Pull request #%s: %s by %s", pr_number, action, pr_author)
+    logger.info(
+        "🔀 Pull request #%s: action=%s normalized=%s by %s",
+        pr_number,
+        action,
+        normalized_action,
+        pr_author,
+    )
 
-    if action == "opened":
+    if normalized_action == "opened":
         message = policy.build_pr_created_message(event)
         notify_lifecycle(message)
 
@@ -88,10 +104,11 @@ def handle_pull_request_event(
                     exc,
                 )
 
-        return {"status": "pr_opened_notified", "pr": pr_number, "action": action}
+        return {"status": "pr_opened_notified", "pr": pr_number, "action": normalized_action}
 
-    if action == "closed" and merged:
-        referenced_issue_refs = _extract_issue_numbers_from_text(pr_title)
+    referenced_issue_refs = _extract_issue_numbers_from_text(pr_title)
+
+    if normalized_action == "merged":
         closed_issue_refs: list[str] = []
         if callable(close_issue_for_issue):
             for issue_ref in referenced_issue_refs:
@@ -121,31 +138,28 @@ def handle_pull_request_event(
                     )
 
         review_mode = effective_review_mode(repo_name)
-        should_notify = policy.should_notify_pr_merged(review_mode)
-        if should_notify:
-            message = policy.build_pr_merged_message(event, review_mode)
-            notify_lifecycle(message)
-            return {
-                "status": "pr_merged_notified",
-                "pr": pr_number,
-                "action": action,
-                "review_mode": review_mode,
-                "cleaned_issue_refs": cleaned_issue_refs,
-                "closed_issue_refs": closed_issue_refs,
-            }
-
-        logger.info(
-            "Skipping PR merged notification for #%s due to review mode '%s'",
-            pr_number,
-            review_mode,
-        )
+        message = policy.build_pr_merged_message(event, review_mode)
+        notify_lifecycle(message)
         return {
-            "status": "pr_merged_skipped_manual_review",
+            "status": "pr_merged_notified",
             "pr": pr_number,
-            "action": action,
+            "action": normalized_action,
             "review_mode": review_mode,
             "cleaned_issue_refs": cleaned_issue_refs,
             "closed_issue_refs": closed_issue_refs,
         }
 
-    return {"status": "logged", "pr": pr_number, "action": action}
+    if normalized_action == "closed":
+        review_mode = effective_review_mode(repo_name)
+        message = policy.build_pr_closed_unmerged_message(event)
+        notify_lifecycle(message)
+        return {
+            "status": "pr_closed_unmerged_notified",
+            "pr": pr_number,
+            "action": normalized_action,
+            "review_mode": review_mode,
+            "cleaned_issue_refs": [],
+            "closed_issue_refs": [],
+        }
+
+    return {"status": "logged", "pr": pr_number, "action": normalized_action}

--- a/nexus/plugins/builtin/git_webhook_policy_plugin.py
+++ b/nexus/plugins/builtin/git_webhook_policy_plugin.py
@@ -64,25 +64,37 @@ class GitWebhookPolicyPlugin:
         if "object_kind" in payload and payload["object_kind"] == "merge_request":
             mr = payload.get("object_attributes", {})
             project = payload.get("project", {})
-            author = (
+            actor = (
                 payload["user"].get("username", "unknown")
                 if isinstance(payload.get("user"), dict)
                 else "unknown"
             )
-            merged = mr.get("state") == "merged"
+            merged = str(mr.get("state", "")).strip().lower() == "merged"
+            raw_action = str(mr.get("action", "") or "").strip().lower()
+            if merged or raw_action in {"merge", "merged"}:
+                action = "merged"
+            elif raw_action in {"close", "closed"} or str(mr.get("state", "")).strip().lower() == "closed":
+                action = "closed"
+            else:
+                action = raw_action or str(mr.get("state", "")).strip().lower()
+            merge_user = payload.get("merge_user") or payload.get("user") or {}
             return {
-                "action": mr.get("action"),
+                "action": action,
                 "number": mr.get("iid"),
                 "title": mr.get("title", ""),
                 "url": mr.get("url", ""),
-                "author": author,
+                "author": actor,
                 "merged": merged,
-                "merged_by": author if merged else "unknown",
+                "merged_by": (
+                    merge_user.get("username", "unknown") if merged and isinstance(merge_user, dict) else "unknown"
+                ),
+                "closed_by": actor if action == "closed" and not merged else "unknown",
                 "repo": project.get("path_with_namespace", "unknown"),
             }
 
         pr = payload.get("pull_request", {}) or {}
         repository = payload.get("repository", {}) or {}
+        sender = payload.get("sender") or {}
 
         return {
             "action": payload.get("action"),
@@ -96,6 +108,7 @@ class GitWebhookPolicyPlugin:
                 if isinstance(pr.get("merged_by"), dict)
                 else "unknown"
             ),
+            "closed_by": sender.get("login", "unknown") if isinstance(sender, dict) else "unknown",
             "repo": repository.get("full_name", "unknown"),
         }
 
@@ -189,8 +202,14 @@ class GitWebhookPolicyPlugin:
         return default
 
     def should_notify_pr_merged(self, review_mode: str) -> bool:
-        """Return True when PR merge notifications should be emitted."""
-        return self._normalize_review_mode(review_mode) == "auto"
+        """Backward-compatible helper retained for older callers.
+
+        PR/MR lifecycle outcomes should always reach the human-facing surface;
+        review mode only affects merge policy, not whether close/merge events are
+        surfaced.
+        """
+        _ = review_mode
+        return True
 
     def verify_signature(
         self,
@@ -307,7 +326,20 @@ class GitWebhookPolicyPlugin:
             f"Title: {event.get('title', '')}\n"
             f"Repository: {event.get('repo', 'unknown')}\n"
             f"Merged by: @{event.get('merged_by', 'unknown')}\n"
-            f"Review mode: `{self._normalize_review_mode(review_mode)}`\n\n"
+            f"Review mode: `{self._normalize_review_mode(review_mode)}`\n"
+            "Cleanup: `eligible for local worktree cleanup`\n\n"
+            f"🔗 {event.get('url', '')}"
+        )
+
+    def build_pr_closed_unmerged_message(self, event: dict[str, Any]) -> str:
+        """Build PR/MR closed-without-merge lifecycle notification message."""
+        return (
+            "🛑 **PR/MR Closed Without Merge**\n\n"
+            f"PR/MR: #{event.get('number', '')}\n"
+            f"Title: {event.get('title', '')}\n"
+            f"Repository: {event.get('repo', 'unknown')}\n"
+            f"Closed by: @{event.get('closed_by', 'unknown')}\n"
+            "Cleanup: `conservative (no auto-cleanup)`\n\n"
             f"🔗 {event.get('url', '')}"
         )
 

--- a/nexus/plugins/builtin/git_webhook_policy_plugin.py
+++ b/nexus/plugins/builtin/git_webhook_policy_plugin.py
@@ -69,9 +69,12 @@ class GitWebhookPolicyPlugin:
                 if isinstance(payload.get("user"), dict)
                 else "unknown"
             )
-            merged = str(mr.get("state", "")).strip().lower() == "merged"
             raw_action = str(mr.get("action", "") or "").strip().lower()
-            if merged or raw_action in {"merge", "merged"}:
+            merged = (
+                str(mr.get("state", "")).strip().lower() == "merged"
+                or raw_action in {"merge", "merged"}
+            )
+            if merged:
                 action = "merged"
             elif raw_action in {"close", "closed"} or str(mr.get("state", "")).strip().lower() == "closed":
                 action = "closed"

--- a/tests/test_builtin_git_webhook_policy_plugin.py
+++ b/tests/test_builtin_git_webhook_policy_plugin.py
@@ -84,6 +84,32 @@ def test_parse_gitlab_merge_request_merged_event_prefers_merge_user():
     assert event["repo"] == "acme/repo"
 
 
+def test_parse_gitlab_merge_request_action_merge_without_merged_state_is_still_merged():
+    """action='merge' alone (state not yet updated to 'merged') must yield merged=True."""
+    plugin = GitWebhookPolicyPlugin()
+
+    event = plugin.parse_pull_request_event(
+        {
+            "object_kind": "merge_request",
+            "user": {"username": "actor"},
+            "project": {"path_with_namespace": "acme/repo"},
+            "object_attributes": {
+                "action": "merge",
+                "state": "open",  # state not yet updated
+                "iid": 21,
+                "title": "Fix #99",
+                "url": "https://gitlab.com/acme/repo/-/merge_requests/21",
+            },
+            "merge_user": {"username": "maintainer"},
+        }
+    )
+
+    assert event["action"] == "merged"
+    assert event["merged"] is True
+    assert event["merged_by"] == "maintainer"
+    assert event["closed_by"] == "unknown"
+
+
 def test_parse_gitlab_merge_request_closed_unmerged_event_tracks_closer():
     plugin = GitWebhookPolicyPlugin()
 

--- a/tests/test_builtin_git_webhook_policy_plugin.py
+++ b/tests/test_builtin_git_webhook_policy_plugin.py
@@ -30,3 +30,97 @@ def test_resolve_project_key_matches_repo_in_github_repos_list():
     )
 
     assert project == "project_alpha"
+
+
+def test_parse_github_pull_request_closed_unmerged_event():
+    plugin = GitWebhookPolicyPlugin()
+
+    event = plugin.parse_pull_request_event(
+        {
+            "action": "closed",
+            "pull_request": {
+                "number": 18,
+                "title": "Fix #42",
+                "html_url": "https://github.com/acme/repo/pull/18",
+                "user": {"login": "dev"},
+                "merged": False,
+                "merged_by": None,
+            },
+            "repository": {"full_name": "acme/repo"},
+            "sender": {"login": "maintainer"},
+        }
+    )
+
+    assert event["action"] == "closed"
+    assert event["merged"] is False
+    assert event["closed_by"] == "maintainer"
+    assert event["merged_by"] == "unknown"
+    assert event["repo"] == "acme/repo"
+
+
+def test_parse_gitlab_merge_request_merged_event_prefers_merge_user():
+    plugin = GitWebhookPolicyPlugin()
+
+    event = plugin.parse_pull_request_event(
+        {
+            "object_kind": "merge_request",
+            "user": {"username": "actor"},
+            "project": {"path_with_namespace": "acme/repo"},
+            "object_attributes": {
+                "action": "merge",
+                "state": "merged",
+                "iid": 19,
+                "title": "Fix #42",
+                "url": "https://gitlab.com/acme/repo/-/merge_requests/19",
+            },
+            "merge_user": {"username": "maintainer"},
+        }
+    )
+
+    assert event["action"] == "merged"
+    assert event["merged"] is True
+    assert event["merged_by"] == "maintainer"
+    assert event["closed_by"] == "unknown"
+    assert event["repo"] == "acme/repo"
+
+
+def test_parse_gitlab_merge_request_closed_unmerged_event_tracks_closer():
+    plugin = GitWebhookPolicyPlugin()
+
+    event = plugin.parse_pull_request_event(
+        {
+            "object_kind": "merge_request",
+            "user": {"username": "closer"},
+            "project": {"path_with_namespace": "acme/repo"},
+            "object_attributes": {
+                "action": "close",
+                "state": "closed",
+                "iid": 20,
+                "title": "Fix #77",
+                "url": "https://gitlab.com/acme/repo/-/merge_requests/20",
+            },
+        }
+    )
+
+    assert event["action"] == "closed"
+    assert event["merged"] is False
+    assert event["closed_by"] == "closer"
+    assert event["merged_by"] == "unknown"
+
+
+def test_build_pr_closed_unmerged_message_mentions_conservative_cleanup():
+    plugin = GitWebhookPolicyPlugin()
+
+    message = plugin.build_pr_closed_unmerged_message(
+        {
+            "number": 20,
+            "title": "Fix #77",
+            "repo": "acme/repo",
+            "closed_by": "closer",
+            "url": "https://example.test/pr/20",
+        }
+    )
+
+    assert "Closed Without Merge" in message
+    assert "Cleanup: `conservative (no auto-cleanup)`" in message
+    assert "@closer" in message

--- a/tests/test_webhook_pr_service.py
+++ b/tests/test_webhook_pr_service.py
@@ -1,4 +1,20 @@
-from nexus.core.webhook.pr_service import evaluate_issue_close_for_pr_merge
+from unittest.mock import MagicMock
+
+from nexus.core.webhook.pr_service import (
+    evaluate_issue_close_for_pr_merge,
+    handle_pull_request_event,
+)
+
+
+class _Policy:
+    def build_pr_created_message(self, event):
+        return "created"
+
+    def build_pr_merged_message(self, event, review_mode):
+        return f"merged:{review_mode}"
+
+    def build_pr_closed_unmerged_message(self, event):
+        return f"closed:{event['number']}"
 
 
 def test_evaluate_issue_close_for_pr_merge_allows_completed_workflow():
@@ -44,3 +60,85 @@ def test_evaluate_issue_close_for_pr_merge_blocks_incomplete_steps():
 
     assert allowed is False
     assert reason == "workflow step 'document_close' is 'pending'"
+
+
+def test_handle_pull_request_event_opened_notifies_and_autoqueues():
+    notifications = []
+    launches = []
+    result = handle_pull_request_event(
+        event={
+            "action": "opened",
+            "number": 10,
+            "title": "Fix #42",
+            "author": "dev",
+            "repo": "acme/repo",
+        },
+        logger=MagicMock(),
+        policy=_Policy(),
+        notify_lifecycle=lambda msg: notifications.append(msg) or True,
+        effective_review_mode=lambda _repo: "manual",
+        launch_next_agent=lambda *args, **kwargs: launches.append((args, kwargs))
+        or (123, "copilot"),
+    )
+    assert result["status"] == "pr_opened_notified"
+    assert notifications == ["created"]
+    assert launches
+
+
+def test_handle_pull_request_event_merged_notifies_and_cleans_up():
+    notifications = []
+    cleanups = []
+    closes = []
+    result = handle_pull_request_event(
+        event={
+            "action": "closed",
+            "merged": True,
+            "number": 10,
+            "title": "Close #42 and #77",
+            "repo": "acme/repo",
+            "author": "dev",
+        },
+        logger=MagicMock(),
+        policy=_Policy(),
+        notify_lifecycle=lambda msg: notifications.append(msg) or True,
+        effective_review_mode=lambda _repo: "manual",
+        launch_next_agent=lambda *args, **kwargs: (None, None),
+        cleanup_worktree_for_issue=lambda repo, issue: cleanups.append((repo, issue)) or True,
+        close_issue_for_issue=lambda repo, issue: closes.append((repo, issue)) or True,
+    )
+    assert result["status"] == "pr_merged_notified"
+    assert notifications == ["merged:manual"]
+    assert result["cleaned_issue_refs"] == ["42", "77"]
+    assert result["closed_issue_refs"] == ["42", "77"]
+    assert closes == [("acme/repo", "42"), ("acme/repo", "77")]
+    assert cleanups == [("acme/repo", "42"), ("acme/repo", "77")]
+
+
+def test_handle_pull_request_event_closed_unmerged_notifies_without_cleanup():
+    notifications = []
+    cleanups = []
+    closes = []
+    result = handle_pull_request_event(
+        event={
+            "action": "closed",
+            "merged": False,
+            "number": 10,
+            "title": "Close #42 and #77",
+            "repo": "acme/repo",
+            "author": "dev",
+            "closed_by": "maintainer",
+        },
+        logger=MagicMock(),
+        policy=_Policy(),
+        notify_lifecycle=lambda msg: notifications.append(msg) or True,
+        effective_review_mode=lambda _repo: "auto",
+        launch_next_agent=lambda *args, **kwargs: (None, None),
+        cleanup_worktree_for_issue=lambda repo, issue: cleanups.append((repo, issue)) or True,
+        close_issue_for_issue=lambda repo, issue: closes.append((repo, issue)) or True,
+    )
+    assert result["status"] == "pr_closed_unmerged_notified"
+    assert notifications == ["closed:10"]
+    assert result["cleaned_issue_refs"] == []
+    assert result["closed_issue_refs"] == []
+    assert closes == []
+    assert cleanups == []


### PR DESCRIPTION
- [x] Investigate reviewer comment: `action="merged"` with `merged=False` possible in GitLab branch
- [x] Fix: derive `merged` from both `mr.state == "merged"` **and** `raw_action in {"merge", "merged"}` so `action` and `merged` are always consistent
- [x] Add regression test: GitLab event with `action="merge"` but `state="open"` correctly yields `merged=True`
- [x] All 13 webhook/plugin tests pass
- [x] CodeQL: no alerts

<!-- START COPILOT CODING AGENT TIPS -->
---

🔒 GitHub Advanced Security automatically protects Copilot coding agent pull requests. You can protect all pull requests by enabling Advanced Security for your repositories. [Learn more about Advanced Security.](https://gh.io/cca-advanced-security)