### PR TITLE
fix: include aiohttp in nexus-bot runtime extras

### DIFF
--- a/examples/nexus-bot/.env.example
+++ b/examples/nexus-bot/.env.example
@@ -86,6 +86,8 @@ NEXUS_COMMAND_BRIDGE_ALLOWED_SENDER_IDS=
 # NEXUS_OPENCLAW_BRIDGE_TOKEN=your_openclaw_hooks_token_here
 # NEXUS_OPENCLAW_SENDER_ID=your_telegram_chat_id_here   # e.g. 47168736
 # NEXUS_OPENCLAW_CHANNEL=telegram
+# Leave unset to keep workflow notifications passive in the OpenClaw chat.
+# NEXUS_OPENCLAW_WAKE_MODE=now
 
 # ================================
 # INFRASTRUCTURE / STORAGE

--- a/examples/nexus-bot/INSTALL.md
+++ b/examples/nexus-bot/INSTALL.md
@@ -199,6 +199,7 @@ NEXUS_CHAT_TRANSCRIPT_OWNER=openclaw
 NEXUS_COMMAND_BRIDGE_ENABLED=true
 NEXUS_COMMAND_BRIDGE_AUTH_TOKEN=replace_with_a_long_random_secret
 NEXUS_COMMAND_BRIDGE_ALLOWED_SOURCES=openclaw
+NEXUS_OPENCLAW_WAKE_MODE=
 
 # Choose one:
 NEXUS_STORAGE_BACKEND=filesystem
@@ -212,6 +213,20 @@ NEXUS_STORAGE_DSN=postgresql://nexus:your_password@127.0.0.1:5432/nexus
 # Typically disabled because OpenClaw owns end-user auth flows
 NEXUS_AUTH_ENABLED=false
 ```
+
+Leave `NEXUS_OPENCLAW_WAKE_MODE` unset unless you explicitly want Nexus workflow notifications to wake the OpenClaw
+agent session. The passive default avoids notification loops and stuck "Compacting context" states in the operator
+chat.
+
+If OpenClaw is already stuck on `Compacting context...`, clear `NEXUS_OPENCLAW_WAKE_MODE`, restart the bridge/runtime,
+and verify the effective setting before retrying:
+
+```bash
+curl -s http://127.0.0.1:8091/api/v1/operator/runtime-health \
+  -H "Authorization: Bearer $NEXUS_COMMAND_BRIDGE_AUTH_TOKEN"
+```
+
+In a safe passive setup, `bridge.openclaw_wake_mode` should be `null` (or absent) and `warnings` should be empty.
 
 ### Run
 

--- a/nexus/adapters/notifications/openclaw.py
+++ b/nexus/adapters/notifications/openclaw.py
@@ -9,6 +9,7 @@ Configuration (env vars or project_config.yaml plugin block):
     NEXUS_OPENCLAW_BRIDGE_TOKEN   Bearer token for the OpenClaw hooks endpoint
     NEXUS_OPENCLAW_SENDER_ID      Telegram/channel chat ID to deliver notifications to
     NEXUS_OPENCLAW_CHANNEL        Optional channel hint (e.g. "telegram")
+    NEXUS_OPENCLAW_WAKE_MODE      Optional OpenClaw wake mode override. Leave unset for passive notifications.
 
 Requires hooks to be enabled in openclaw.json:
     {
@@ -219,6 +220,7 @@ class OpenClawNotificationChannel(NotificationChannel):
         auth_token: Bearer token for the bridge.  Defaults to ``NEXUS_OPENCLAW_BRIDGE_TOKEN``.
         sender_id:  Target session/chat ID.  Defaults to ``NEXUS_OPENCLAW_SENDER_ID``.
         channel:    Optional channel hint forwarded in the payload (e.g. ``"telegram"``).
+        wake_mode:  Optional OpenClaw wake mode override. Leave unset for passive notifications.
         timeout:    HTTP request timeout in seconds.
     """
 
@@ -229,6 +231,7 @@ class OpenClawNotificationChannel(NotificationChannel):
         sender_id: str | None = None,
         channel: str | None = None,
         session_key: str | None = None,
+        wake_mode: str | None = None,
         timeout: int = 10,
     ):
         _require_aiohttp()
@@ -239,6 +242,7 @@ class OpenClawNotificationChannel(NotificationChannel):
         self._sender_id = sender_id or os.getenv("NEXUS_OPENCLAW_SENDER_ID") or ""
         self._channel = channel or os.getenv("NEXUS_OPENCLAW_CHANNEL") or "telegram"
         self._session_key = session_key or os.getenv("NEXUS_OPENCLAW_SESSION_KEY") or ""
+        self._wake_mode = str(wake_mode or os.getenv("NEXUS_OPENCLAW_WAKE_MODE") or "").strip()
         self._timeout_seconds = timeout
         self._reply_secret = os.getenv("NEXUS_OPENCLAW_REPLY_SECRET") or self._auth_token
         self._reply_ttl_seconds = int(os.getenv("NEXUS_OPENCLAW_REPLY_TTL_SECONDS") or "900")
@@ -405,8 +409,9 @@ class OpenClawNotificationChannel(NotificationChannel):
             "name": "Nexus",
             "deliver": True,
             "channel": self._channel or "telegram",
-            "wakeMode": "now",
         }
+        if self._wake_mode:
+            payload["wakeMode"] = self._wake_mode
         if metadata:
             payload["metadata"] = metadata
         resolved_session_key = str(session_key or self._session_key or "").strip()

--- a/nexus/core/command_bridge/operator.py
+++ b/nexus/core/command_bridge/operator.py
@@ -713,16 +713,27 @@ class BridgeOperatorService:
         runtime_ops = RuntimeOpsPlugin()
         active = await self.active_workflows(limit=100)
         failures = await self.recent_failures(limit=20)
+        runtime_mode = str(os.getenv("NEXUS_RUNTIME_MODE") or "").strip() or None
+        openclaw_wake_mode = str(os.getenv("NEXUS_OPENCLAW_WAKE_MODE") or "").strip() or None
+        warnings: list[str] = []
+        if runtime_mode == "openclaw" and openclaw_wake_mode:
+            warnings.append(
+                "OpenClaw wake mode is enabled. Wakeful workflow notifications can loop back into the "
+                "operator chat and leave OpenClaw stuck on 'Compacting context...'. Leave "
+                "NEXUS_OPENCLAW_WAKE_MODE unset for passive notifications unless interactive wakeups are required."
+            )
         return {
             "ok": True,
             "timestamp": datetime.now(UTC).isoformat(),
-            "runtime_mode": str(os.getenv("NEXUS_RUNTIME_MODE") or "").strip() or None,
+            "runtime_mode": runtime_mode,
             "storage_backend": storage_name,
             "bridge": {
                 "command_bridge_auth_configured": bool(str(os.getenv("NEXUS_COMMAND_BRIDGE_AUTH_TOKEN") or "").strip()),
                 "openclaw_bridge_url": bool(str(os.getenv("NEXUS_OPENCLAW_BRIDGE_URL") or "").strip()),
                 "openclaw_bridge_token": bool(str(os.getenv("NEXUS_OPENCLAW_BRIDGE_TOKEN") or "").strip()),
+                "openclaw_sender_id": bool(str(os.getenv("NEXUS_OPENCLAW_SENDER_ID") or "").strip()),
                 "openclaw_session_key": bool(str(os.getenv("NEXUS_OPENCLAW_SESSION_KEY") or "").strip()),
+                "openclaw_wake_mode": openclaw_wake_mode,
             },
             "tooling": {
                 "gh": shutil.which("gh") is not None,
@@ -731,6 +742,7 @@ class BridgeOperatorService:
             },
             "active_workflow_count": int(active.get("count") or 0) if active.get("ok") else None,
             "recent_failure_count": int(failures.get("count") or 0) if failures.get("ok") else None,
+            "warnings": warnings,
         }
 
     def _cli_identity(self, cli_name: str, args: list[str]) -> dict[str, Any]:

--- a/packages/nexus-arc/src/index.test.ts
+++ b/packages/nexus-arc/src/index.test.ts
@@ -269,3 +269,72 @@ test("getRequesterContext forwards OpenClaw auth-backed requester identity", () 
     assert.equal(requester.nexus_id, "openclaw:user:alice");
     assert.equal(requester.is_authorized_sender, true);
 });
+
+test("plugin health surfaces runtime-health wake mode warnings", async () => {
+    const commands = new Map<string, (ctx: Record<string, unknown>) => Promise<{text: string}>>();
+    const originalFetch = globalThis.fetch;
+    let fetchCount = 0;
+
+    try {
+        globalThis.fetch = (async (input: string | URL | Request) => {
+            const url = String(input);
+            fetchCount += 1;
+            if (url.endsWith("/api/v1/capabilities")) {
+                return new Response(
+                    JSON.stringify({ok: true, supported_commands: ["health", "plan"]}),
+                    {status: 200}
+                );
+            }
+            if (url.endsWith("/api/v1/operator/runtime-health")) {
+                return new Response(
+                    JSON.stringify({
+                        ok: true,
+                        runtime_mode: "openclaw",
+                        active_workflow_count: 2,
+                        recent_failure_count: 1,
+                        bridge: {
+                            openclaw_wake_mode: "now"
+                        },
+                        warnings: [
+                            "OpenClaw wake mode is enabled and can leave OpenClaw stuck on 'Compacting context...'."
+                        ]
+                    }),
+                    {status: 200}
+                );
+            }
+            throw new Error(`Unexpected fetch URL: ${url}`);
+        }) as typeof fetch;
+
+        const pluginModule = await import("./index.ts");
+        pluginModule.default.register({
+            registerCommand(command) {
+                commands.set(command.name, command.handler);
+            }
+        });
+
+        const healthHandler = commands.get("nexus");
+        assert.ok(healthHandler);
+
+        const result = await healthHandler({
+            args: "health",
+            senderId: "alice",
+            senderName: "Alice",
+            channel: "telegram",
+            channelId: "chat-1",
+            messageId: "1001",
+            isAuthorizedSender: true,
+            config: {
+                bridgeUrl: "http://127.0.0.1:8091",
+                authToken: "secret"
+            }
+        });
+
+        assert.match(result.text, /Runtime Mode: openclaw/);
+        assert.match(result.text, /OpenClaw Wake Mode: now/);
+        assert.match(result.text, /Compacting context/);
+        assert.match(result.text, /Active Workflows: 2/);
+        assert.equal(fetchCount, 2);
+    } finally {
+        globalThis.fetch = originalFetch;
+    }
+});

--- a/packages/nexus-arc/src/index.ts
+++ b/packages/nexus-arc/src/index.ts
@@ -998,7 +998,11 @@ async function getBridgeCapabilities(config: Required<PluginConfig>): Promise<Br
 }
 
 async function getBridgeHealth(config: Required<PluginConfig>): Promise<Record<string, unknown>> {
-    return callBridgeGet("/healthz", config);
+    try {
+        return await callBridgeGet("/api/v1/operator/runtime-health", config);
+    } catch {
+        return callBridgeGet("/healthz", config);
+    }
 }
 
 export function formatBridgeError(error: unknown): string {
@@ -1143,11 +1147,30 @@ function renderHealthText(
     lines.push(`Bridge URL: ${config.bridgeUrl}`);
     lines.push(`HTTP: ${healthPayload.ok === true ? "ok" : "unexpected"}`);
     lines.push(`Auth token configured: ${config.authToken ? "yes" : "no"}`);
+    const runtimeMode = stringValue(healthPayload.runtime_mode);
+    if (runtimeMode) {
+        lines.push(`Runtime Mode: ${runtimeMode}`);
+    }
+    const bridge = isRecord(healthPayload.bridge) ? healthPayload.bridge : {};
+    const wakeMode = stringValue(bridge.openclaw_wake_mode);
+    if (wakeMode) {
+        lines.push(`OpenClaw Wake Mode: ${wakeMode}`);
+    }
+    if (typeof healthPayload.active_workflow_count === "number") {
+        lines.push(`Active Workflows: ${healthPayload.active_workflow_count}`);
+    }
+    if (typeof healthPayload.recent_failure_count === "number") {
+        lines.push(`Recent Failures: ${healthPayload.recent_failure_count}`);
+    }
     if (Array.isArray(capabilities?.supported_commands) && capabilities.supported_commands.length > 0) {
         lines.push(`Supported commands: ${capabilities.supported_commands.join(", ")}`);
     }
-    if (warnings.length > 0) {
-        lines.push(`Warnings: ${warnings.join(" ")}`);
+    const runtimeWarnings = Array.isArray(healthPayload.warnings)
+        ? healthPayload.warnings.filter((item): item is string => typeof item === "string" && item.length > 0)
+        : [];
+    const combinedWarnings = [...warnings, ...runtimeWarnings];
+    if (combinedWarnings.length > 0) {
+        lines.push(`Warnings: ${combinedWarnings.join(" ")}`);
     }
     return lines.join("\n");
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -96,6 +96,7 @@ nexus-bot-runtime = [
     "apscheduler>=3.11",
     "requests>=2.32",
     "cryptography>=42.0",
+    "aiohttp>=3.9",
 ]
 nexus-bot-chat = [
     "nexus-arc[telegram,discord]",

--- a/tests/test_adapters.py
+++ b/tests/test_adapters.py
@@ -1773,7 +1773,10 @@ class TestOpenClawNotificationChannel:
         channel._sender_id = "12345"
         channel._channel = "telegram"
         channel._session_key = ""
+        channel._wake_mode = ""
         channel._timeout_seconds = 10
+        channel._reply_secret = "test-token"
+        channel._reply_ttl_seconds = 900
         channel._sessions_by_loop = {}
         return channel
 
@@ -1801,6 +1804,13 @@ class TestOpenClawNotificationChannel:
         assert payload["name"] == "Nexus"
         assert payload["deliver"] is True
         assert payload["channel"] == "telegram"
+        assert "wakeMode" not in payload
+
+    def test_build_payload_includes_wake_mode_when_configured(self):
+        channel = self._make_channel()
+        channel._wake_mode = "now"
+        payload = channel._build_payload("Hello OpenClaw")
+        assert payload["wakeMode"] == "now"
 
     def test_build_payload_includes_to_when_recipient_set(self):
         channel = self._make_channel()
@@ -1908,6 +1918,7 @@ class TestOpenClawNotificationChannel:
         assert payload["metadata"]["payload"]["summary"] == (
             "Review requested for OpenClaw notification payload updates."
         )
+        assert "wakeMode" not in payload
         assert payload["metadata"]["routing"]["reply_hint"]["correlation_token"] == "corr-123"
         assert payload["metadata"]["actions"][0]["name"] == "approve"
         assert "Workflow #123" in payload["message"]

--- a/tests/test_command_bridge_operator.py
+++ b/tests/test_command_bridge_operator.py
@@ -254,6 +254,26 @@ async def test_workflow_logs_context_returns_summary_plus_recent_log_tail(operat
 
 
 @pytest.mark.asyncio
+async def test_runtime_health_warns_when_openclaw_wake_mode_is_enabled(
+    operator_service: BridgeOperatorService,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    monkeypatch.setenv("NEXUS_RUNTIME_MODE", "openclaw")
+    monkeypatch.setenv("NEXUS_OPENCLAW_WAKE_MODE", "now")
+    monkeypatch.setenv("NEXUS_OPENCLAW_BRIDGE_URL", "https://jarvis.ghabs.me")
+    monkeypatch.setenv("NEXUS_OPENCLAW_BRIDGE_TOKEN", "secret")
+    monkeypatch.setenv("NEXUS_OPENCLAW_SENDER_ID", "47168736")
+
+    payload = await operator_service.runtime_health()
+
+    assert payload["ok"] is True
+    assert payload["runtime_mode"] == "openclaw"
+    assert payload["bridge"]["openclaw_wake_mode"] == "now"
+    assert payload["bridge"]["openclaw_sender_id"] is True
+    assert any("Compacting context" in warning for warning in payload["warnings"])
+
+
+@pytest.mark.asyncio
 async def test_workflow_authorship_audit_classifies_bot_vs_human_signals(operator_service: BridgeOperatorService):
     payload = await operator_service.workflow_authorship_audit(issue_number="105")
 


### PR DESCRIPTION
The OpenClaw notification channel requires aiohttp, but the `nexus-bot-runtime` extra did not include it.

This change adds aiohttp to the runtime extra so the local docker compose stack and install path can initialize the OpenClaw notification channel without warnings.