### PR TITLE
docs: reposition Nexus ARC as agent integration layer

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Nexus ARC (Agentic Runtime Core)
 
-**Production-grade framework for orchestrating AI agents in multi-step workflows**
+**Authenticated integration and orchestration layer for AI agents**
 
 [![License](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 [![Python 3.11+](https://img.shields.io/badge/python-3.11+-blue.svg)](https://www.python.org/downloads/)
@@ -9,40 +9,76 @@
 
 ## What is Nexus ARC?
 
-Nexus ARC (Agentic Runtime Core) is the **Git-native AI orchestration framework**. Unlike other frameworks that log
-agent actions to ephemeral files, Nexus creates permanent, traceable artifacts in your Git platform (GitHub, GitLab,
-Bitbucket).
+Nexus ARC (Agentic Runtime Core) is a **Git-native workflow engine that is evolving into the authenticated integration
+layer for AI agents**.
 
-### Why Git-Native?
+It still does the orchestration work Nexus was built for:
 
-Every agent action becomes part of your development history:
+- multi-step workflows
+- stateful execution
+- retries, timeouts, and fallback
+- Git-native traceability through issues, comments, PRs, and reviews
+
+But in practice Nexus is also becoming the place where agents safely interact with real external systems:
+
+- **OAuth and credentialed integrations**
+- **connector/adaptor logic for third-party APIs**
+- **bridge endpoints for trusted operator surfaces such as OpenClaw**
+- **policy, audit, and workflow-aware external actions**
+
+### Why this matters
+
+Most agent systems are good at prompting and bad at the boring but critical parts:
+
+- credential storage
+- token refresh
+- permission boundaries
+- provider-specific API quirks
+- auditability of external actions
+- routing external data into workflows safely
+
+Nexus ARC is being shaped to own that layer.
+
+### Git-native remains a core differentiator
+
+Every important action can still become part of your durable development history:
 
 - 🎯 **Issues** track what was requested and decided
-- 💬 **Comments** preserve agent reasoning and handoffs
+- 💬 **Comments** preserve reasoning and handoffs
 - 🔀 **Pull Requests** contain actual code changes
 - ✅ **Reviews** create approval gates with full context
-- 📊 **Git History** provides permanent audit trail
+- 📊 **Git history** remains a permanent audit trail
 
-**The result:** Complete traceability, searchability, and accountability for AI workflows.
+### OpenClaw vs Nexus ARC
 
-### Production-Ready Features
+A useful mental model:
 
-- ✅ **Reliability**: Auto-retry, timeout detection, graceful failure handling
-- ✅ **State Management**: Persistent workflow state with audit trails
-- ✅ **AI Orchestration**: Route work to the best AI tool (Copilot, Gemini, soon Claude and Codex)
-- ✅ **Fallback Support**: Automatic failover when tools are rate-limited or unavailable
-- ✅ **Pluggable Architecture**: Bring your own storage, git platform, notification system
+- **OpenClaw** = operator surface, chat UX, agent runtime
+- **Nexus ARC** = workflows, connectors, credentials, audit, control plane
 
-**Think of it as Temporal meets GitHub Actions for AI agents** — workflows that integrate seamlessly with your
-development process.
+OpenClaw is where Jarvis talks to you.
+Nexus ARC is where Jarvis gets safe, reusable access to authenticated systems.
+
+### Current product shape
+
+- ✅ **Workflow orchestration**: multi-step execution with persistent state
+- ✅ **Reliability**: retries, timeouts, graceful failure handling
+- ✅ **Git-native auditability**: traceable artifacts in your dev platform
+- ✅ **Bridge/operator control**: OpenClaw-friendly operator endpoints
+- ✅ **Pluggable architecture**: storage, git platforms, notification systems
+- 🚧 **Connector model**: explicit credential-aware integrations as first-class building blocks
+
+**Think of it as Temporal meets GitHub Actions for AI agents — with an emerging credentialed integration layer for real-world automation.**
 
 > 📖 **Documentation:**
-> - [Usage Guide & Examples](docs/USAGE.md) - How to use nexus-arc in your project
-> - [Plugin Architecture](docs/PLUGINS.md) - Build and load Telegram/GitHub/AI integrations as plugins
-> - [OpenClaw Release Guide](docs/OPENCLAW_RELEASE.md) - Package Nexus ARC with the OpenClaw plugin
-> - [Config Bootstrap Lifecycle](docs/CONFIG_BOOTSTRAP_LIFECYCLE.md) - Explicit runtime startup order and singleton-test
-    hooks
-> - [Autofix Learning Contract](docs/AUTOFIX_LEARNING.md) - Event schema, retry-guard behavior, and rollout
+> - [Usage Guide & Examples](docs/USAGE.md) - how to use Nexus ARC in your project
+> - [Architecture](docs/ARCHITECTURE.md) - current system split and historical evolution
+> - [Connectors & Credentials](docs/CONNECTORS.md) - where OAuth, token storage, and third-party integrations belong
+> - [OpenClaw Operator Surface](docs/OPENCLAW_OPERATOR_SURFACE.md) - how OpenClaw acts as a trusted control plane over Nexus ARC
+> - [Plugin Architecture](docs/PLUGINS.md) - build and load Telegram/GitHub/AI integrations as plugins
+> - [OpenClaw Release Guide](docs/OPENCLAW_RELEASE.md) - package Nexus ARC with the OpenClaw plugin
+> - [Config Bootstrap Lifecycle](docs/CONFIG_BOOTSTRAP_LIFECYCLE.md) - explicit runtime startup order and singleton-test hooks
+> - [Autofix Learning Contract](docs/AUTOFIX_LEARNING.md) - event schema, retry-guard behavior, and rollout
 > - [Comparison with Google ADK, LangChain, and others](docs/COMPARISON.md)
 > - [Positioning & Messaging](docs/POSITIONING.md)
 
@@ -214,40 +250,44 @@ engine.add_observer(exporter)
 
 ## Architecture
 
+```text
+┌──────────────────────────────────────────────────────────────┐
+│           Operator / Runtime Surfaces                        │
+│      OpenClaw, CLI, webhooks, chat clients, automations     │
+└────────────────────────────┬─────────────────────────────────┘
+                             │
+                             ▼
+┌──────────────────────────────────────────────────────────────┐
+│                  Nexus ARC Control Plane                     │
+│  command bridge • operator APIs • workflow triggers         │
+└────────────────────────────┬─────────────────────────────────┘
+                             │
+                             ▼
+┌──────────────────────────────────────────────────────────────┐
+│                Workflow & Policy Engine                      │
+│  state machine • retries • timeouts • audit • routing       │
+└───────────────┬───────────────────────────────┬──────────────┘
+                │                               │
+                ▼                               ▼
+┌───────────────────────────────┐   ┌──────────────────────────┐
+│ Connectors / Credential Layer │   │ Persistent State         │
+│ OAuth • token storage • API   │   │ workflow state • audit   │
+│ adapters • provider policies  │   │ logs • metrics           │
+└───────────────┬───────────────┘   └──────────────────────────┘
+                │
+                ▼
+┌──────────────────────────────────────────────────────────────┐
+│        External Systems and AI Runtimes                      │
+│ GitHub • GitLab • email • social APIs • AI providers        │
+└──────────────────────────────────────────────────────────────┘
 ```
-┌─────────────────────────────────────────────────────────┐
-│                  Input Adapters                         │
-│  (Telegram, Slack, Webhook, CLI, GitHub Issues)         │
-└────────────────────┬────────────────────────────────────┘
-                     │
-                     ▼
-┌──────────────────────────────────────────────────────┐
-│                Workflow Engine (ARC)                 │
-│  ┌────────────────────────────────────────────────┐  │
-│  │  Step Manager → State Machine → Audit Logger   │  │
-│  └────────────────────────────────────────────────┘  │
-└────────────┬──────────────────────┬──────────────────┘
-             │                      │
-    ┌────────▼────────┐    ┌───────▼────────┐
-    │ AI Orchestrator │    │ Storage Backend│
-    │  - Provider     │    │  - State       │
-    │    Selection    │    │  - Audit Log   │
-    │  - Retry Logic  │    │  - Metrics     │
-    │  - Fallback     │    └────────────────┘
-    └────────┬────────┘
-             │
-    ┌────────▼─────────────────────┐
-    │     AI Providers             │
-    │  (Copilot, Gemini, soon      │
-    │   Claude & Codex)            │
-    └──────────────────────────────┘
-             │
-    ┌────────▼────────┐
-    │ Output Adapters │
-    │  (Git Platform, │
-    │   Notifications)│
-    └─────────────────┘
-```
+
+In practice:
+
+- **OpenClaw** is the conversational/operator-facing surface
+- **Nexus ARC** is the authenticated integration + workflow layer
+- **connectors** are where third-party API auth and provider-specific logic belong
+- **Git-native artifacts** remain the durable audit trail whenever the workflow is development-facing
 
 ---
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,9 +1,99 @@
 # Nexus ARC (Agentic Runtime Core) Architecture
 
-> **About this document:** This shows the evolution from the original Nexus Telegram bot (coupled architecture) to the
-> generic Nexus ARC (Agentic Runtime Core) framework (pluggable architecture). The migration sections are specific to
-> that
-> project but demonstrate how to adopt the framework.
+> **About this document:** This document now serves two purposes:
+> 1. describe the **current architectural direction** for Nexus ARC as an authenticated integration and orchestration layer for AI agents
+> 2. preserve the **historical evolution** from the original coupled Telegram bot into a reusable framework
+
+## Current architectural direction
+
+Nexus ARC started as a Git-native workflow/orchestration framework. That is still true.
+
+But the system is increasingly taking on a second responsibility: acting as the **credential-aware integration layer**
+that lets agents interact with external systems safely.
+
+### Responsibility split
+
+A useful working model is:
+
+- **OpenClaw / operator surfaces**
+  - chat UX
+  - agent runtime
+  - user interaction
+  - notifications and command entrypoints
+
+- **Nexus ARC**
+  - workflow state and orchestration
+  - bridge/control endpoints
+  - connector and adapter logic
+  - OAuth / token / credential handling
+  - policy and audit boundaries for external actions
+
+This split matters because it keeps the conversational/runtime shell separate from the business logic and auth logic of
+real integrations.
+
+### Current stack view
+
+```text
+┌──────────────────────────────────────────────────────────────┐
+│         Operator / Runtime Surfaces                          │
+│ OpenClaw • CLI • webhooks • trusted automation callers       │
+└────────────────────────────┬─────────────────────────────────┘
+                             │
+                             ▼
+┌──────────────────────────────────────────────────────────────┐
+│                  Nexus ARC Control Plane                     │
+│      command bridge • operator APIs • workflow triggers      │
+└────────────────────────────┬─────────────────────────────────┘
+                             │
+                             ▼
+┌──────────────────────────────────────────────────────────────┐
+│                Workflow & Policy Engine                      │
+│  step execution • retries • timeout handling • audit         │
+└───────────────┬───────────────────────────────┬──────────────┘
+                │                               │
+                ▼                               ▼
+┌───────────────────────────────┐   ┌──────────────────────────┐
+│ Connectors / Credential Layer │   │ Persistent State         │
+│ OAuth • token storage • API   │   │ workflow state • audit   │
+│ adapters • provider policies  │   │ logs • metrics           │
+└───────────────┬───────────────┘   └──────────────────────────┘
+                │
+                ▼
+┌──────────────────────────────────────────────────────────────┐
+│       External Systems and AI Runtimes                       │
+│ GitHub • GitLab • email • social APIs • AI providers         │
+└──────────────────────────────────────────────────────────────┘
+```
+
+### Why this direction makes sense
+
+Most agent systems can reason, but they struggle with the operational layer around real integrations:
+
+- token storage and refresh
+- permission boundaries
+- provider-specific API quirks
+- auditability for external actions
+- safe reuse of authenticated capabilities across agents
+
+Nexus ARC is a natural home for that layer because it already owns workflow state, audit trails, bridge endpoints, and
+provider/runtime routing.
+
+### Design implication
+
+When deciding where a new capability belongs:
+
+- if it is primarily **chat UX / conversation / agent interaction**, it probably belongs in **OpenClaw**
+- if it is primarily **OAuth / credentials / third-party API access / reusable workflow capability**, it probably belongs in **Nexus ARC**
+
+Examples:
+
+- LinkedIn OAuth connector → Nexus ARC
+- GitHub repo sync / issue bridge → Nexus ARC
+- “Jarvis, show me my LinkedIn-enriched leads” → OpenClaw calling Nexus ARC
+
+---
+
+## Historical evolution
 
 ## Original Nexus (Coupled Architecture)
 

--- a/docs/BLOG-What-Nexus-ARC-Is-Becoming.md
+++ b/docs/BLOG-What-Nexus-ARC-Is-Becoming.md
@@ -1,0 +1,276 @@
+# What Nexus ARC Is Becoming
+
+For a while, we described Nexus ARC mainly as a Git-native orchestration framework for AI agents.
+
+That is still true.
+
+But as we kept building real workflows and integrating Nexus ARC with OpenClaw, another pattern became hard to ignore:
+
+**Nexus ARC is not just orchestrating agents. It is becoming the authenticated integration layer that lets agents interact with real systems safely.**
+
+That shift is worth making explicit.
+
+---
+
+## The original story was real
+
+Nexus ARC started from a practical problem: most agent systems leave behind bad operational artifacts.
+
+They log to ephemeral files.
+They hide decisions in runtime traces.
+They make it hard to answer simple questions like:
+
+- What happened?
+- Why did the agent choose that path?
+- Where is the durable record of the work?
+- How do I connect the reasoning to the implementation?
+
+The Git-native model was our answer to that.
+
+Instead of treating Git as an output sink, Nexus ARC treats Git as part of the system of record:
+
+- issues track requests and decisions
+- comments preserve handoffs and context
+- pull requests contain implementation artifacts
+- reviews become approval boundaries
+- workflow state remains traceable over time
+
+That framing still matters. It is still one of the strongest things about Nexus ARC.
+
+---
+
+## But real agent systems need more than orchestration
+
+Once agents move beyond toy tasks, the hard part stops being prompt design.
+
+The hard part becomes integration.
+
+Not just “can the model call an API?”
+
+The hard part is everything around that API:
+
+- OAuth setup
+- token storage
+- refresh flow management
+- provider-specific quirks
+- permission boundaries
+- rate-limit handling
+- auditability of external actions
+- safe reuse of authenticated capabilities across workflows and agents
+
+This is where most agent systems get messy.
+
+The conversational/runtime layer often ends up carrying too much responsibility:
+
+- chat UX
+- prompting
+- execution
+- credentials
+- integrations
+- policy
+- control-plane actions
+
+That stack becomes brittle fast.
+
+---
+
+## The split that now makes sense
+
+A much cleaner architecture is emerging:
+
+### OpenClaw
+OpenClaw is the **operator-facing runtime surface**.
+
+It is where the human interacts with the system.
+It is where an assistant like Jarvis plans, explains, summarizes, and accepts commands.
+It is where agent runtime concerns live.
+
+### Nexus ARC
+Nexus ARC is the **workflow + authenticated integration layer**.
+
+It is where the system should manage:
+
+- workflow state
+- orchestration and retries
+- bridge/control endpoints
+- connectors/adapters
+- OAuth and credentials
+- policy-aware external actions
+- durable audit trails
+
+OpenClaw is where the operator talks.
+Nexus ARC is where the operator’s intent becomes safe, reusable, credentialed automation.
+
+That is a much better separation of concerns.
+
+---
+
+## Why this is a stronger product direction
+
+“AI orchestration framework” is useful, but broad.
+
+“Authenticated integration and orchestration layer for AI agents” is sharper.
+
+It points directly at a real gap in the ecosystem.
+
+Most frameworks are good at one or more of these:
+
+- agent abstractions
+- prompting chains
+- tool calling
+- retrieval
+- evaluation
+
+But the boring infrastructure that makes agents useful in production is usually an afterthought.
+
+Things like:
+
+- how an agent gets access to a real third-party system
+- how you safely store and rotate credentials
+- how a workflow proves what action was taken and why
+- how you let multiple agents reuse the same connector without spraying secrets everywhere
+- how an operator retains control over external actions
+
+Those are not side concerns. They are the difference between a demo and a system you can trust.
+
+Nexus ARC is increasingly well-positioned to own that layer.
+
+---
+
+## Git-native still matters
+
+This is not a pivot away from Git-native traceability.
+
+If anything, the integration-layer direction makes the Git-native story stronger.
+
+Because once agents start interacting with external systems, auditability matters even more.
+
+If an agent:
+
+- created a GitHub issue
+- enriched a CRM record
+- queried a provider with a real OAuth token
+- prepared a workflow decision that triggered an email send
+
+then we need durable records of:
+
+- what happened
+- which workflow initiated it
+- which connector was used
+- which policy allowed it
+- what the outcome was
+
+Git-native artifacts remain one of the best durable surfaces for development-facing workflows.
+
+Nexus ARC should keep leaning into that.
+
+---
+
+## A concrete example: LinkedIn
+
+LinkedIn is a good test case for the architectural boundary.
+
+Suppose we want Jarvis to help with lead discovery or job outreach.
+
+The wrong place to embed all of that logic is directly in the chat runtime.
+
+Why?
+
+Because the problem is not mainly conversational.
+The real complexity is:
+
+- app registration
+- OAuth
+- token lifecycle
+- provider limitations
+- connector normalization
+- workflow-safe actions
+- auditability
+
+That belongs in Nexus ARC.
+
+Then OpenClaw can do what it does best:
+
+- ask for the data
+- summarize the results
+- help decide what to do next
+- trigger a workflow action via Nexus ARC
+
+This pattern is likely to repeat for many integrations:
+
+- GitHub
+- Google
+- Slack
+- email
+- social APIs
+- CRM systems
+
+That is a sign that the architecture is converging on something real.
+
+---
+
+## The new mental model
+
+A useful way to think about Nexus ARC now is:
+
+> **Nexus ARC is the authenticated integration and orchestration backbone for agent systems.**
+
+It does not replace the chat/runtime shell.
+It complements it.
+
+It is the place where workflows, connectors, credentials, and external-action auditability come together.
+
+That is a more defensible foundation than trying to be a generic everything-for-agents framework.
+
+---
+
+## What changes from here
+
+If we take this direction seriously, a few things should become first-class in Nexus ARC:
+
+### 1. Connectors
+Explicit provider/integration adapters with stable workflow-facing actions.
+
+### 2. Credentials
+A clear model for storing auth state, refresh tokens, scopes, and runtime health.
+
+### 3. Policy boundaries
+Which workflows, operators, or agents may use which external capabilities.
+
+### 4. Bridge/operator surfaces
+Trusted runtime systems like OpenClaw should be able to call Nexus ARC safely and inspect its state cleanly.
+
+### 5. Auditability
+External actions should be explainable and traceable, not just executed.
+
+---
+
+## What is not changing
+
+Nexus ARC is not abandoning orchestration.
+
+It is not abandoning Git-native history.
+
+It is not becoming “just an OAuth wrapper.”
+
+The orchestration layer remains central.
+The Git-native model remains central.
+
+What is changing is the recognition that real orchestration for agents inevitably includes authenticated integration work.
+
+That layer deserves to be designed, not improvised.
+
+---
+
+## The short version
+
+Nexus ARC started as a Git-native framework for orchestrating AI workflows.
+
+It is becoming something more precise:
+
+**a workflow engine, control plane, and authenticated integration layer for AI agents operating in real systems.**
+
+That is not a contradiction.
+It is the natural consequence of trying to build agent systems that are actually useful.
+
+And honestly, that feels like the right direction.

--- a/docs/CONNECTORS.md
+++ b/docs/CONNECTORS.md
@@ -1,0 +1,287 @@
+# Connectors & Credentials in Nexus ARC
+
+This document describes the emerging connector model for Nexus ARC: where
+OAuth flows, token handling, provider adapters, and authenticated external
+actions should live.
+
+## Why this exists
+
+AI agents are easy to connect to toy tools and hard to connect safely to real
+systems.
+
+The difficult part is usually not prompting. It is everything around the API:
+
+- OAuth and app registration
+- access token storage
+- refresh token lifecycle
+- scope boundaries
+- provider-specific quirks
+- auditability of external actions
+- deciding which agent is allowed to use which credentialed capability
+
+Nexus ARC is the right place to own that complexity.
+
+## What a connector is
+
+In Nexus ARC, a **connector** is the combination of:
+
+1. **authentication model**
+   - OAuth 2.0
+   - API keys
+   - service account credentials
+   - sessionless token exchange when supported
+
+2. **credential storage + lifecycle**
+   - encrypted or protected storage
+   - refresh / expiry tracking
+   - revocation / invalidation handling
+
+3. **provider adapter logic**
+   - request/response normalization
+   - pagination, retries, backoff
+   - error translation
+   - rate-limit awareness
+
+4. **workflow-facing actions**
+   - reusable operations that agents or workflows can invoke
+   - examples: `github.issue.create`, `email.send`, `linkedin.profile.me`
+
+5. **audit hooks**
+   - what was called
+   - by which workflow / operator / agent
+   - with which outcome
+   - without exposing raw secrets
+
+## What belongs in Nexus ARC vs OpenClaw
+
+### Belongs in Nexus ARC
+
+- provider registration metadata
+- OAuth start/callback/refresh flows
+- token persistence
+- connector configuration
+- normalized provider models
+- rate-limit state and retry policy
+- bridge endpoints for authenticated actions
+- workflow-safe external action execution
+- auditing of connector usage
+
+### Belongs in OpenClaw
+
+- conversational UI
+- operator commands and summaries
+- agent interaction / planning
+- approval prompts and human-facing explanations
+- invoking Nexus ARC bridge commands
+
+### Mental model
+
+- **OpenClaw** asks for work to be done
+- **Nexus ARC** knows how to do authenticated work safely
+
+## Canonical connector lifecycle
+
+### 1. Register app / auth config
+
+Example inputs:
+
+- client id
+- client secret
+- redirect URI
+- scopes
+- provider-specific metadata
+
+### 2. Start auth flow
+
+Nexus ARC should be able to expose a bridge action such as:
+
+- `connector.auth.start(provider="linkedin")`
+
+Result:
+
+- authorization URL
+- opaque state token
+- callback tracking metadata
+
+### 3. Complete callback
+
+Nexus ARC receives the callback and stores:
+
+- access token
+- refresh token (if available)
+- expiry
+- scopes granted
+- auth status
+
+### 4. Expose normalized actions
+
+Once connected, the connector exposes workflow-facing actions such as:
+
+- `linkedin.profile.me`
+- `linkedin.company.lookup`
+- `github.issue.create`
+- `email.send`
+
+The action shape should be stable even if provider-specific API details change.
+
+### 5. Track auth/runtime state
+
+Nexus ARC should record:
+
+- token validity
+- last refresh attempt
+- recent auth failures
+- rate-limit state
+- connector health
+
+### 6. Audit usage
+
+For each action, Nexus ARC should be able to answer:
+
+- which workflow called it
+- which operator or bridge client triggered it
+- whether it succeeded or failed
+- what provider resource was touched
+
+## Connector design principles
+
+### 1. Normalize late, not too early
+
+Do not flatten provider-specific semantics so aggressively that useful detail is
+lost.
+
+Bad:
+- one giant generic `social_api.call`
+
+Better:
+- explicit provider actions with normalized outputs where it helps
+
+### 2. Hide secrets, not metadata
+
+Secrets should never be returned to operators or agents.
+
+But these should be visible:
+
+- auth status
+- scopes granted
+- token expiry window
+- connector health
+- last successful use
+
+### 3. Connector actions should be workflow-safe
+
+An action should be designed to work inside a workflow with:
+
+- retries
+- timeouts
+- idempotency assumptions
+- audit trails
+- approval gates where needed
+
+### 4. Bridge-first, not runtime-hack-first
+
+If OpenClaw or another operator surface needs a connector capability, prefer
+calling a Nexus ARC bridge/operator endpoint over duplicating OAuth/API logic in
+that runtime.
+
+### 5. Policy matters
+
+Credentialed actions should eventually support policy decisions such as:
+
+- which workflows may use this connector
+- which agents may invoke which actions
+- whether human approval is required
+- whether write actions are allowed at all
+
+## Suggested connector structure
+
+A likely long-term shape inside Nexus ARC could be something like:
+
+```text
+nexus/
+  adapters/
+    integrations/
+      linkedin/
+        client.py
+        oauth.py
+        models.py
+        actions.py
+        storage.py
+        health.py
+      github/
+      google/
+      email/
+```
+
+Possible separation of concerns:
+
+- `oauth.py` → auth flow and token refresh
+- `client.py` → low-level API client
+- `models.py` → normalized objects
+- `actions.py` → workflow-facing operations
+- `storage.py` → token/config persistence
+- `health.py` → runtime status and rate-limit tracking
+
+## Example: LinkedIn
+
+If Nexus ARC adds an official LinkedIn connector, the connector should probably
+focus on what the official API can support safely and durably:
+
+- auth status
+- current identity/profile info
+- company/profile metadata where available
+- normalized lead/contact enrichment
+
+OpenClaw/Jarvis can then do things like:
+
+- ask Nexus whether LinkedIn is connected
+- enrich CRM contacts with LinkedIn metadata
+- trigger workflow actions that depend on LinkedIn auth
+
+But the connector itself belongs in Nexus ARC.
+
+## Minimal bridge surface to target
+
+A practical bridge/operator surface for connectors would include:
+
+### Auth / status
+- `connector.auth.start`
+- `connector.auth.complete`
+- `connector.auth.status`
+- `connector.auth.revoke`
+
+### Health / metadata
+- `connector.health`
+- `connector.scopes`
+- `connector.last-used`
+
+### Actions
+- `connector.action.invoke`
+
+Or, better, explicit namespaced actions such as:
+
+- `linkedin.profile.me`
+- `linkedin.company.lookup`
+- `email.send`
+- `github.issue.create`
+
+## Recommended rollout order
+
+1. **document the connector model**
+2. **add credential/auth state primitives**
+3. **add one official connector end to end**
+4. **expose bridge/operator APIs for that connector**
+5. **let OpenClaw operate it as a trusted surface**
+
+## Short version
+
+Nexus ARC should become the place where:
+
+- external systems are connected
+- credentials are stored safely
+- provider APIs are normalized
+- workflows use those integrations
+- agent-triggered external actions are audited
+
+That makes Nexus ARC more than an orchestration framework.
+It becomes the authenticated integration backbone for agent systems.

--- a/docs/POSITIONING.md
+++ b/docs/POSITIONING.md
@@ -4,15 +4,13 @@
 
 ## Elevator Pitch (30 seconds)
 
-**"Nexus ARC is the Git-native AI orchestration framework. Unlike Google ADK or LangChain that log agent actions to
-files, we create permanent artifacts in GitHub — every decision becomes an issue, every implementation becomes a PR,
-every workflow has a complete audit trail. Think Temporal meets GitHub Actions for AI agents."**
+**"Nexus ARC is a Git-native orchestration framework that is evolving into the authenticated integration layer for AI agents. It runs multi-step workflows, keeps a durable audit trail in Git artifacts, and gives agent systems a safe place for connectors, credentials, and policy-aware external actions. Think Temporal meets GitHub Actions for AI agents — plus the integration backbone they actually need in production."**
 
 ---
 
 ## One-Liner
 
-**"The only AI workflow framework where agent actions become part of your Git history, not ephemeral logs."**
+**"Git-native workflows, authenticated connectors, and durable audit trails for AI agents."**
 
 ---
 


### PR DESCRIPTION
## Summary
- reframe Nexus ARC around authenticated integration + orchestration
- document the OpenClaw vs Nexus ARC responsibility split
- add connectors/credentials architecture guidance
- add a draft blog post: what Nexus ARC is becoming

## Why
The current docs understate the direction Nexus ARC is taking in practice: not just Git-native orchestration, but also the credential-aware integration layer that lets agents interact with external systems safely.

## Included
- README refresh
- architecture doc refresh
- positioning doc alignment
- new connectors doc
- blog draft
