### PR TITLE
feat(openclaw): /api/v1/agents/run bridge endpoint + nexus-agents OpenClaw skill (issue #155)

### DIFF
--- a/nexus/core/command_bridge/agents_handler.py
+++ b/nexus/core/command_bridge/agents_handler.py
@@ -1,0 +1,164 @@
+"""
+nexus/core/command_bridge/agents_handler.py
+
+Handles POST /api/v1/agents/run — invokes nexus/agents/ composition primitives
+from the bridge HTTP API (used by OpenClaw skill and other callers).
+
+Request schema:
+    {
+        "task": "string (required) — the task to run",
+        "agent_type": "sequential|parallel|loop|coordinator (default: sequential)",
+        "agents": [
+            {"name": "string", "description": "string", "response": "string (mock only)"}
+        ],
+        "router_url": "string (optional, default: http://127.0.0.1:7771)",
+        "max_iterations": int (LoopAgent only, default 5),
+        "stop_condition": "string (LoopAgent only, Python expression on output.content)"
+    }
+
+Response schema:
+    {
+        "ok": bool,
+        "output": "string",
+        "metadata": dict,
+        "error": "string (if ok=False)"
+    }
+"""
+from __future__ import annotations
+
+import asyncio
+import logging
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+
+async def handle_agents_run(payload: dict[str, Any], config: dict | None = None) -> dict[str, Any]:
+    """
+    Entry point for POST /api/v1/agents/run.
+    Builds the requested agent composition and runs it.
+    """
+    from nexus.agents.base import AgentContext, AgentOutput, BaseAgent
+    from nexus.agents.sequential import SequentialAgent
+    from nexus.agents.parallel import ParallelAgent
+    from nexus.agents.loop import LoopAgent
+    from nexus.agents.coordinator import Coordinator
+
+    task = (payload.get("task") or "").strip()
+    if not task:
+        return {"ok": False, "error": "task is required"}
+
+    agent_type = (payload.get("agent_type") or "sequential").lower()
+    agents_spec = payload.get("agents") or []
+    router_url = payload.get("router_url") or "http://127.0.0.1:7771"
+    max_iterations = int(payload.get("max_iterations") or 5)
+    stop_expr = payload.get("stop_condition") or ""
+
+    if not agents_spec:
+        return {"ok": False, "error": "agents list is required"}
+
+    # Build sub-agents from spec
+    sub_agents: list[BaseAgent] = _build_sub_agents(agents_spec, config=config)
+
+    try:
+        agent: BaseAgent
+        if agent_type == "sequential":
+            agent = SequentialAgent(name="bridge_sequential", sub_agents=sub_agents)
+        elif agent_type == "parallel":
+            agent = ParallelAgent(name="bridge_parallel", sub_agents=sub_agents)
+        elif agent_type == "loop":
+            if len(sub_agents) != 1:
+                return {"ok": False, "error": "loop agent_type requires exactly one agent"}
+            stop_fn = _make_stop_condition(stop_expr)
+            agent = LoopAgent(
+                name="bridge_loop",
+                sub_agent=sub_agents[0],
+                stop_condition=stop_fn,
+                max_iterations=max_iterations,
+            )
+        elif agent_type == "coordinator":
+            ai_provider = _get_ai_provider(config)
+            if ai_provider is None:
+                return {"ok": False, "error": "coordinator requires an AI provider; none configured"}
+            agent = Coordinator(
+                name="bridge_coordinator",
+                sub_agents=sub_agents,
+                ai_provider=ai_provider,
+                router_url=router_url,
+            )
+        else:
+            return {"ok": False, "error": f"unknown agent_type: {agent_type}"}
+
+        context = AgentContext(task=task)
+        output = await agent.run(context)
+        return {"ok": True, "output": output.content, "metadata": output.metadata}
+
+    except Exception as exc:
+        logger.exception("agents_run failed: %s", exc)
+        return {"ok": False, "error": str(exc)}
+
+
+def _build_sub_agents(specs: list[dict], config: dict | None = None):
+    """
+    Build sub-agents from spec list.
+    If an AI provider is available, wraps each spec as an LLMSubAgent.
+    Falls back to a MockSubAgent (returns description as output) for tests.
+    """
+    from nexus.agents.base import AgentContext, AgentOutput, BaseAgent
+
+    ai_provider = _get_ai_provider(config)
+
+    agents = []
+    for spec in specs:
+        name = spec.get("name") or "unnamed"
+        description = spec.get("description") or ""
+
+        if ai_provider is not None:
+            from nexus.agents.coordinator import LLMSubAgent
+            agents.append(LLMSubAgent(name=name, description=description, ai_provider=ai_provider))
+        else:
+            # MockSubAgent: returns spec-defined response (useful for testing/dry-run)
+            fixed_response = spec.get("response") or f"[{name}]: {description}"
+
+            class _MockAgent(BaseAgent):
+                def __init__(self, _name, _desc, _resp):
+                    super().__init__(name=_name, description=_desc)
+                    self._resp = _resp
+
+                async def run(self, context: AgentContext) -> AgentOutput:
+                    return AgentOutput(content=self._resp, metadata={"mock": True, "agent": self.name})
+
+            agents.append(_MockAgent(name, description, fixed_response))
+
+    return agents
+
+
+def _get_ai_provider(config: dict | None):
+    """Try to resolve an AIProvider from config. Returns None if unavailable."""
+    if not config:
+        return None
+    try:
+        provider_factory = config.get("ai_provider_factory")
+        if callable(provider_factory):
+            return provider_factory()
+    except Exception as exc:
+        logger.debug("Could not resolve AI provider: %s", exc)
+    return None
+
+
+def _make_stop_condition(expr: str):
+    """
+    Build a stop_condition callable from a Python expression string.
+    The expression is evaluated with `output` in scope (AgentOutput).
+    Falls back to never-stop if expression is empty or invalid.
+    """
+    if not expr:
+        return lambda output: False
+
+    def _stop(output):
+        try:
+            return bool(eval(expr, {}, {"output": output, "content": output.content}))  # noqa: S307
+        except Exception:
+            return False
+
+    return _stop

--- a/nexus/core/command_bridge/agents_handler.py
+++ b/nexus/core/command_bridge/agents_handler.py
@@ -26,7 +26,6 @@ Response schema:
 """
 from __future__ import annotations
 
-import asyncio
 import logging
 from typing import Any
 
@@ -38,11 +37,11 @@ async def handle_agents_run(payload: dict[str, Any], config: dict | None = None)
     Entry point for POST /api/v1/agents/run.
     Builds the requested agent composition and runs it.
     """
-    from nexus.agents.base import AgentContext, AgentOutput, BaseAgent
-    from nexus.agents.sequential import SequentialAgent
-    from nexus.agents.parallel import ParallelAgent
-    from nexus.agents.loop import LoopAgent
+    from nexus.agents.base import AgentContext, BaseAgent
     from nexus.agents.coordinator import Coordinator
+    from nexus.agents.loop import LoopAgent
+    from nexus.agents.parallel import ParallelAgent
+    from nexus.agents.sequential import SequentialAgent
 
     task = (payload.get("task") or "").strip()
     if not task:

--- a/nexus/core/command_bridge/http.py
+++ b/nexus/core/command_bridge/http.py
@@ -493,6 +493,14 @@ def create_command_bridge_app(
                 result = asyncio.run(router.receive_reply(reply))
                 return _command_result_response(start_response, result)
 
+            # ── nexus/agents/ multi-agent bridge endpoint ─────────────────────
+            if method == "POST" and path == "/api/v1/agents/run":
+                payload = _load_json_body(environ)
+                from nexus.core.command_bridge.agents_handler import handle_agents_run
+                result = asyncio.run(handle_agents_run(payload, config=config))
+                status = 200 if result.get("ok") else 400
+                return _json_response(start_response, status, result)
+
             return _json_response(start_response, 404, {"error": "Not found"})
         except ReplyTokenError as exc:
             error_code = getattr(exc, "code", "invalid_reply_token")

--- a/nexus/core/command_bridge/tests/test_agents_handler.py
+++ b/nexus/core/command_bridge/tests/test_agents_handler.py
@@ -1,0 +1,90 @@
+"""Integration tests for POST /api/v1/agents/run bridge endpoint."""
+from __future__ import annotations
+
+import asyncio
+import pytest
+
+from nexus.core.command_bridge.agents_handler import handle_agents_run
+
+
+AGENTS = [
+    {"name": "Summariser", "description": "Summarises text", "response": "Summary done"},
+    {"name": "Reviewer", "description": "Reviews output", "response": "Review OK"},
+]
+
+
+def test_sequential_run():
+    result = asyncio.run(handle_agents_run({
+        "task": "Summarise this document",
+        "agent_type": "sequential",
+        "agents": AGENTS,
+    }))
+    assert result["ok"] is True
+    assert "Review OK" in result["output"]
+    assert "metadata" in result
+
+
+def test_parallel_run():
+    result = asyncio.run(handle_agents_run({
+        "task": "Analyse in parallel",
+        "agent_type": "parallel",
+        "agents": AGENTS,
+    }))
+    assert result["ok"] is True
+    assert "Summary done" in result["output"]
+    assert "Review OK" in result["output"]
+
+
+def test_loop_run():
+    counter = {"n": 0}
+    result = asyncio.run(handle_agents_run({
+        "task": "Keep trying",
+        "agent_type": "loop",
+        "agents": [{"name": "Worker", "description": "Does work", "response": "done"}],
+        "max_iterations": 3,
+        "stop_condition": "True",  # stops immediately on first iteration
+    }))
+    assert result["ok"] is True
+    assert result["metadata"]["loop_iterations"] == 1
+
+
+def test_loop_requires_single_agent():
+    result = asyncio.run(handle_agents_run({
+        "task": "loop",
+        "agent_type": "loop",
+        "agents": AGENTS,  # two agents — should fail
+    }))
+    assert result["ok"] is False
+    assert "exactly one" in result["error"]
+
+
+def test_missing_task():
+    result = asyncio.run(handle_agents_run({"agent_type": "sequential", "agents": AGENTS}))
+    assert result["ok"] is False
+    assert "task is required" in result["error"]
+
+
+def test_missing_agents():
+    result = asyncio.run(handle_agents_run({"task": "do something", "agent_type": "sequential"}))
+    assert result["ok"] is False
+    assert "agents list" in result["error"]
+
+
+def test_unknown_agent_type():
+    result = asyncio.run(handle_agents_run({
+        "task": "task",
+        "agent_type": "invalid_type",
+        "agents": AGENTS,
+    }))
+    assert result["ok"] is False
+    assert "unknown agent_type" in result["error"]
+
+
+def test_coordinator_without_provider():
+    result = asyncio.run(handle_agents_run({
+        "task": "coordinate",
+        "agent_type": "coordinator",
+        "agents": AGENTS,
+    }))
+    assert result["ok"] is False
+    assert "AI provider" in result["error"]

--- a/skills/nexus-agents/SKILL.md
+++ b/skills/nexus-agents/SKILL.md
@@ -1,0 +1,98 @@
+---
+name: nexus-agents
+description: >
+  Invoke nexus/agents/ multi-agent composition pipelines from chat.
+  Use when you need to run a Sequential, Parallel, Loop, or Coordinator
+  pipeline of specialized agents against a task — for analysis, review,
+  code generation, or any multi-step reasoning that benefits from
+  multiple specialized agents working together.
+---
+
+# nexus-agents skill
+
+## What it does
+
+Sends a task to the Nexus bridge (`POST /api/v1/agents/run`) which runs the
+requested agent composition using `nexus/agents/` primitives and returns the result.
+
+## Usage
+
+```
+POST http://127.0.0.1:8091/api/v1/agents/run
+Authorization: Bearer <NEXUS_BRIDGE_TOKEN>
+Content-Type: application/json
+
+{
+  "task": "Review this PR for security issues and summarise findings",
+  "agent_type": "sequential",
+  "agents": [
+    {"name": "SecurityReviewer", "description": "Reviews code for security vulnerabilities"},
+    {"name": "Summariser", "description": "Summarises findings into a concise report"}
+  ]
+}
+```
+
+## agent_type options
+
+| type | behaviour |
+|---|---|
+| `sequential` | agents run in order; each receives prior outputs |
+| `parallel` | agents run concurrently; outputs merged |
+| `loop` | single agent repeats until stop_condition or max_iterations |
+| `coordinator` | LLM picks the best agent; nexus-router selects model |
+
+## LoopAgent extra fields
+
+```json
+{
+  "agent_type": "loop",
+  "agents": [{"name": "Refiner", "description": "Refines output"}],
+  "max_iterations": 5,
+  "stop_condition": "'DONE' in content"
+}
+```
+
+`stop_condition` is a Python expression evaluated with `output` (AgentOutput)
+and `content` (output.content) in scope.
+
+## Response
+
+```json
+{
+  "ok": true,
+  "output": "Final agent output text",
+  "metadata": {
+    "coordinator_selected_agent": "...",
+    "sequential_outputs": [...],
+    "loop_iterations": 3
+  }
+}
+```
+
+## How to invoke from Jarvis
+
+When Gab asks to "run agents" or "coordinate agents" on a task, call the bridge:
+
+```python
+import json, urllib.request
+
+payload = json.dumps({
+    "task": "<task>",
+    "agent_type": "sequential",
+    "agents": [...]
+}).encode()
+
+req = urllib.request.Request(
+    "http://127.0.0.1:8091/api/v1/agents/run",
+    data=payload,
+    headers={
+        "Content-Type": "application/json",
+        "Authorization": f"Bearer {BRIDGE_TOKEN}"
+    },
+    method="POST"
+)
+with urllib.request.urlopen(req) as resp:
+    result = json.loads(resp.read())
+```
+
+Then return `result["output"]` to the user.


### PR DESCRIPTION
Clean rebase of #157 on top of merged #153 + lint fixes.

Implements Layer 3 — HTTP bridge endpoint and OpenClaw skill for interactive invocation from chat.

- `POST /api/v1/agents/run` — sequential, parallel, loop, coordinator agent types
- MockSubAgent fallback when no AI provider configured
- `skills/nexus-agents/SKILL.md` — OpenClaw skill with usage examples
- 8 integration tests
- Lint fixes: F401/UP035/UP037 (ruff)

Closes #155.