### PR TITLE
fix: recover older router feedback cards

### DIFF
--- a/nexus/core/handlers/callback_command_handlers.py
+++ b/nexus/core/handlers/callback_command_handlers.py
@@ -30,6 +30,7 @@ from nexus.core.telegram.telegram_router_feedback_service import (
     decision_token,
     has_feedback_submission,
     load_external_pending_feedback,
+    load_feedback_meta_for_ref,
     remember_feedback_submission,
     resolve_feedback_token,
     submit_feedback,
@@ -312,21 +313,26 @@ async def route_feedback_callback_handler(ctx: InteractiveContext, deps: Callbac
     expected_refs = {actual_decision_id, decision_token(actual_decision_id)}
     if decision_ref not in expected_refs:
         # Allow older cards to be submitted when a newer card overwrote the
-        # single pending slot. If the callback token resolves for this user,
-        # rebuild a minimal pending payload for that decision instead of
-        # rejecting with "latest route".
+        # single pending slot. Recover the exact stored metadata for the
+        # clicked card when possible so delayed/batched feedback still maps to
+        # the original routed decision.
+        recovered = load_feedback_meta_for_ref(user_id=str(ctx.user_id or ""), decision_ref=decision_ref)
         resolved = resolve_feedback_token(user_id=str(ctx.user_id or ""), decision_ref=decision_ref)
         if not resolved or not _is_uuid(resolved):
             await ctx.edit_message_text(message_id=query.message_id, text="⚠️ Feedback no longer matches the latest route.", buttons=[])
             return
-        pending = {
-            "decision_id": resolved,
-            "feedback_mode": "router",
-            "task_type": str(pending.get("task_type") or "unknown"),
-            "selected_model": str(pending.get("selected_model") or "unknown"),
-            "source_channel": str(pending.get("source_channel") or "telegram"),
-            "metadata": pending.get("metadata") if isinstance(pending.get("metadata"), dict) else {},
-        }
+        if isinstance(recovered, dict):
+            pending = dict(recovered)
+        else:
+            pending = {
+                "decision_id": resolved,
+                "feedback_mode": "router",
+                "task_type": str(pending.get("task_type") or "unknown"),
+                "selected_model": str(pending.get("selected_model") or "unknown"),
+                "source_channel": str(pending.get("source_channel") or "telegram"),
+                "metadata": pending.get("metadata") if isinstance(pending.get("metadata"), dict) else {},
+            }
+        pending["decision_id"] = resolved
         ctx.user_state[PENDING_KEY] = pending
         actual_decision_id = resolved
 

--- a/nexus/core/telegram/telegram_router_feedback_service.py
+++ b/nexus/core/telegram/telegram_router_feedback_service.py
@@ -509,8 +509,12 @@ def load_feedback_meta_for_ref(*, user_id: str, decision_ref: str | None, store_
     ref = str(decision_ref or "").strip()
     if not uid or not ref:
         return None
+    # UUID decision_id: derive the stored token key deterministically so that
+    # callbacks carrying the full decision_id (older cards) still resolve meta.
     if len(ref) > 10 and ref.count("-") >= 4:
-        return None
+        ref = decision_token(ref)
+        if not ref:
+            return None
 
     now_ts = int(time.time())
     payload = _load_token_map_store(store_path=store_path)

--- a/nexus/core/telegram/telegram_router_feedback_service.py
+++ b/nexus/core/telegram/telegram_router_feedback_service.py
@@ -247,6 +247,13 @@ async def maybe_send_feedback_prompt(*, ctx: Any, user_state: dict[str, Any], fe
         sent_id = await ctx.reply_text(text, buttons=buttons, parse_mode=None)
         meta["feedback_message_id"] = str(sent_id or "") or None
         user_state[PENDING_KEY] = meta
+        if source_user_id:
+            store_external_pending_feedback(user_id=source_user_id, meta=meta)
+            register_feedback_token(
+                user_id=source_user_id,
+                decision_id=str(meta.get("decision_id") or ""),
+                meta=meta,
+            )
     except Exception:
         LOGGER.debug("Router feedback card send failed", exc_info=True)
 
@@ -434,7 +441,14 @@ def _prune_token_map(payload: dict[str, Any], now_ts: int) -> None:
             payload.pop(user_id, None)
 
 
-def register_feedback_token(*, user_id: str, decision_id: str | None, ttl_seconds: int = TOKEN_MAP_TTL_SECONDS, store_path: str = TOKEN_MAP_STORE_PATH) -> None:
+def register_feedback_token(
+    *,
+    user_id: str,
+    decision_id: str | None,
+    meta: dict[str, Any] | None = None,
+    ttl_seconds: int = TOKEN_MAP_TTL_SECONDS,
+    store_path: str = TOKEN_MAP_STORE_PATH,
+) -> None:
     uid = str(user_id or "").strip()
     did = str(decision_id or "").strip()
     if not uid or not did:
@@ -446,11 +460,14 @@ def register_feedback_token(*, user_id: str, decision_id: str | None, ttl_second
     payload = _load_token_map_store(store_path=store_path)
     _prune_token_map(payload, now_ts)
     refs = payload.setdefault(uid, {})
-    refs[token] = {
+    entry = {
         "decision_id": did,
         "created_at": now_ts,
         "expires_at": now_ts + max(60, int(ttl_seconds or TOKEN_MAP_TTL_SECONDS)),
     }
+    if isinstance(meta, dict):
+        entry["meta"] = dict(meta)
+    refs[token] = entry
     try:
         _save_token_map_store(payload, store_path=store_path)
     except Exception:
@@ -485,6 +502,35 @@ def resolve_feedback_token(*, user_id: str, decision_ref: str | None, store_path
     except Exception:
         LOGGER.debug("Failed to refresh token map TTL", exc_info=True)
     return decision_id
+
+
+def load_feedback_meta_for_ref(*, user_id: str, decision_ref: str | None, store_path: str = TOKEN_MAP_STORE_PATH) -> dict[str, Any] | None:
+    uid = str(user_id or "").strip()
+    ref = str(decision_ref or "").strip()
+    if not uid or not ref:
+        return None
+    if len(ref) > 10 and ref.count("-") >= 4:
+        return None
+
+    now_ts = int(time.time())
+    payload = _load_token_map_store(store_path=store_path)
+    _prune_token_map(payload, now_ts)
+    refs = payload.get(uid)
+    if not isinstance(refs, dict):
+        return None
+    entry = refs.get(ref)
+    if not isinstance(entry, dict):
+        return None
+    meta = entry.get("meta")
+    if not isinstance(meta, dict):
+        return None
+
+    entry["expires_at"] = now_ts + TOKEN_MAP_TTL_SECONDS
+    try:
+        _save_token_map_store(payload, store_path=store_path)
+    except Exception:
+        LOGGER.debug("Failed to refresh token map TTL", exc_info=True)
+    return dict(meta)
 
 
 def send_feedback_prompt_to_telegram_user(*, chat_id: str, text: str, buttons: list[list[Button]], token: str | None = None, timeout_seconds: float = 4.0) -> tuple[bool, str]:
@@ -562,7 +608,11 @@ async def maybe_send_feedback_prompt_external(
 
     meta["feedback_message_id"] = str(detail or "") or None
     store_external_pending_feedback(user_id=telegram_user_id, meta=meta)
-    register_feedback_token(user_id=telegram_user_id, decision_id=str(meta.get("decision_id") or ""))
+    register_feedback_token(
+        user_id=telegram_user_id,
+        decision_id=str(meta.get("decision_id") or ""),
+        meta=meta,
+    )
     return True
 
 

--- a/tests/test_router_feedback_cards.py
+++ b/tests/test_router_feedback_cards.py
@@ -1,0 +1,127 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from nexus.core.handlers import callback_command_handlers as callback_handlers
+from nexus.core.handlers.callback_command_handlers import CallbackHandlerDeps, route_feedback_callback_handler
+from nexus.core.telegram import telegram_router_feedback_service as feedback_service
+
+
+class _DummyCtx:
+    def __init__(self, *, action_data: str, user_id: str, user_state: dict):
+        self.user_id = user_id
+        self.user_state = user_state
+        self.query = SimpleNamespace(action_data=action_data, message_id="42")
+        self.edits: list[dict] = []
+        self.answered = 0
+
+    async def answer_callback_query(self, text: str | None = None):
+        del text
+        self.answered += 1
+
+    async def edit_message_text(self, *, message_id: str, text: str, buttons=None, parse_mode=None):
+        self.edits.append(
+            {
+                "message_id": message_id,
+                "text": text,
+                "buttons": buttons,
+                "parse_mode": parse_mode,
+            }
+        )
+
+
+def _deps() -> CallbackHandlerDeps:
+    return CallbackHandlerDeps(
+        logger=SimpleNamespace(info=lambda *a, **k: None, warning=lambda *a, **k: None),
+        prompt_issue_selection=lambda *a, **k: None,
+        dispatch_command=lambda *a, **k: None,
+        get_project_label=lambda value: value,
+        get_repo=lambda value: value,
+        get_direct_issue_plugin=lambda *a, **k: None,
+        get_workflow_state_plugin=lambda *a, **k: None,
+        workflow_state_plugin_kwargs={},
+        action_handlers={},
+        report_bug_action=lambda *a, **k: None,
+        router_feedback_url="http://router.test",
+    )
+
+
+def test_feedback_token_round_trips_meta(tmp_path):
+    store_path = tmp_path / "tokens.json"
+    decision_id = "11111111-1111-4111-8111-111111111111"
+    meta = {
+        "decision_id": decision_id,
+        "task_type": "reasoning",
+        "selected_model": "openai/gpt-5",
+        "source_channel": "telegram",
+        "metadata": {"source_message_preview": "older routed turn"},
+    }
+
+    feedback_service.register_feedback_token(
+        user_id="user-1",
+        decision_id=decision_id,
+        meta=meta,
+        store_path=str(store_path),
+    )
+
+    token = feedback_service.decision_token(decision_id)
+    assert feedback_service.resolve_feedback_token(
+        user_id="user-1",
+        decision_ref=token,
+        store_path=str(store_path),
+    ) == decision_id
+    assert feedback_service.load_feedback_meta_for_ref(
+        user_id="user-1",
+        decision_ref=token,
+        store_path=str(store_path),
+    ) == meta
+
+
+@pytest.mark.asyncio
+async def test_route_feedback_callback_accepts_older_card_when_token_resolves(monkeypatch):
+    old_decision = "11111111-1111-4111-8111-111111111111"
+    latest_decision = "22222222-2222-4222-8222-222222222222"
+    old_meta = {
+        "decision_id": old_decision,
+        "feedback_mode": "router",
+        "task_type": "reasoning",
+        "selected_model": "openai/gpt-5",
+        "source_channel": "telegram",
+        "metadata": {"source_message_preview": "first routed reply"},
+    }
+    latest_meta = {
+        "decision_id": latest_decision,
+        "feedback_mode": "router",
+        "task_type": "coding",
+        "selected_model": "anthropic/claude-sonnet",
+        "source_channel": "telegram",
+        "metadata": {"source_message_preview": "newer routed reply"},
+    }
+    token = feedback_service.decision_token(old_decision)
+    submitted: dict = {}
+
+    monkeypatch.setattr(callback_handlers, "load_feedback_meta_for_ref", lambda **kwargs: dict(old_meta))
+    monkeypatch.setattr(callback_handlers, "resolve_feedback_token", lambda **kwargs: old_decision)
+    monkeypatch.setattr(callback_handlers, "has_feedback_submission", lambda *a, **k: False)
+    monkeypatch.setattr(
+        callback_handlers,
+        "submit_feedback",
+        lambda *, router_url, payload: (submitted.update({"router_url": router_url, "payload": payload}) or True, "ok"),
+    )
+
+    ctx = _DummyCtx(
+        action_data=f"routefb:ok:{token}",
+        user_id="user-1",
+        user_state={feedback_service.PENDING_KEY: dict(latest_meta)},
+    )
+
+    await route_feedback_callback_handler(ctx, _deps())
+
+    assert submitted["router_url"] == "http://router.test"
+    assert submitted["payload"]["decision_id"] == old_decision
+    assert submitted["payload"]["metadata"]["task_type"] == "reasoning"
+    assert submitted["payload"]["metadata"]["selected_model"] == "openai/gpt-5"
+    assert ctx.edits[-1]["text"] == "✅ Feedback recorded."
+    assert feedback_service.PENDING_KEY not in ctx.user_state

--- a/tests/test_router_feedback_cards.py
+++ b/tests/test_router_feedback_cards.py
@@ -79,6 +79,33 @@ def test_feedback_token_round_trips_meta(tmp_path):
     ) == meta
 
 
+def test_load_feedback_meta_for_ref_accepts_uuid_decision_id(tmp_path):
+    """UUID decision_id passed as decision_ref should resolve meta via token derivation."""
+    store_path = tmp_path / "tokens.json"
+    decision_id = "33333333-3333-4333-8333-333333333333"
+    meta = {
+        "decision_id": decision_id,
+        "task_type": "coding",
+        "selected_model": "anthropic/claude-opus",
+        "source_channel": "telegram",
+        "metadata": {"source_message_preview": "uuid ref test turn"},
+    }
+
+    feedback_service.register_feedback_token(
+        user_id="user-2",
+        decision_id=decision_id,
+        meta=meta,
+        store_path=str(store_path),
+    )
+
+    # Passing the full UUID as decision_ref should still return the stored meta.
+    assert feedback_service.load_feedback_meta_for_ref(
+        user_id="user-2",
+        decision_ref=decision_id,
+        store_path=str(store_path),
+    ) == meta
+
+
 @pytest.mark.asyncio
 async def test_route_feedback_callback_accepts_older_card_when_token_resolves(monkeypatch):
     old_decision = "11111111-1111-4111-8111-111111111111"


### PR DESCRIPTION
- [x] Explore and understand the current code
- [x] Fix `load_feedback_meta_for_ref()` to handle UUID refs by computing token via `decision_token()` and looking up `refs[token]`
- [x] Add test `test_load_feedback_meta_for_ref_accepts_uuid_decision_id` for UUID-ref-based metadata recovery
- [x] Run tests - all 3 pass
- [x] Final code review (Code Review + CodeQL: no issues)