### PR TITLE
feat(workflow): CompositeStep — wire nexus/agents/ primitives into Nexus Workflow (issue #154)

### DIFF
--- a/nexus/core/workflow_engine/__init__.py
+++ b/nexus/core/workflow_engine/__init__.py
@@ -1,1 +1,5 @@
 """Internal collaborators for workflow engine refactors."""
+from nexus.core.workflow_engine.composite_step import CompositeStep
+
+__all__ = ["CompositeStep"]
+

--- a/nexus/core/workflow_engine/composite_step.py
+++ b/nexus/core/workflow_engine/composite_step.py
@@ -1,0 +1,72 @@
+"""
+nexus/workflow/composite_step.py — CompositeStep: wraps nexus/agents/ primitives
+into a Nexus Workflow step, preserving Git artifact writing and DB persistence.
+"""
+from __future__ import annotations
+
+import asyncio
+import logging
+from typing import Any
+
+from nexus.agents.base import AgentContext, AgentOutput, BaseAgent
+
+logger = logging.getLogger(__name__)
+
+
+class CompositeStep:
+    """
+    Wraps a nexus/agents/ BaseAgent composition (Sequential/Parallel/Loop/Coordinator)
+    as a callable that Nexus Workflow can invoke in place of a single AI provider call.
+
+    The WorkflowEngine's on_step_transition still fires; Git artifact writing
+    and DB state transitions (started → complete/failed) are handled by the caller
+    as usual. CompositeStep only runs the agent tree and returns the merged output.
+
+    Usage in a workflow step definition (optional, opt-in):
+        step.metadata["composite_agent"] = CompositeStep(my_sequential_agent)
+
+    When a step has a composite_agent in metadata, the workflow engine should call:
+        output = await composite_step.run(task=prompt, prior_outputs=[...])
+    and use the returned content as the step output instead of calling the AIProvider directly.
+    """
+
+    # Metadata key used to store a CompositeStep on a WorkflowStep
+    METADATA_KEY = "composite_agent"
+
+    def __init__(self, agent: BaseAgent) -> None:
+        self.agent = agent
+
+    async def run(
+        self,
+        task: str,
+        prior_outputs: list[AgentOutput] | None = None,
+        metadata: dict[str, Any] | None = None,
+    ) -> AgentOutput:
+        """
+        Execute the agent tree and return the final AgentOutput.
+        prior_outputs: outputs from previous workflow steps (used as context)
+        """
+        context = AgentContext(
+            task=task,
+            prior_outputs=prior_outputs or [],
+            metadata=metadata or {},
+        )
+        try:
+            output = await self.agent.run(context)
+            logger.info(
+                "CompositeStep(%s) completed. output_length=%d",
+                self.agent.name,
+                len(output.content),
+            )
+            return output
+        except Exception as exc:
+            logger.error("CompositeStep(%s) failed: %s", self.agent.name, exc)
+            return AgentOutput(
+                content=f"[CompositeStep failed: {exc}]",
+                metadata={"error": str(exc), "agent": self.agent.name},
+            )
+
+    @classmethod
+    def from_metadata(cls, step_metadata: dict[str, Any]) -> "CompositeStep | None":
+        """Extract a CompositeStep from a WorkflowStep's metadata dict, if present."""
+        return step_metadata.get(cls.METADATA_KEY)

--- a/nexus/core/workflow_engine/tests/test_composite_step.py
+++ b/nexus/core/workflow_engine/tests/test_composite_step.py
@@ -1,0 +1,96 @@
+"""Tests for CompositeStep — workflow integration of nexus/agents/ primitives."""
+from __future__ import annotations
+
+import asyncio
+import pytest
+
+from nexus.agents.base import AgentContext, AgentOutput, BaseAgent
+from nexus.agents.sequential import SequentialAgent
+from nexus.agents.parallel import ParallelAgent
+from nexus.agents.loop import LoopAgent
+from nexus.core.workflow_engine.composite_step import CompositeStep
+
+
+class FixedAgent(BaseAgent):
+    def __init__(self, name: str, response: str):
+        super().__init__(name=name, description=f"{name} agent")
+        self.response = response
+
+    async def run(self, context: AgentContext) -> AgentOutput:
+        return AgentOutput(content=self.response, metadata={"agent": self.name})
+
+
+def test_composite_step_runs_sequential():
+    a = FixedAgent("A", "result_a")
+    b = FixedAgent("B", "result_b")
+    seq = SequentialAgent("pipeline", [a, b])
+    cs = CompositeStep(seq)
+
+    output = asyncio.run(cs.run(task="do work"))
+    assert output.content == "result_b"
+    assert "sequential_outputs" in output.metadata
+
+
+def test_composite_step_runs_parallel():
+    a = FixedAgent("X", "x_out")
+    b = FixedAgent("Y", "y_out")
+    par = ParallelAgent("par", [a, b])
+    cs = CompositeStep(par)
+
+    output = asyncio.run(cs.run(task="parallel work"))
+    assert "x_out" in output.content
+    assert "y_out" in output.content
+
+
+def test_composite_step_runs_loop():
+    counter = [0]
+
+    class CountAgent(BaseAgent):
+        async def run(self, context: AgentContext) -> AgentOutput:
+            counter[0] += 1
+            return AgentOutput(content=str(counter[0]))
+
+    loop = LoopAgent("loop", CountAgent("c"), stop_condition=lambda o: int(o.content) >= 2, max_iterations=5)
+    cs = CompositeStep(loop)
+    output = asyncio.run(cs.run(task="loop"))
+    assert output.content == "2"
+    assert output.metadata["loop_iterations"] == 2
+
+
+def test_composite_step_passes_prior_outputs():
+    received = []
+
+    class RecordAgent(BaseAgent):
+        async def run(self, context: AgentContext) -> AgentOutput:
+            received.append(len(context.prior_outputs))
+            return AgentOutput(content="ok")
+
+    cs = CompositeStep(RecordAgent("r"))
+    prior = [AgentOutput(content="prev1"), AgentOutput(content="prev2")]
+    asyncio.run(cs.run(task="task", prior_outputs=prior))
+    assert received[0] == 2
+
+
+def test_composite_step_handles_agent_failure():
+    """CompositeStep must not raise — returns error AgentOutput on failure."""
+    class BrokenAgent(BaseAgent):
+        async def run(self, context: AgentContext) -> AgentOutput:
+            raise RuntimeError("agent exploded")
+
+    cs = CompositeStep(BrokenAgent("broken"))
+    output = asyncio.run(cs.run(task="risky"))
+    assert "CompositeStep failed" in output.content
+    assert "error" in output.metadata
+
+
+def test_composite_step_from_metadata():
+    agent = FixedAgent("agent", "result")
+    cs = CompositeStep(agent)
+    meta = {CompositeStep.METADATA_KEY: cs}
+    retrieved = CompositeStep.from_metadata(meta)
+    assert retrieved is cs
+
+
+def test_composite_step_from_metadata_missing():
+    result = CompositeStep.from_metadata({})
+    assert result is None


### PR DESCRIPTION
Clean rebase of #156 on top of merged #153.

Adds `CompositeStep` to wire `nexus/agents/` composition primitives into the Nexus Workflow engine as Layer 2.

- `nexus/core/workflow_engine/composite_step.py` — wraps any BaseAgent tree; opt-in via step metadata
- `nexus/core/workflow_engine/__init__.py` — exports `CompositeStep`
- 7 tests: sequential, parallel, loop, prior_outputs, error handling, metadata
- Zero breaking changes to existing workflow engine

Closes #154.