### PR TITLE
feat: add n8n state machine bridge

### DIFF
--- a/docs/N8N_STATE_MACHINE_BRIDGE.md
+++ b/docs/N8N_STATE_MACHINE_BRIDGE.md
@@ -1,0 +1,102 @@
+# n8n State Machine Bridge
+
+This bridge lets n8n own visible workflow state while Nexus ARC keeps control of
+policy and coding execution.
+
+## Runtime Split
+
+- Chat reasoning stays in OpenClaw/Nexus.
+- n8n stores and displays workflow state transitions.
+- Nexus command bridge exposes authenticated state and coding endpoints.
+- OpenCode runs coding work only through the Nexus bridge, in an isolated git
+  worktree under an allowlisted repository root.
+
+## Endpoints
+
+All endpoints require the existing command bridge bearer token.
+
+### Create Run
+
+`POST /api/v1/n8n/runs`
+
+```json
+{
+  "run_id": "optional-stable-id",
+  "task": "Implement the agreed task",
+  "project_key": "nexus",
+  "issue_number": "123",
+  "requester": {
+    "source": "telegram",
+    "sender_id": "47168736"
+  }
+}
+```
+
+### Update Run
+
+`POST /api/v1/n8n/runs/update`
+
+```json
+{
+  "run_id": "n8n-abc123",
+  "state": "approved",
+  "message": "Gab approved implementation"
+}
+```
+
+Allowed states:
+
+`queued`, `reasoning`, `planning`, `approved`, `coding`, `review`, `test`,
+`pr`, `done`, `blocked`, `failed`, `cancelled`.
+
+### Get Run
+
+`GET /api/v1/n8n/runs/<run_id>`
+
+### Execute Coding
+
+`POST /api/v1/n8n/coding/execute`
+
+```json
+{
+  "run_id": "n8n-abc123",
+  "task": "Make the requested code change",
+  "project_key": "nexus",
+  "worker": "opencode",
+  "agent": "build",
+  "base_branch": "develop",
+  "branch": "n8n/n8n-abc123"
+}
+```
+
+The bridge resolves `project_key` to the configured workspace, creates a git
+worktree, then launches:
+
+```bash
+opencode run --agent build --format json --dir <worktree> --dangerously-skip-permissions <prompt>
+```
+
+OpenCode is instructed not to push, merge, or create PRs. PR creation should be
+an explicit later state in the n8n workflow.
+
+## Environment
+
+- `NEXUS_N8N_STATE_DIR`: run records, default `/var/lib/nexus/n8n-state`
+- `NEXUS_N8N_WORKTREE_DIR`: isolated worktrees, default `/var/lib/nexus/n8n-worktrees`
+- `NEXUS_N8N_LOG_DIR`: OpenCode logs, default `/var/lib/nexus/logs/n8n`
+- `NEXUS_N8N_REPO_ALLOWLIST`: colon-separated allowed roots, default `/home/ubuntu/git`
+- `NEXUS_OPENCODE_CLI`: OpenCode binary path, default from `PATH`
+
+## n8n Shape
+
+A minimal workflow is:
+
+1. Manual/chat webhook trigger.
+2. `POST /api/v1/n8n/runs`.
+3. Human approval node.
+4. `POST /api/v1/n8n/runs/update` with `approved`.
+5. `POST /api/v1/n8n/coding/execute`.
+6. Poll `GET /api/v1/n8n/runs/<run_id>` or inspect returned job log.
+7. Move to review/test/PR states.
+
+Use n8n credentials for the bearer token. Do not put the token in node bodies.

--- a/examples/n8n/openclaw-opencode-state-machine.json
+++ b/examples/n8n/openclaw-opencode-state-machine.json
@@ -1,0 +1,111 @@
+{
+  "name": "OpenClaw + OpenCode State Machine",
+  "nodes": [
+    {
+      "parameters": {},
+      "id": "manual-trigger",
+      "name": "Manual Trigger",
+      "type": "n8n-nodes-base.manualTrigger",
+      "typeVersion": 1,
+      "position": [
+        0,
+        0
+      ]
+    },
+    {
+      "parameters": {
+        "method": "POST",
+        "url": "http://nexus-bridge-1:8091/api/v1/n8n/runs",
+        "authentication": "predefinedCredentialType",
+        "nodeCredentialType": "httpBearerAuth",
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "{\n  \"task\": \"={{$json.task || 'Implement the approved task'}}\",\n  \"project_key\": \"={{$json.project_key || 'nexus'}}\",\n  \"issue_number\": \"={{$json.issue_number || ''}}\",\n  \"requester\": {\n    \"source\": \"n8n\"\n  }\n}"
+      },
+      "id": "create-run",
+      "name": "Create Nexus Run",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [
+        240,
+        0
+      ]
+    },
+    {
+      "parameters": {
+        "method": "POST",
+        "url": "http://nexus-bridge-1:8091/api/v1/n8n/runs/update",
+        "authentication": "predefinedCredentialType",
+        "nodeCredentialType": "httpBearerAuth",
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "{\n  \"run_id\": \"={{$json.run.run_id}}\",\n  \"state\": \"approved\",\n  \"message\": \"Approved from n8n\"\n}"
+      },
+      "id": "mark-approved",
+      "name": "Mark Approved",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [
+        480,
+        0
+      ]
+    },
+    {
+      "parameters": {
+        "method": "POST",
+        "url": "http://nexus-bridge-1:8091/api/v1/n8n/coding/execute",
+        "authentication": "predefinedCredentialType",
+        "nodeCredentialType": "httpBearerAuth",
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "{\n  \"run_id\": \"={{$json.run.run_id}}\",\n  \"task\": \"={{$json.run.task}}\",\n  \"project_key\": \"={{$json.run.project_key}}\",\n  \"worker\": \"opencode\",\n  \"agent\": \"build\",\n  \"base_branch\": \"develop\"\n}"
+      },
+      "id": "execute-opencode",
+      "name": "Execute OpenCode",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [
+        720,
+        0
+      ]
+    }
+  ],
+  "connections": {
+    "Manual Trigger": {
+      "main": [
+        [
+          {
+            "node": "Create Nexus Run",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Create Nexus Run": {
+      "main": [
+        [
+          {
+            "node": "Mark Approved",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Mark Approved": {
+      "main": [
+        [
+          {
+            "node": "Execute OpenCode",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    }
+  },
+  "settings": {
+    "executionOrder": "v1"
+  }
+}

--- a/nexus/core/command_bridge/http.py
+++ b/nexus/core/command_bridge/http.py
@@ -121,7 +121,9 @@ def create_command_bridge_app(
                         {"error": allow_error[0], "error_code": allow_error[1]},
                     )
                 result = asyncio.run(router.route(request))
-                _maybe_dispatch_route_feedback_prompt_external(router=router, request=request, result=result)
+                _maybe_dispatch_route_feedback_prompt_external(
+                    router=router, request=request, result=result
+                )
                 return _command_result_response(start_response, result)
 
             if method == "POST" and path == "/api/v1/router/feedback-card":
@@ -137,13 +139,17 @@ def create_command_bridge_app(
 
                 task_type = str(payload.get("task_type") or "").strip() or "unknown"
                 selected_model = str(payload.get("selected_model") or "").strip() or "unknown"
-                source_channel = str(payload.get("source_channel") or "openclaw").strip() or "openclaw"
+                source_channel = (
+                    str(payload.get("source_channel") or "openclaw").strip() or "openclaw"
+                )
                 source_message_id = str(payload.get("source_message_id") or "").strip() or None
                 confidence = payload.get("confidence")
                 classifier_source = str(payload.get("classifier_source") or "").strip() or None
                 shadow_mode = bool(payload.get("shadow_mode"))
                 actual_model = str(payload.get("actual_model") or "").strip() or None
-                source_message_preview = str(payload.get("source_message_preview") or "").strip() or None
+                source_message_preview = (
+                    str(payload.get("source_message_preview") or "").strip() or None
+                )
 
                 result_payload = {
                     "routing_feedback": {
@@ -168,7 +174,9 @@ def create_command_bridge_app(
                 sent = asyncio.run(
                     maybe_send_feedback_prompt_external(
                         telegram_user_id=telegram_user_id,
-                        feedback_config=getattr(router.hands_free_deps, "router_feedback_config", None),
+                        feedback_config=getattr(
+                            router.hands_free_deps, "router_feedback_config", None
+                        ),
                         result=result_payload,
                         source_message_id=source_message_id,
                         source_channel=source_channel,
@@ -201,17 +209,23 @@ def create_command_bridge_app(
 
             if method == "GET" and path == "/api/v1/operator/workflows/active":
                 params = _query_params(environ)
-                payload = asyncio.run(router.get_active_workflows(limit=_int_param(params, "limit", 20)))
+                payload = asyncio.run(
+                    router.get_active_workflows(limit=_int_param(params, "limit", 20))
+                )
                 return _json_response(start_response, 200 if payload.get("ok") else 500, payload)
 
             if method == "GET" and path == "/api/v1/operator/workflows/recent-failures":
                 params = _query_params(environ)
-                payload = asyncio.run(router.get_recent_failures(limit=_int_param(params, "limit", 20)))
+                payload = asyncio.run(
+                    router.get_recent_failures(limit=_int_param(params, "limit", 20))
+                )
                 return _json_response(start_response, 200 if payload.get("ok") else 500, payload)
 
             if method == "GET" and path == "/api/v1/operator/workflows/recent-incidents":
                 params = _query_params(environ)
-                payload = asyncio.run(router.get_recent_incidents(limit=_int_param(params, "limit", 20)))
+                payload = asyncio.run(
+                    router.get_recent_incidents(limit=_int_param(params, "limit", 20))
+                )
                 return _json_response(start_response, 200 if payload.get("ok") else 500, payload)
 
             if method == "GET" and path == "/api/v1/operator/workflows/status":
@@ -222,7 +236,10 @@ def create_command_bridge_app(
                     return _json_response(
                         start_response,
                         400,
-                        {"ok": False, "error": "Missing query parameter: provide 'workflow_id' or 'issue_number'."},
+                        {
+                            "ok": False,
+                            "error": "Missing query parameter: provide 'workflow_id' or 'issue_number'.",
+                        },
                     )
                 payload = asyncio.run(
                     router.operator_service.workflow_status(
@@ -240,7 +257,10 @@ def create_command_bridge_app(
                     return _json_response(
                         start_response,
                         400,
-                        {"ok": False, "error": "Missing query parameter: provide 'workflow_id' or 'issue_number'."},
+                        {
+                            "ok": False,
+                            "error": "Missing query parameter: provide 'workflow_id' or 'issue_number'.",
+                        },
                     )
                 payload = asyncio.run(
                     router.get_workflow_summary(
@@ -258,7 +278,10 @@ def create_command_bridge_app(
                     return _json_response(
                         start_response,
                         400,
-                        {"ok": False, "error": "Missing query parameter: provide 'workflow_id' or 'issue_number'."},
+                        {
+                            "ok": False,
+                            "error": "Missing query parameter: provide 'workflow_id' or 'issue_number'.",
+                        },
                     )
                 payload = asyncio.run(
                     router.get_workflow_timeline(
@@ -276,7 +299,10 @@ def create_command_bridge_app(
                     return _json_response(
                         start_response,
                         400,
-                        {"ok": False, "error": "Missing query parameter: provide 'workflow_id' or 'issue_number'."},
+                        {
+                            "ok": False,
+                            "error": "Missing query parameter: provide 'workflow_id' or 'issue_number'.",
+                        },
                     )
                 payload = asyncio.run(
                     router.get_workflow_diagnosis(
@@ -294,7 +320,10 @@ def create_command_bridge_app(
                     return _json_response(
                         start_response,
                         400,
-                        {"ok": False, "error": "Missing query parameter: provide 'workflow_id' or 'issue_number'."},
+                        {
+                            "ok": False,
+                            "error": "Missing query parameter: provide 'workflow_id' or 'issue_number'.",
+                        },
                     )
                 payload = asyncio.run(
                     router.get_workflow_authorship_audit(
@@ -312,7 +341,10 @@ def create_command_bridge_app(
                     return _json_response(
                         start_response,
                         400,
-                        {"ok": False, "error": "Missing query parameter: provide 'workflow_id' or 'issue_number'."},
+                        {
+                            "ok": False,
+                            "error": "Missing query parameter: provide 'workflow_id' or 'issue_number'.",
+                        },
                     )
                 payload = asyncio.run(
                     router.get_workflow_blockers(
@@ -330,7 +362,10 @@ def create_command_bridge_app(
                     return _json_response(
                         start_response,
                         400,
-                        {"ok": False, "error": "Missing query parameter: provide 'workflow_id' or 'issue_number'."},
+                        {
+                            "ok": False,
+                            "error": "Missing query parameter: provide 'workflow_id' or 'issue_number'.",
+                        },
                     )
                 payload = asyncio.run(
                     router.get_workflow_logs_context(
@@ -375,7 +410,11 @@ def create_command_bridge_app(
                 # Validate required fields
                 content = payload.get("content")
                 if not isinstance(content, str) or not content.strip():
-                    return _json_response(start_response, 400, {"ok": False, "error": "content is required and must be non-empty"})
+                    return _json_response(
+                        start_response,
+                        400,
+                        {"ok": False, "error": "content is required and must be non-empty"},
+                    )
                 campaign_id = payload.get("campaign_id") or payload.get("campaign") or None
                 dry_run_raw = payload.get("dry_run", True)
                 if isinstance(dry_run_raw, bool):
@@ -388,19 +427,31 @@ def create_command_bridge_app(
                 nexus_id = payload.get("nexus_id") or None
                 chat_platform = payload.get("chat_platform") or None
                 chat_id = payload.get("chat_id") or None
-                metadata = payload.get("metadata") if isinstance(payload.get("metadata"), dict) else None
+                metadata = (
+                    payload.get("metadata") if isinstance(payload.get("metadata"), dict) else None
+                )
 
                 # Fallback: use authenticated sender id header if available
                 if not nexus_id and not (chat_platform and chat_id):
-                    sender_hdr = environ.get("HTTP_X_SENDER_ID") or environ.get("HTTP_X_OPENCLAW_SENDER_ID") or ""
+                    sender_hdr = (
+                        environ.get("HTTP_X_SENDER_ID")
+                        or environ.get("HTTP_X_OPENCLAW_SENDER_ID")
+                        or ""
+                    )
                     sender_hdr = str(sender_hdr).strip()
                     if sender_hdr:
                         # assume openclaw/telegram callers carry platform info
                         chat_id = chat_id or sender_hdr
-                        chat_platform = chat_platform or environ.get("HTTP_X_SENDER_PLATFORM") or environ.get("HTTP_X_OPENCLAW_PLATFORM") or None
+                        chat_platform = (
+                            chat_platform
+                            or environ.get("HTTP_X_SENDER_PLATFORM")
+                            or environ.get("HTTP_X_OPENCLAW_PLATFORM")
+                            or None
+                        )
 
                 try:
                     from nexus.core.social_publish_linkedin import publish_linkedin_text
+
                     result = publish_linkedin_text(
                         content=content,
                         campaign_id=campaign_id,
@@ -413,7 +464,11 @@ def create_command_bridge_app(
                     )
                 except Exception as exc:
                     _logger.exception("LinkedIn publish handler failed")
-                    return _json_response(start_response, 500, {"ok": False, "error": "internal_error", "error_detail": str(exc)})
+                    return _json_response(
+                        start_response,
+                        500,
+                        {"ok": False, "error": "internal_error", "error_detail": str(exc)},
+                    )
 
                 status = 200 if result.get("ok") else 400
                 return _json_response(start_response, status, result)
@@ -515,14 +570,45 @@ def create_command_bridge_app(
             if method == "POST" and path == "/api/v1/agents/run":
                 payload = _load_json_body(environ)
                 from nexus.core.command_bridge.agents_handler import handle_agents_run
+
                 result = asyncio.run(handle_agents_run(payload, config=config))
                 status = 200 if result.get("ok") else 400
                 return _json_response(start_response, status, result)
 
+            if method == "POST" and path == "/api/v1/n8n/runs":
+                payload = _load_json_body(environ)
+                from nexus.core.command_bridge.n8n_state_machine import create_run
+
+                result = create_run(payload)
+                return _json_response(start_response, 201, result)
+
+            if method == "POST" and path == "/api/v1/n8n/runs/update":
+                payload = _load_json_body(environ)
+                from nexus.core.command_bridge.n8n_state_machine import update_run
+
+                result = update_run(payload)
+                return _json_response(start_response, 200, result)
+
+            if method == "GET" and path.startswith("/api/v1/n8n/runs/"):
+                run_id = path.rsplit("/", 1)[-1]
+                from nexus.core.command_bridge.n8n_state_machine import get_run
+
+                result = get_run(run_id)
+                return _json_response(start_response, 200, result)
+
+            if method == "POST" and path == "/api/v1/n8n/coding/execute":
+                payload = _load_json_body(environ)
+                from nexus.core.command_bridge.n8n_state_machine import execute_coding_task
+
+                result = execute_coding_task(payload)
+                return _json_response(start_response, 202, result)
+
             return _json_response(start_response, 404, {"error": "Not found"})
         except ReplyTokenError as exc:
             error_code = getattr(exc, "code", "invalid_reply_token")
-            status_code = 410 if error_code in {"reply_token_expired", "reply_replay_detected"} else 409
+            status_code = (
+                410 if error_code in {"reply_token_expired", "reply_replay_detected"} else 409
+            )
             return _json_response(
                 start_response, status_code, {"error": str(exc), "error_code": error_code}
             )
@@ -623,7 +709,9 @@ def _validate_requester(
     requester = request.requester
     sender_id = str(requester.sender_id or "").strip()
     allowed_sender_ids = [
-        str(item or "").strip() for item in (config.allowed_sender_ids or []) if str(item or "").strip()
+        str(item or "").strip()
+        for item in (config.allowed_sender_ids or [])
+        if str(item or "").strip()
     ]
 
     # Backward-compatible auth gate:
@@ -633,7 +721,9 @@ def _validate_requester(
             return "Authenticated OpenClaw requester is required", "requester_not_authorized"
 
     allowed_sources = [
-        str(item or "").strip().lower() for item in (config.allowed_sources or []) if str(item or "").strip()
+        str(item or "").strip().lower()
+        for item in (config.allowed_sources or [])
+        if str(item or "").strip()
     ]
     if allowed_sources:
         source = str(requester.source_platform or "").strip().lower()
@@ -643,7 +733,6 @@ def _validate_requester(
     if allowed_sender_ids and sender_id not in allowed_sender_ids:
         return f"Sender '{sender_id}' is not allowed", "sender_not_allowed"
     return None
-
 
 
 def _query_params(environ: dict[str, Any]) -> dict[str, list[str]]:
@@ -717,7 +806,9 @@ def _command_result_response(start_response, result: CommandResult):
     return _json_response(start_response, status_code, result.to_dict())
 
 
-def _maybe_dispatch_route_feedback_prompt_external(*, router: CommandRouter, request: CommandRequest, result: CommandResult) -> None:
+def _maybe_dispatch_route_feedback_prompt_external(
+    *, router: CommandRouter, request: CommandRequest, result: CommandResult
+) -> None:
     """Best-effort fallback: send router feedback card directly from /commands/route.
 
     This removes hard dependency on a second /router/feedback-card callback from OpenClaw.
@@ -734,14 +825,20 @@ def _maybe_dispatch_route_feedback_prompt_external(*, router: CommandRouter, req
         source_message_id = None
         metadata = getattr(request.context, "metadata", {}) if request.context is not None else {}
         if isinstance(metadata, dict):
-            source_message_id = str(
-                metadata.get("source_message_id")
-                or metadata.get("message_id")
-                or metadata.get("telegram_message_id")
-                or ""
-            ).strip() or None
+            source_message_id = (
+                str(
+                    metadata.get("source_message_id")
+                    or metadata.get("message_id")
+                    or metadata.get("telegram_message_id")
+                    or ""
+                ).strip()
+                or None
+            )
 
-        source_channel = str(getattr(request.requester, "source_platform", "") or "openclaw").strip() or "openclaw"
+        source_channel = (
+            str(getattr(request.requester, "source_platform", "") or "openclaw").strip()
+            or "openclaw"
+        )
 
         sent = asyncio.run(
             maybe_send_feedback_prompt_external(

--- a/nexus/core/command_bridge/n8n_state_machine.py
+++ b/nexus/core/command_bridge/n8n_state_machine.py
@@ -1,0 +1,412 @@
+"""n8n-facing state machine bridge for controlled coding execution."""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import shutil
+import subprocess
+import time
+import uuid
+from pathlib import Path
+from typing import Any
+
+_VALID_STATES = {
+    "queued",
+    "reasoning",
+    "planning",
+    "approved",
+    "coding",
+    "review",
+    "test",
+    "pr",
+    "done",
+    "blocked",
+    "failed",
+    "cancelled",
+}
+_TERMINAL_STATES = {"done", "blocked", "failed", "cancelled"}
+_BRANCH_RE = re.compile(r"^[A-Za-z0-9._/-]+$")
+
+
+def create_run(payload: dict[str, Any]) -> dict[str, Any]:
+    """Create a durable n8n workflow run record."""
+    task = _required_str(payload, "task")
+    run_id = _clean_id(payload.get("run_id")) or f"n8n-{uuid.uuid4().hex[:12]}"
+    initial_state = _normalize_state(payload.get("state") or "queued")
+
+    now = _now()
+    record = {
+        "run_id": run_id,
+        "state": initial_state,
+        "task": task,
+        "project_key": _optional_str(payload.get("project_key")),
+        "issue_number": _optional_str(payload.get("issue_number")),
+        "workflow_id": _optional_str(payload.get("workflow_id")),
+        "requester": (
+            dict(payload.get("requester") or {})
+            if isinstance(payload.get("requester"), dict)
+            else {}
+        ),
+        "metadata": (
+            dict(payload.get("metadata") or {}) if isinstance(payload.get("metadata"), dict) else {}
+        ),
+        "created_at": now,
+        "updated_at": now,
+        "events": [
+            {
+                "at": now,
+                "state": initial_state,
+                "event": "run_created",
+                "message": "n8n workflow run created",
+            }
+        ],
+        "coding_jobs": [],
+    }
+    _save_run(record)
+    return {"ok": True, "run": _public_run(record)}
+
+
+def update_run(payload: dict[str, Any]) -> dict[str, Any]:
+    """Update state/metadata for an existing n8n workflow run."""
+    run_id = _required_str(payload, "run_id")
+    record = _load_run(run_id)
+    state = payload.get("state")
+    if state is not None:
+        next_state = _normalize_state(state)
+        current_state = str(record.get("state") or "")
+        if current_state in _TERMINAL_STATES and next_state != current_state:
+            raise ValueError(f"run {run_id} is terminal ({current_state})")
+        record["state"] = next_state
+
+    if isinstance(payload.get("metadata"), dict):
+        metadata = dict(record.get("metadata") or {})
+        metadata.update(dict(payload["metadata"]))
+        record["metadata"] = metadata
+
+    message = _optional_str(payload.get("message"))
+    now = _now()
+    record["updated_at"] = now
+    record.setdefault("events", []).append(
+        {
+            "at": now,
+            "state": str(record.get("state") or ""),
+            "event": str(payload.get("event") or "state_updated"),
+            "message": message,
+        }
+    )
+    _save_run(record)
+    return {"ok": True, "run": _public_run(record)}
+
+
+def get_run(run_id: str) -> dict[str, Any]:
+    """Return a single n8n workflow run record."""
+    return {"ok": True, "run": _public_run(_load_run(run_id))}
+
+
+def execute_coding_task(payload: dict[str, Any]) -> dict[str, Any]:
+    """Launch an allowlisted OpenCode coding job for an n8n workflow run."""
+    run_id = _required_str(payload, "run_id")
+    task = _required_str(payload, "task")
+    record = _load_run(run_id)
+    if str(record.get("state") or "") in _TERMINAL_STATES:
+        raise ValueError(f"run {run_id} is terminal ({record.get('state')})")
+
+    worker = str(payload.get("worker") or "opencode").strip().lower()
+    if worker != "opencode":
+        raise ValueError("only the 'opencode' worker is supported by this bridge")
+
+    repo_dir = _resolve_repo_dir(payload, record)
+    base_branch = _safe_branch(str(payload.get("base_branch") or "develop").strip() or "develop")
+    branch = _safe_branch(str(payload.get("branch") or f"n8n/{run_id}").strip() or f"n8n/{run_id}")
+    worktree_dir = _worktree_root() / run_id / repo_dir.name
+    log_file = _logs_root() / f"{run_id}-{int(time.time())}-opencode.log"
+    dry_run = _bool(payload.get("dry_run"))
+    agent = str(payload.get("agent") or "build").strip() or "build"
+    model = _optional_str(payload.get("model"))
+
+    if not dry_run:
+        _prepare_worktree(
+            repo_dir=repo_dir, worktree_dir=worktree_dir, branch=branch, base_branch=base_branch
+        )
+
+    prompt = _coding_prompt(
+        task=task,
+        run_id=run_id,
+        project_key=str(record.get("project_key") or ""),
+        issue_number=str(record.get("issue_number") or ""),
+    )
+    cmd = _opencode_command(
+        prompt=prompt,
+        worktree_dir=worktree_dir,
+        agent=agent,
+        model=model,
+    )
+
+    job = {
+        "job_id": f"job-{uuid.uuid4().hex[:12]}",
+        "worker": worker,
+        "state": "dry_run" if dry_run else "running",
+        "pid": None,
+        "repo_dir": str(repo_dir),
+        "worktree_dir": str(worktree_dir),
+        "branch": branch,
+        "base_branch": base_branch,
+        "log_file": str(log_file),
+        "created_at": _now(),
+    }
+
+    if not dry_run:
+        log_file.parent.mkdir(parents=True, exist_ok=True)
+        log_handle = log_file.open("ab")
+        proc = subprocess.Popen(
+            cmd,
+            cwd=str(worktree_dir),
+            stdout=log_handle,
+            stderr=subprocess.STDOUT,
+            stdin=subprocess.DEVNULL,
+            start_new_session=True,
+        )
+        log_handle.close()
+        job["pid"] = int(proc.pid)
+
+    record.setdefault("coding_jobs", []).append(job)
+    record["state"] = "coding"
+    record["updated_at"] = _now()
+    record.setdefault("events", []).append(
+        {
+            "at": record["updated_at"],
+            "state": "coding",
+            "event": "coding_job_started" if not dry_run else "coding_job_dry_run",
+            "message": f"OpenCode job {job['job_id']} prepared",
+        }
+    )
+    _save_run(record)
+
+    return {
+        "ok": True,
+        "run_id": run_id,
+        "job": _public_job(job),
+        "dry_run": dry_run,
+        "command_preview": _command_preview(cmd),
+    }
+
+
+def _state_dir() -> Path:
+    return Path(os.getenv("NEXUS_N8N_STATE_DIR", "/var/lib/nexus/n8n-state")).expanduser()
+
+
+def _worktree_root() -> Path:
+    return Path(os.getenv("NEXUS_N8N_WORKTREE_DIR", "/var/lib/nexus/n8n-worktrees")).expanduser()
+
+
+def _logs_root() -> Path:
+    return Path(os.getenv("NEXUS_N8N_LOG_DIR", "/var/lib/nexus/logs/n8n")).expanduser()
+
+
+def _run_path(run_id: str) -> Path:
+    clean = _clean_id(run_id)
+    if not clean:
+        raise ValueError("run_id is required")
+    return _state_dir() / f"{clean}.json"
+
+
+def _load_run(run_id: str) -> dict[str, Any]:
+    path = _run_path(run_id)
+    if not path.exists():
+        raise ValueError(f"run not found: {run_id}")
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _save_run(record: dict[str, Any]) -> None:
+    path = _run_path(str(record.get("run_id") or ""))
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = path.with_suffix(".json.tmp")
+    tmp.write_text(json.dumps(record, indent=2, sort_keys=True), encoding="utf-8")
+    tmp.replace(path)
+
+
+def _resolve_repo_dir(payload: dict[str, Any], record: dict[str, Any]) -> Path:
+    explicit = _optional_str(payload.get("repo_dir") or payload.get("repo_path"))
+    if explicit:
+        candidate = Path(explicit).expanduser().resolve()
+    else:
+        project_key = _optional_str(payload.get("project_key")) or _optional_str(
+            record.get("project_key")
+        )
+        if not project_key:
+            raise ValueError("project_key or repo_dir is required")
+        candidate = _repo_dir_for_project(project_key)
+
+    if not (candidate / ".git").exists():
+        raise ValueError(f"repo_dir is not a git repository: {candidate}")
+
+    allowed_roots = _allowed_repo_roots()
+    if not any(_is_relative_to(candidate, root) for root in allowed_roots):
+        raise ValueError(f"repo_dir is not allowlisted: {candidate}")
+    return candidate
+
+
+def _repo_dir_for_project(project_key: str) -> Path:
+    from nexus.core.config import PROJECT_CONFIG
+
+    cfg = PROJECT_CONFIG.get(project_key)
+    if not isinstance(cfg, dict):
+        raise ValueError(f"unknown project_key: {project_key}")
+    workspace = str(cfg.get("workspace") or "").strip()
+    if not workspace:
+        raise ValueError(f"project has no workspace configured: {project_key}")
+    base_dir = Path(os.getenv("BASE_DIR", "/home/ubuntu/git")).expanduser()
+    return (base_dir / workspace).resolve()
+
+
+def _allowed_repo_roots() -> list[Path]:
+    raw = os.getenv("NEXUS_N8N_REPO_ALLOWLIST", "/home/ubuntu/git")
+    roots = [Path(item).expanduser().resolve() for item in raw.split(":") if item.strip()]
+    return roots or [Path("/home/ubuntu/git").resolve()]
+
+
+def _prepare_worktree(*, repo_dir: Path, worktree_dir: Path, branch: str, base_branch: str) -> None:
+    worktree_dir.parent.mkdir(parents=True, exist_ok=True)
+    subprocess.run(["git", "-C", str(repo_dir), "fetch", "origin", base_branch], check=True)
+    if worktree_dir.exists():
+        return
+    subprocess.run(
+        [
+            "git",
+            "-C",
+            str(repo_dir),
+            "worktree",
+            "add",
+            "-B",
+            branch,
+            str(worktree_dir),
+            f"origin/{base_branch}",
+        ],
+        check=True,
+    )
+
+
+def _opencode_command(
+    *,
+    prompt: str,
+    worktree_dir: Path,
+    agent: str,
+    model: str | None,
+) -> list[str]:
+    opencode = os.getenv("NEXUS_OPENCODE_CLI", shutil.which("opencode") or "opencode")
+    cmd = [
+        opencode,
+        "run",
+        "--agent",
+        agent,
+        "--format",
+        "json",
+        "--dir",
+        str(worktree_dir),
+        "--title",
+        "n8n coding task",
+        "--dangerously-skip-permissions",
+    ]
+    if model:
+        cmd.extend(["--model", model])
+    cmd.append(prompt)
+    return cmd
+
+
+def _coding_prompt(*, task: str, run_id: str, project_key: str, issue_number: str) -> str:
+    context = [f"n8n workflow run: {run_id}"]
+    if project_key:
+        context.append(f"project: {project_key}")
+    if issue_number:
+        context.append(f"issue: {issue_number}")
+    return (
+        "You are Atlas, the OpenCode coding worker for a Nexus-controlled n8n state machine.\n"
+        "Work only inside the current git worktree. Make the smallest complete change for the task.\n"
+        "Run relevant tests or checks when possible. Do not push, merge, or create external PRs.\n\n"
+        + "\n".join(context)
+        + "\n\nTask:\n"
+        + task
+    )
+
+
+def _public_run(record: dict[str, Any]) -> dict[str, Any]:
+    result = dict(record)
+    result["coding_jobs"] = [
+        _public_job(job) for job in result.get("coding_jobs", []) if isinstance(job, dict)
+    ]
+    return result
+
+
+def _public_job(job: dict[str, Any]) -> dict[str, Any]:
+    result = dict(job)
+    pid = result.get("pid")
+    if isinstance(pid, int) and pid > 0:
+        result["running"] = _pid_running(pid)
+    return result
+
+
+def _pid_running(pid: int) -> bool:
+    try:
+        os.kill(pid, 0)
+        return True
+    except OSError:
+        return False
+
+
+def _command_preview(cmd: list[str]) -> list[str]:
+    if not cmd:
+        return []
+    preview = list(cmd)
+    if len(preview) > 1:
+        preview[-1] = "<prompt>"
+    return preview
+
+
+def _normalize_state(value: Any) -> str:
+    state = str(value or "").strip().lower().replace("-", "_")
+    if state not in _VALID_STATES:
+        raise ValueError(f"invalid run state: {value}")
+    return state
+
+
+def _safe_branch(value: str) -> str:
+    branch = value.strip().strip("/")
+    if not branch or ".." in branch or branch.startswith("-") or not _BRANCH_RE.match(branch):
+        raise ValueError(f"invalid branch name: {value}")
+    return branch
+
+
+def _clean_id(value: Any) -> str:
+    return re.sub(r"[^A-Za-z0-9_.-]", "-", str(value or "").strip())[:80]
+
+
+def _required_str(payload: dict[str, Any], key: str) -> str:
+    value = str(payload.get(key) or "").strip()
+    if not value:
+        raise ValueError(f"{key} is required")
+    return value
+
+
+def _optional_str(value: Any) -> str | None:
+    text = str(value or "").strip()
+    return text or None
+
+
+def _bool(value: Any) -> bool:
+    if isinstance(value, bool):
+        return value
+    return str(value or "").strip().lower() in {"1", "true", "yes", "on"}
+
+
+def _now() -> str:
+    return time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime())
+
+
+def _is_relative_to(path: Path, root: Path) -> bool:
+    try:
+        path.relative_to(root)
+        return True
+    except ValueError:
+        return False

--- a/tests/test_command_bridge_http.py
+++ b/tests/test_command_bridge_http.py
@@ -78,7 +78,11 @@ class _FakeRouter:
         return {"ok": True, "runtime_mode": "openclaw"}
 
     async def get_doctor(self, **kwargs):
-        return {"ok": True, "scope": "workflow" if kwargs.get("issue_number") else "runtime", **kwargs}
+        return {
+            "ok": True,
+            "scope": "workflow" if kwargs.get("issue_number") else "runtime",
+            **kwargs,
+        }
 
     async def get_active_workflows(self, *, limit: int = 20):
         return {"ok": True, "count": 1, "items": [{"workflow_id": "demo-42-full"}], "limit": limit}
@@ -87,28 +91,65 @@ class _FakeRouter:
         return {"ok": True, "count": 1, "items": [{"workflow_id": "demo-99-full"}], "limit": limit}
 
     async def get_recent_incidents(self, *, limit: int = 20):
-        return {"ok": True, "count": 1, "items": [{"workflow_id": "demo-88-full", "severity": "high"}], "limit": limit}
+        return {
+            "ok": True,
+            "count": 1,
+            "items": [{"workflow_id": "demo-88-full", "severity": "high"}],
+            "limit": limit,
+        }
 
     async def get_git_identity_status(self):
         return {"ok": True, "github": {"installed": True}}
 
     async def get_workflow_summary(self, *, workflow_id=None, issue_number=None):
-        return {"ok": True, "summary": "demo summary", "workflow_id": workflow_id, "issue_number": issue_number}
+        return {
+            "ok": True,
+            "summary": "demo summary",
+            "workflow_id": workflow_id,
+            "issue_number": issue_number,
+        }
 
     async def get_workflow_timeline(self, *, workflow_id=None, issue_number=None):
-        return {"ok": True, "workflow_id": workflow_id, "issue_number": issue_number, "timeline": [{"step_num": 1, "name": "triage"}]}
+        return {
+            "ok": True,
+            "workflow_id": workflow_id,
+            "issue_number": issue_number,
+            "timeline": [{"step_num": 1, "name": "triage"}],
+        }
 
     async def get_workflow_diagnosis(self, *, workflow_id=None, issue_number=None):
-        return {"ok": True, "diagnosis": "agent_running", "likely_cause": "demo cause", "workflow_id": workflow_id, "issue_number": issue_number}
+        return {
+            "ok": True,
+            "diagnosis": "agent_running",
+            "likely_cause": "demo cause",
+            "workflow_id": workflow_id,
+            "issue_number": issue_number,
+        }
 
     async def get_workflow_authorship_audit(self, *, workflow_id=None, issue_number=None):
-        return {"ok": True, "workflow_id": workflow_id, "issue_number": issue_number, "authorship": {"classification": "human_requested"}}
+        return {
+            "ok": True,
+            "workflow_id": workflow_id,
+            "issue_number": issue_number,
+            "authorship": {"classification": "human_requested"},
+        }
 
     async def get_workflow_blockers(self, *, workflow_id=None, issue_number=None):
-        return {"ok": True, "workflow_id": workflow_id, "issue_number": issue_number, "blocking": True, "blockers": [{"type": "approval_required"}]}
+        return {
+            "ok": True,
+            "workflow_id": workflow_id,
+            "issue_number": issue_number,
+            "blocking": True,
+            "blockers": [{"type": "approval_required"}],
+        }
 
     async def get_workflow_logs_context(self, *, workflow_id=None, issue_number=None):
-        return {"ok": True, "workflow_id": workflow_id, "issue_number": issue_number, "log_context": [{"file": "demo.log", "lines": ["hello"]}]}
+        return {
+            "ok": True,
+            "workflow_id": workflow_id,
+            "issue_number": issue_number,
+            "log_context": [{"file": "demo.log", "lines": ["hello"]}],
+        }
 
     async def explain_routing(self, **kwargs):
         return {"ok": True, **kwargs}
@@ -137,11 +178,17 @@ class _FakeRouter:
             "cancel": "cancel",
             "refresh_state": "refresh_state",
         }.get(action, "ack")
-        message = "Reply received" if action_name == "ack" else f"Reply action '{action_name}' accepted"
+        message = (
+            "Reply received" if action_name == "ack" else f"Reply action '{action_name}' accepted"
+        )
         return CommandResult(
             status="success",
             message=message,
-            data={"correlation_id": reply.correlation_id, "received": True, "reply_action": action_name},
+            data={
+                "correlation_id": reply.correlation_id,
+                "received": True,
+                "reply_action": action_name,
+            },
         )
 
 
@@ -254,6 +301,93 @@ def test_execute_returns_accepted_response():
     assert status.startswith("202")
     assert payload["workflow_id"] == "demo-42-full"
     assert payload["status"] == "accepted"
+
+
+def test_n8n_run_lifecycle_requires_auth_and_persists_state(tmp_path, monkeypatch):
+    monkeypatch.setenv("NEXUS_N8N_STATE_DIR", str(tmp_path / "state"))
+    app = create_command_bridge_app(
+        _FakeRouter(),
+        config=CommandBridgeConfig(auth_token="secret"),
+    )
+
+    unauthorized_status, unauthorized_payload = _call_app(
+        app,
+        method="POST",
+        path="/api/v1/n8n/runs",
+        payload={"run_id": "demo-run", "task": "ship the bridge"},
+    )
+    create_status, create_payload = _call_app(
+        app,
+        method="POST",
+        path="/api/v1/n8n/runs",
+        auth="Bearer secret",
+        payload={"run_id": "demo-run", "task": "ship the bridge", "project_key": "nexus"},
+    )
+    update_status, update_payload = _call_app(
+        app,
+        method="POST",
+        path="/api/v1/n8n/runs/update",
+        auth="Bearer secret",
+        payload={"run_id": "demo-run", "state": "approved", "message": "Gab approved"},
+    )
+    get_status, get_payload = _call_app(
+        app,
+        method="GET",
+        path="/api/v1/n8n/runs/demo-run",
+        auth="Bearer secret",
+    )
+
+    assert unauthorized_status.startswith("401")
+    assert unauthorized_payload["error_code"] == "missing_bearer_token"
+    assert create_status.startswith("201")
+    assert create_payload["run"]["state"] == "queued"
+    assert update_status.startswith("200")
+    assert update_payload["run"]["state"] == "approved"
+    assert get_status.startswith("200")
+    assert get_payload["run"]["events"][-1]["message"] == "Gab approved"
+
+
+def test_n8n_coding_execute_prepares_opencode_dry_run(tmp_path, monkeypatch):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / ".git").mkdir()
+    monkeypatch.setenv("NEXUS_N8N_STATE_DIR", str(tmp_path / "state"))
+    monkeypatch.setenv("NEXUS_N8N_WORKTREE_DIR", str(tmp_path / "worktrees"))
+    monkeypatch.setenv("NEXUS_N8N_LOG_DIR", str(tmp_path / "logs"))
+    monkeypatch.setenv("NEXUS_N8N_REPO_ALLOWLIST", str(tmp_path))
+    monkeypatch.setenv("NEXUS_OPENCODE_CLI", "/usr/bin/opencode")
+    app = create_command_bridge_app(
+        _FakeRouter(),
+        config=CommandBridgeConfig(auth_token="secret"),
+    )
+    _call_app(
+        app,
+        method="POST",
+        path="/api/v1/n8n/runs",
+        auth="Bearer secret",
+        payload={"run_id": "demo-run", "task": "implement the task"},
+    )
+
+    status, payload = _call_app(
+        app,
+        method="POST",
+        path="/api/v1/n8n/coding/execute",
+        auth="Bearer secret",
+        payload={
+            "run_id": "demo-run",
+            "task": "add a small feature",
+            "repo_dir": str(repo),
+            "dry_run": True,
+        },
+    )
+
+    assert status.startswith("202")
+    assert payload["ok"] is True
+    assert payload["dry_run"] is True
+    assert payload["job"]["worker"] == "opencode"
+    assert payload["job"]["state"] == "dry_run"
+    assert payload["job"]["worktree_dir"].endswith("demo-run/repo")
+    assert payload["command_preview"][-1] == "<prompt>"
 
 
 def test_execute_rejects_sender_allowlist_with_structured_error():
@@ -427,6 +561,7 @@ def test_replay_protection_rejects_duplicate_nonce():
     )
 
     import uuid
+
     fresh_ts = str(time.time())
     nonce = f"unique-nonce-{uuid.uuid4().hex}"
 


### PR DESCRIPTION
## Summary
- add authenticated n8n run state endpoints on the Nexus command bridge
- add controlled OpenCode execution endpoint with repo allowlist and isolated git worktrees
- document the n8n/Nexus/OpenCode split and include an importable n8n starter workflow

## Verification
- /home/ubuntu/git/ghabs/nexus-arc/venv/bin/python -m pytest -q -o addopts='' tests/test_command_bridge_http.py
- /home/ubuntu/git/ghabs/nexus-arc/venv/bin/ruff check nexus/core/command_bridge/n8n_state_machine.py nexus/core/command_bridge/http.py tests/test_command_bridge_http.py
- python3 -m json.tool examples/n8n/openclaw-opencode-state-machine.json >/dev/null