### PR TITLE
feat: add Nexus workflow to n8n converter

### DIFF
--- a/examples/workflows/README.md
+++ b/examples/workflows/README.md
@@ -76,3 +76,16 @@ marketing = WorkflowDefinition.from_yaml("social_media_marketing_workflow.yaml")
 ## Creating Your Own Workflow
 
 See `examples/README.md` for instructions on defining agents and workflows.
+
+## n8n Workflow Templates
+
+Importable n8n equivalents are generated under `examples/workflows/n8n/`.
+They keep n8n as the state machine and call the Nexus command bridge for state
+updates and guarded OpenCode execution on developer steps.
+
+Regenerate them after changing workflow YAML:
+
+```bash
+nexus translate to-n8n examples/workflows/enterprise_full_workflow.yaml \
+  -o examples/workflows/n8n/enterprise_full_workflow.json
+```

--- a/examples/workflows/n8n/development_fast_track_workflow.json
+++ b/examples/workflows/n8n/development_fast_track_workflow.json
@@ -1,0 +1,445 @@
+{
+  "name": "Development Fast-Track Workflow",
+  "nodes": [
+    {
+      "parameters": {},
+      "id": "manual-trigger",
+      "name": "Manual Trigger",
+      "type": "n8n-nodes-base.manualTrigger",
+      "typeVersion": 1,
+      "position": [
+        0,
+        0
+      ]
+    },
+    {
+      "parameters": {
+        "method": "POST",
+        "url": "http://nexus-bridge-1:8091/api/v1/n8n/runs",
+        "authentication": "predefinedCredentialType",
+        "nodeCredentialType": "httpBearerAuth",
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "{\n  \"task\": \"={{$json.task || $json.title || 'Run Nexus workflow'}}\",\n  \"project_key\": \"={{$json.project_key || $json.project || 'nexus'}}\",\n  \"issue_number\": \"={{$json.issue_number || $json.issue || ''}}\",\n  \"requester\": {\n    \"source\": \"n8n\",\n    \"workflow\": \"Development Fast-Track Workflow\"\n  },\n  \"metadata\": {\n    \"nexus_workflow\": {\n      \"name\": \"Development Fast-Track Workflow\",\n      \"description\": \"Critical path for urgent fixes with minimal stages.\",\n      \"version\": \"0.1.0\"\n    },\n    \"workflow_type\": \"fast-track\",\n    \"source\": \"examples/workflows/development_fast_track_workflow.yaml\"\n  }\n}"
+      },
+      "id": "create-nexus-run",
+      "name": "Create Nexus Run",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [
+        260,
+        0
+      ],
+      "notesInFlow": true,
+      "notes": "Creates the durable Nexus run that n8n will advance."
+    },
+    {
+      "parameters": {
+        "method": "POST",
+        "url": "http://nexus-bridge-1:8091/api/v1/n8n/runs/update",
+        "authentication": "predefinedCredentialType",
+        "nodeCredentialType": "httpBearerAuth",
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "{\n  \"run_id\": \"={{$json.run?.run_id || $json.run_id}}\",\n  \"state\": \"triage\",\n  \"message\": \"Starting Nexus step triage\",\n  \"data\": {\n    \"step\": {\n      \"id\": \"triage\",\n      \"index\": 1,\n      \"name\": \"Emergency Triage\",\n      \"description\": \"Rapid assessment of urgency and blast radius\",\n      \"agent_type\": \"triage\",\n      \"context_policy\": \"minimal\",\n      \"tools\": [\n        \"vcs:read_issue\",\n        \"vcs:add_label\",\n        \"vcs:add_comment\"\n      ],\n      \"inputs\": [\n        {\n          \"issue_url\": \"string\"\n        }\n      ],\n      \"outputs\": [\n        {\n          \"urgency\": \"enum[critical|urgent]\"\n        },\n        {\n          \"impact\": \"string\"\n        }\n      ],\n      \"on_success\": \"develop\"\n    }\n  }\n}"
+      },
+      "id": "start-triage",
+      "name": "01 Start triage",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [
+        560,
+        0
+      ],
+      "notesInFlow": true,
+      "notes": "Rapid assessment of urgency and blast radius"
+    },
+    {
+      "parameters": {
+        "method": "POST",
+        "url": "http://nexus-bridge-1:8091/api/v1/n8n/runs/update",
+        "authentication": "predefinedCredentialType",
+        "nodeCredentialType": "httpBearerAuth",
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "{\n  \"run_id\": \"={{$json.run?.run_id || $json.run_id}}\",\n  \"state\": \"triage_completed\",\n  \"message\": \"Completed Nexus step triage\",\n  \"data\": {\n    \"step\": {\n      \"id\": \"triage\",\n      \"name\": \"Emergency Triage\",\n      \"description\": \"Rapid assessment of urgency and blast radius\",\n      \"agent_type\": \"triage\",\n      \"context_policy\": \"minimal\",\n      \"tools\": [\n        \"vcs:read_issue\",\n        \"vcs:add_label\",\n        \"vcs:add_comment\"\n      ],\n      \"inputs\": [\n        {\n          \"issue_url\": \"string\"\n        }\n      ],\n      \"outputs\": [\n        {\n          \"urgency\": \"enum[critical|urgent]\"\n        },\n        {\n          \"impact\": \"string\"\n        }\n      ],\n      \"on_success\": \"develop\"\n    }\n  }\n}"
+      },
+      "id": "complete-triage",
+      "name": "Complete triage",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [
+        780,
+        0
+      ],
+      "notesInFlow": true,
+      "notes": "Replace this state transition with a concrete agent/tool call when available."
+    },
+    {
+      "parameters": {
+        "method": "POST",
+        "url": "http://nexus-bridge-1:8091/api/v1/n8n/runs/update",
+        "authentication": "predefinedCredentialType",
+        "nodeCredentialType": "httpBearerAuth",
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "{\n  \"run_id\": \"={{$json.run?.run_id || $json.run_id}}\",\n  \"state\": \"develop\",\n  \"message\": \"Starting Nexus step develop\",\n  \"data\": {\n    \"step\": {\n      \"id\": \"develop\",\n      \"index\": 2,\n      \"name\": \"Fast-Track Implementation\",\n      \"description\": \"Implement minimal safe fix\",\n      \"agent_type\": \"developer\",\n      \"context_policy\": \"deep\",\n      \"tools\": [\n        \"vcs:create_branch\",\n        \"vcs:edit_file\",\n        \"vcs:create_pr\",\n        \"vcs:add_comment\"\n      ],\n      \"inputs\": [\n        {\n          \"issue_url\": \"string\"\n        }\n      ],\n      \"outputs\": [\n        {\n          \"pr_url\": \"string\"\n        },\n        {\n          \"rollback_plan\": \"string\"\n        }\n      ],\n      \"on_success\": \"review\",\n      \"audit_limit\": 50,\n      \"include_audit_history\": true\n    }\n  }\n}"
+      },
+      "id": "start-develop",
+      "name": "02 Start develop",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [
+        920,
+        120
+      ],
+      "notesInFlow": true,
+      "notes": "Implement minimal safe fix"
+    },
+    {
+      "parameters": {
+        "method": "POST",
+        "url": "http://nexus-bridge-1:8091/api/v1/n8n/coding/execute",
+        "authentication": "predefinedCredentialType",
+        "nodeCredentialType": "httpBearerAuth",
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "{\n  \"run_id\": \"={{$json.run?.run_id || $json.run_id}}\",\n  \"task\": \"={{$json.task || $json.run?.task || \\\"Implement minimal safe fix\\\"}}\",\n  \"project_key\": \"={{$json.project_key || $json.run?.project_key || 'nexus'}}\",\n  \"worker\": \"opencode\",\n  \"agent\": \"build\",\n  \"base_branch\": \"develop\",\n  \"metadata\": {\n    \"step\": {\n      \"id\": \"develop\",\n      \"name\": \"Fast-Track Implementation\",\n      \"description\": \"Implement minimal safe fix\",\n      \"agent_type\": \"developer\",\n      \"context_policy\": \"deep\",\n      \"tools\": [\n        \"vcs:create_branch\",\n        \"vcs:edit_file\",\n        \"vcs:create_pr\",\n        \"vcs:add_comment\"\n      ],\n      \"inputs\": [\n        {\n          \"issue_url\": \"string\"\n        }\n      ],\n      \"outputs\": [\n        {\n          \"pr_url\": \"string\"\n        },\n        {\n          \"rollback_plan\": \"string\"\n        }\n      ],\n      \"on_success\": \"review\",\n      \"audit_limit\": 50,\n      \"include_audit_history\": true\n    }\n  }\n}"
+      },
+      "id": "execute-opencode-develop",
+      "name": "Execute OpenCode develop",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [
+        1140,
+        120
+      ],
+      "notesInFlow": true,
+      "notes": "Guarded Nexus endpoint: allowlist, isolated worktree, no push/merge/PR."
+    },
+    {
+      "parameters": {
+        "method": "POST",
+        "url": "http://nexus-bridge-1:8091/api/v1/n8n/runs/update",
+        "authentication": "predefinedCredentialType",
+        "nodeCredentialType": "httpBearerAuth",
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "{\n  \"run_id\": \"={{$json.run?.run_id || $json.run_id}}\",\n  \"state\": \"review\",\n  \"message\": \"Starting Nexus step review\",\n  \"data\": {\n    \"step\": {\n      \"id\": \"review\",\n      \"index\": 3,\n      \"name\": \"Quick Verification\",\n      \"description\": \"Fast review with full CI/regression requirement\",\n      \"agent_type\": \"reviewer\",\n      \"context_policy\": \"standard\",\n      \"tools\": [\n        \"vcs:review_pr\",\n        \"vcs:approve_pr\",\n        \"vcs:request_changes\"\n      ],\n      \"inputs\": [\n        {\n          \"pr_urls\": \"list[string]\"\n        }\n      ],\n      \"outputs\": [\n        {\n          \"approval_status\": \"enum[approved|rejected]\"\n        }\n      ],\n      \"on_success\": \"route_review\"\n    }\n  }\n}"
+      },
+      "id": "start-review",
+      "name": "03 Start review",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [
+        1280,
+        0
+      ],
+      "notesInFlow": true,
+      "notes": "Fast review with full CI/regression requirement"
+    },
+    {
+      "parameters": {
+        "method": "POST",
+        "url": "http://nexus-bridge-1:8091/api/v1/n8n/runs/update",
+        "authentication": "predefinedCredentialType",
+        "nodeCredentialType": "httpBearerAuth",
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "{\n  \"run_id\": \"={{$json.run?.run_id || $json.run_id}}\",\n  \"state\": \"review_completed\",\n  \"message\": \"Completed Nexus step review\",\n  \"data\": {\n    \"step\": {\n      \"id\": \"review\",\n      \"name\": \"Quick Verification\",\n      \"description\": \"Fast review with full CI/regression requirement\",\n      \"agent_type\": \"reviewer\",\n      \"context_policy\": \"standard\",\n      \"tools\": [\n        \"vcs:review_pr\",\n        \"vcs:approve_pr\",\n        \"vcs:request_changes\"\n      ],\n      \"inputs\": [\n        {\n          \"pr_urls\": \"list[string]\"\n        }\n      ],\n      \"outputs\": [\n        {\n          \"approval_status\": \"enum[approved|rejected]\"\n        }\n      ],\n      \"on_success\": \"route_review\"\n    }\n  }\n}"
+      },
+      "id": "complete-review",
+      "name": "Complete review",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [
+        1500,
+        0
+      ],
+      "notesInFlow": true,
+      "notes": "Replace this state transition with a concrete agent/tool call when available."
+    },
+    {
+      "parameters": {
+        "method": "POST",
+        "url": "http://nexus-bridge-1:8091/api/v1/n8n/runs/update",
+        "authentication": "predefinedCredentialType",
+        "nodeCredentialType": "httpBearerAuth",
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "{\n  \"run_id\": \"={{$json.run?.run_id || $json.run_id}}\",\n  \"state\": \"route_review\",\n  \"message\": \"Starting Nexus step route_review\",\n  \"data\": {\n    \"step\": {\n      \"id\": \"route_review\",\n      \"index\": 4,\n      \"name\": \"Route After Verification\",\n      \"agent_type\": \"router\",\n      \"context_policy\": \"minimal\",\n      \"routes\": [\n        {\n          \"when\": \"approval_status == 'approved'\",\n          \"then\": \"close_loop\"\n        },\n        {\n          \"default\": \"develop\"\n        }\n      ]\n    }\n  }\n}"
+      },
+      "id": "start-route_review",
+      "name": "04 Start route_review",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [
+        1640,
+        260
+      ]
+    },
+    {
+      "parameters": {
+        "jsCode": "const routes = [\n  {\n    \"when\": \"approval_status == 'approved'\",\n    \"then\": \"close_loop\"\n  },\n  {\n    \"default\": \"develop\"\n  }\n];\nconst state = $json;\n\nfunction toJsExpression(expr) {\n  return String(expr)\n    .replace(/\\band\\b/g, '&&')\n    .replace(/\\bor\\b/g, '||')\n    .replace(/\\bnot\\b/g, '!')\n    .replace(/\\bTrue\\b/g, 'true')\n    .replace(/\\bFalse\\b/g, 'false')\n    .replace(/\\bNone\\b/g, 'null');\n}\n\nfunction evaluate(expr) {\n  const keys = Object.keys(state);\n  const values = Object.values(state);\n  try {\n    return Boolean(Function(...keys, `return (${toJsExpression(expr)});`)(...values));\n  } catch (error) {\n    return false;\n  }\n}\n\nlet nextStep = null;\nfor (const route of routes) {\n  if (route.when && evaluate(route.when)) {\n    nextStep = route.then;\n    break;\n  }\n  if (!route.when && route.default && nextStep === null) {\n    nextStep = route.default;\n  }\n}\n\nreturn [{ json: { ...state, next_step: nextStep } }];\n"
+      },
+      "id": "route-route_review",
+      "name": "Route route_review",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [
+        1860,
+        260
+      ],
+      "notesInFlow": true,
+      "notes": "Evaluates Nexus route rules and writes next_step."
+    },
+    {
+      "parameters": {
+        "method": "POST",
+        "url": "http://nexus-bridge-1:8091/api/v1/n8n/runs/update",
+        "authentication": "predefinedCredentialType",
+        "nodeCredentialType": "httpBearerAuth",
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "{\n  \"run_id\": \"={{$json.run?.run_id || $json.run_id}}\",\n  \"state\": \"close_loop\",\n  \"message\": \"Starting Nexus step close_loop\",\n  \"data\": {\n    \"step\": {\n      \"id\": \"close_loop\",\n      \"index\": 5,\n      \"name\": \"Summarize & Close\",\n      \"description\": \"Post fast-track summary\",\n      \"agent_type\": \"summarizer\",\n      \"context_policy\": \"standard\",\n      \"tools\": [\n        \"vcs:add_comment\"\n      ],\n      \"inputs\": [\n        {\n          \"issue_url\": \"string\"\n        }\n      ],\n      \"outputs\": [\n        {\n          \"summary\": \"string\"\n        }\n      ],\n      \"final_step\": true,\n      \"audit_limit\": 10\n    }\n  }\n}"
+      },
+      "id": "start-close_loop",
+      "name": "05 Start close_loop",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [
+        2000,
+        0
+      ],
+      "notesInFlow": true,
+      "notes": "Post fast-track summary"
+    },
+    {
+      "parameters": {
+        "method": "POST",
+        "url": "http://nexus-bridge-1:8091/api/v1/n8n/runs/update",
+        "authentication": "predefinedCredentialType",
+        "nodeCredentialType": "httpBearerAuth",
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "{\n  \"run_id\": \"={{$json.run?.run_id || $json.run_id}}\",\n  \"state\": \"close_loop_completed\",\n  \"message\": \"Completed Nexus step close_loop\",\n  \"data\": {\n    \"step\": {\n      \"id\": \"close_loop\",\n      \"name\": \"Summarize & Close\",\n      \"description\": \"Post fast-track summary\",\n      \"agent_type\": \"summarizer\",\n      \"context_policy\": \"standard\",\n      \"tools\": [\n        \"vcs:add_comment\"\n      ],\n      \"inputs\": [\n        {\n          \"issue_url\": \"string\"\n        }\n      ],\n      \"outputs\": [\n        {\n          \"summary\": \"string\"\n        }\n      ],\n      \"final_step\": true,\n      \"audit_limit\": 10\n    }\n  }\n}"
+      },
+      "id": "complete-close_loop",
+      "name": "Complete close_loop",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [
+        2220,
+        0
+      ],
+      "notesInFlow": true,
+      "notes": "Replace this state transition with a concrete agent/tool call when available."
+    },
+    {
+      "parameters": {
+        "mode": "rules",
+        "rules": {
+          "values": [
+            {
+              "conditions": {
+                "conditions": [
+                  {
+                    "leftValue": "={{$json.next_step}}",
+                    "rightValue": "close_loop",
+                    "operator": {
+                      "type": "string",
+                      "operation": "equals"
+                    }
+                  }
+                ],
+                "combinator": "and"
+              }
+            },
+            {
+              "conditions": {
+                "conditions": [
+                  {
+                    "leftValue": "={{$json.next_step}}",
+                    "rightValue": "develop",
+                    "operator": {
+                      "type": "string",
+                      "operation": "equals"
+                    }
+                  }
+                ],
+                "combinator": "and"
+              }
+            }
+          ]
+        },
+        "options": {}
+      },
+      "id": "switch-switch-route_review",
+      "name": "Switch route_review",
+      "type": "n8n-nodes-base.switch",
+      "typeVersion": 3,
+      "position": [
+        2080,
+        260
+      ],
+      "notesInFlow": true,
+      "notes": "Routes to the Nexus step selected by the preceding Code node."
+    }
+  ],
+  "connections": {
+    "01 Start triage": {
+      "main": [
+        [
+          {
+            "node": "Complete triage",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "02 Start develop": {
+      "main": [
+        [
+          {
+            "node": "Execute OpenCode develop",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "03 Start review": {
+      "main": [
+        [
+          {
+            "node": "Complete review",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "04 Start route_review": {
+      "main": [
+        [
+          {
+            "node": "Route route_review",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "05 Start close_loop": {
+      "main": [
+        [
+          {
+            "node": "Complete close_loop",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Create Nexus Run": {
+      "main": [
+        [
+          {
+            "node": "01 Start triage",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Manual Trigger": {
+      "main": [
+        [
+          {
+            "node": "Create Nexus Run",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Complete triage": {
+      "main": [
+        [
+          {
+            "node": "02 Start develop",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Execute OpenCode develop": {
+      "main": [
+        [
+          {
+            "node": "03 Start review",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Complete review": {
+      "main": [
+        [
+          {
+            "node": "04 Start route_review",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Route route_review": {
+      "main": [
+        [
+          {
+            "node": "Switch route_review",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Switch route_review": {
+      "main": [
+        [
+          {
+            "node": "05 Start close_loop",
+            "type": "main",
+            "index": 0
+          }
+        ],
+        [
+          {
+            "node": "02 Start develop",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    }
+  },
+  "settings": {
+    "executionOrder": "v1"
+  },
+  "staticData": null,
+  "tags": [
+    "nexus-arc",
+    "generated"
+  ],
+  "meta": {
+    "nexusArc": {
+      "source": "examples/workflows/development_fast_track_workflow.yaml",
+      "workflowType": "fast-track",
+      "converter": "nexus.translators.to_n8n"
+    }
+  }
+}

--- a/examples/workflows/n8n/development_full_workflow.json
+++ b/examples/workflows/n8n/development_full_workflow.json
@@ -1,0 +1,807 @@
+{
+  "name": "Development Full Workflow",
+  "nodes": [
+    {
+      "parameters": {},
+      "id": "manual-trigger",
+      "name": "Manual Trigger",
+      "type": "n8n-nodes-base.manualTrigger",
+      "typeVersion": 1,
+      "position": [
+        0,
+        0
+      ]
+    },
+    {
+      "parameters": {
+        "method": "POST",
+        "url": "http://nexus-bridge-1:8091/api/v1/n8n/runs",
+        "authentication": "predefinedCredentialType",
+        "nodeCredentialType": "httpBearerAuth",
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "{\n  \"task\": \"={{$json.task || $json.title || 'Run Nexus workflow'}}\",\n  \"project_key\": \"={{$json.project_key || $json.project || 'nexus'}}\",\n  \"issue_number\": \"={{$json.issue_number || $json.issue || ''}}\",\n  \"requester\": {\n    \"source\": \"n8n\",\n    \"workflow\": \"Development Full Workflow\"\n  },\n  \"metadata\": {\n    \"nexus_workflow\": {\n      \"name\": \"Development Full Workflow\",\n      \"description\": \"Multi-agent workflow for processing feature requests and bug reports.\",\n      \"version\": \"0.1.0\"\n    },\n    \"workflow_type\": \"full\",\n    \"source\": \"examples/workflows/development_full_workflow.yaml\"\n  }\n}"
+      },
+      "id": "create-nexus-run",
+      "name": "Create Nexus Run",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [
+        260,
+        0
+      ],
+      "notesInFlow": true,
+      "notes": "Creates the durable Nexus run that n8n will advance."
+    },
+    {
+      "parameters": {
+        "method": "POST",
+        "url": "http://nexus-bridge-1:8091/api/v1/n8n/runs/update",
+        "authentication": "predefinedCredentialType",
+        "nodeCredentialType": "httpBearerAuth",
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "{\n  \"run_id\": \"={{$json.run?.run_id || $json.run_id}}\",\n  \"state\": \"triage\",\n  \"message\": \"Starting Nexus step triage\",\n  \"data\": {\n    \"step\": {\n      \"id\": \"triage\",\n      \"index\": 1,\n      \"name\": \"Initial Routing\",\n      \"description\": \"Analyze issue and classify as bug/feature/doc, suggest priority\",\n      \"agent_type\": \"triage\",\n      \"context_policy\": \"minimal\",\n      \"tools\": [\n        \"vcs:read_issue\",\n        \"vcs:add_comment\",\n        \"vcs:add_label\"\n      ],\n      \"inputs\": [\n        {\n          \"issue_url\": \"string\"\n        }\n      ],\n      \"outputs\": [\n        {\n          \"classification\": \"enum[bug|feature|doc|support]\"\n        },\n        {\n          \"priority\": \"enum[p0-critical|p1-high|p2-medium|p3-low]\"\n        },\n        {\n          \"recommended_assignee\": \"string\"\n        }\n      ],\n      \"on_success\": \"route_by_type\",\n      \"include_audit_history\": false\n    }\n  }\n}"
+      },
+      "id": "start-triage",
+      "name": "01 Start triage",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [
+        560,
+        0
+      ],
+      "notesInFlow": true,
+      "notes": "Analyze issue and classify as bug/feature/doc, suggest priority"
+    },
+    {
+      "parameters": {
+        "method": "POST",
+        "url": "http://nexus-bridge-1:8091/api/v1/n8n/runs/update",
+        "authentication": "predefinedCredentialType",
+        "nodeCredentialType": "httpBearerAuth",
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "{\n  \"run_id\": \"={{$json.run?.run_id || $json.run_id}}\",\n  \"state\": \"triage_completed\",\n  \"message\": \"Completed Nexus step triage\",\n  \"data\": {\n    \"step\": {\n      \"id\": \"triage\",\n      \"name\": \"Initial Routing\",\n      \"description\": \"Analyze issue and classify as bug/feature/doc, suggest priority\",\n      \"agent_type\": \"triage\",\n      \"context_policy\": \"minimal\",\n      \"tools\": [\n        \"vcs:read_issue\",\n        \"vcs:add_comment\",\n        \"vcs:add_label\"\n      ],\n      \"inputs\": [\n        {\n          \"issue_url\": \"string\"\n        }\n      ],\n      \"outputs\": [\n        {\n          \"classification\": \"enum[bug|feature|doc|support]\"\n        },\n        {\n          \"priority\": \"enum[p0-critical|p1-high|p2-medium|p3-low]\"\n        },\n        {\n          \"recommended_assignee\": \"string\"\n        }\n      ],\n      \"on_success\": \"route_by_type\",\n      \"include_audit_history\": false\n    }\n  }\n}"
+      },
+      "id": "complete-triage",
+      "name": "Complete triage",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [
+        780,
+        0
+      ],
+      "notesInFlow": true,
+      "notes": "Replace this state transition with a concrete agent/tool call when available."
+    },
+    {
+      "parameters": {
+        "method": "POST",
+        "url": "http://nexus-bridge-1:8091/api/v1/n8n/runs/update",
+        "authentication": "predefinedCredentialType",
+        "nodeCredentialType": "httpBearerAuth",
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "{\n  \"run_id\": \"={{$json.run?.run_id || $json.run_id}}\",\n  \"state\": \"route_by_type\",\n  \"message\": \"Starting Nexus step route_by_type\",\n  \"data\": {\n    \"step\": {\n      \"id\": \"route_by_type\",\n      \"index\": 2,\n      \"name\": \"Route to Specialist\",\n      \"description\": \"Conditional routing based on issue type\",\n      \"agent_type\": \"router\",\n      \"context_policy\": \"minimal\",\n      \"routes\": [\n        {\n          \"when\": \"classification == 'feature'\",\n          \"then\": \"design\"\n        },\n        {\n          \"when\": \"classification == 'bug'\",\n          \"then\": \"debug\"\n        },\n        {\n          \"when\": \"classification == 'doc'\",\n          \"then\": \"docs_update\"\n        },\n        {\n          \"default\": \"close_loop\"\n        }\n      ]\n    }\n  }\n}"
+      },
+      "id": "start-route_by_type",
+      "name": "02 Start route_by_type",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [
+        920,
+        260
+      ],
+      "notesInFlow": true,
+      "notes": "Conditional routing based on issue type"
+    },
+    {
+      "parameters": {
+        "jsCode": "const routes = [\n  {\n    \"when\": \"classification == 'feature'\",\n    \"then\": \"design\"\n  },\n  {\n    \"when\": \"classification == 'bug'\",\n    \"then\": \"debug\"\n  },\n  {\n    \"when\": \"classification == 'doc'\",\n    \"then\": \"docs_update\"\n  },\n  {\n    \"default\": \"close_loop\"\n  }\n];\nconst state = $json;\n\nfunction toJsExpression(expr) {\n  return String(expr)\n    .replace(/\\band\\b/g, '&&')\n    .replace(/\\bor\\b/g, '||')\n    .replace(/\\bnot\\b/g, '!')\n    .replace(/\\bTrue\\b/g, 'true')\n    .replace(/\\bFalse\\b/g, 'false')\n    .replace(/\\bNone\\b/g, 'null');\n}\n\nfunction evaluate(expr) {\n  const keys = Object.keys(state);\n  const values = Object.values(state);\n  try {\n    return Boolean(Function(...keys, `return (${toJsExpression(expr)});`)(...values));\n  } catch (error) {\n    return false;\n  }\n}\n\nlet nextStep = null;\nfor (const route of routes) {\n  if (route.when && evaluate(route.when)) {\n    nextStep = route.then;\n    break;\n  }\n  if (!route.when && route.default && nextStep === null) {\n    nextStep = route.default;\n  }\n}\n\nreturn [{ json: { ...state, next_step: nextStep } }];\n"
+      },
+      "id": "route-route_by_type",
+      "name": "Route route_by_type",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [
+        1140,
+        260
+      ],
+      "notesInFlow": true,
+      "notes": "Evaluates Nexus route rules and writes next_step."
+    },
+    {
+      "parameters": {
+        "method": "POST",
+        "url": "http://nexus-bridge-1:8091/api/v1/n8n/runs/update",
+        "authentication": "predefinedCredentialType",
+        "nodeCredentialType": "httpBearerAuth",
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "{\n  \"run_id\": \"={{$json.run?.run_id || $json.run_id}}\",\n  \"state\": \"design\",\n  \"message\": \"Starting Nexus step design\",\n  \"data\": {\n    \"step\": {\n      \"id\": \"design\",\n      \"index\": 3,\n      \"name\": \"Create Design Proposal\",\n      \"description\": \"For feature requests: create design doc in PR\",\n      \"agent_type\": \"design\",\n      \"context_policy\": \"standard\",\n      \"tools\": [\n        \"vcs:create_branch\",\n        \"vcs:create_file\",\n        \"vcs:create_pr\",\n        \"vcs:add_comment\"\n      ],\n      \"inputs\": [\n        {\n          \"issue_url\": \"string\"\n        },\n        {\n          \"feature_description\": \"string\"\n        },\n        {\n          \"scope\": \"enum[small|medium|large]\"\n        }\n      ],\n      \"outputs\": [\n        {\n          \"design_pr_url\": \"string\"\n        },\n        {\n          \"estimated_effort\": \"string\"\n        }\n      ],\n      \"on_success\": \"develop\"\n    }\n  }\n}"
+      },
+      "id": "start-design",
+      "name": "03 Start design",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [
+        1280,
+        0
+      ],
+      "notesInFlow": true,
+      "notes": "For feature requests: create design doc in PR"
+    },
+    {
+      "parameters": {
+        "method": "POST",
+        "url": "http://nexus-bridge-1:8091/api/v1/n8n/runs/update",
+        "authentication": "predefinedCredentialType",
+        "nodeCredentialType": "httpBearerAuth",
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "{\n  \"run_id\": \"={{$json.run?.run_id || $json.run_id}}\",\n  \"state\": \"design_completed\",\n  \"message\": \"Completed Nexus step design\",\n  \"data\": {\n    \"step\": {\n      \"id\": \"design\",\n      \"name\": \"Create Design Proposal\",\n      \"description\": \"For feature requests: create design doc in PR\",\n      \"agent_type\": \"design\",\n      \"context_policy\": \"standard\",\n      \"tools\": [\n        \"vcs:create_branch\",\n        \"vcs:create_file\",\n        \"vcs:create_pr\",\n        \"vcs:add_comment\"\n      ],\n      \"inputs\": [\n        {\n          \"issue_url\": \"string\"\n        },\n        {\n          \"feature_description\": \"string\"\n        },\n        {\n          \"scope\": \"enum[small|medium|large]\"\n        }\n      ],\n      \"outputs\": [\n        {\n          \"design_pr_url\": \"string\"\n        },\n        {\n          \"estimated_effort\": \"string\"\n        }\n      ],\n      \"on_success\": \"develop\"\n    }\n  }\n}"
+      },
+      "id": "complete-design",
+      "name": "Complete design",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [
+        1500,
+        0
+      ],
+      "notesInFlow": true,
+      "notes": "Replace this state transition with a concrete agent/tool call when available."
+    },
+    {
+      "parameters": {
+        "method": "POST",
+        "url": "http://nexus-bridge-1:8091/api/v1/n8n/runs/update",
+        "authentication": "predefinedCredentialType",
+        "nodeCredentialType": "httpBearerAuth",
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "{\n  \"run_id\": \"={{$json.run?.run_id || $json.run_id}}\",\n  \"state\": \"debug\",\n  \"message\": \"Starting Nexus step debug\",\n  \"data\": {\n    \"step\": {\n      \"id\": \"debug\",\n      \"index\": 4,\n      \"name\": \"Debug & Root Cause Analysis\",\n      \"description\": \"Identify root cause, reproduction steps, and propose fix architecture\",\n      \"agent_type\": \"debug\",\n      \"context_policy\": \"standard\",\n      \"tools\": [\n        \"vcs:add_comment\",\n        \"vcs:search_codebase\",\n        \"vcs:add_label\"\n      ],\n      \"inputs\": [\n        {\n          \"issue_url\": \"string\"\n        }\n      ],\n      \"outputs\": [\n        {\n          \"suspected_cause\": \"string\"\n        },\n        {\n          \"reproduction_steps\": \"string\"\n        },\n        {\n          \"affected_versions\": \"list[string]\"\n        }\n      ],\n      \"on_success\": \"develop\"\n    }\n  }\n}"
+      },
+      "id": "start-debug",
+      "name": "04 Start debug",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [
+        1640,
+        120
+      ],
+      "notesInFlow": true,
+      "notes": "Identify root cause, reproduction steps, and propose fix architecture"
+    },
+    {
+      "parameters": {
+        "method": "POST",
+        "url": "http://nexus-bridge-1:8091/api/v1/n8n/runs/update",
+        "authentication": "predefinedCredentialType",
+        "nodeCredentialType": "httpBearerAuth",
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "{\n  \"run_id\": \"={{$json.run?.run_id || $json.run_id}}\",\n  \"state\": \"debug_completed\",\n  \"message\": \"Completed Nexus step debug\",\n  \"data\": {\n    \"step\": {\n      \"id\": \"debug\",\n      \"name\": \"Debug & Root Cause Analysis\",\n      \"description\": \"Identify root cause, reproduction steps, and propose fix architecture\",\n      \"agent_type\": \"debug\",\n      \"context_policy\": \"standard\",\n      \"tools\": [\n        \"vcs:add_comment\",\n        \"vcs:search_codebase\",\n        \"vcs:add_label\"\n      ],\n      \"inputs\": [\n        {\n          \"issue_url\": \"string\"\n        }\n      ],\n      \"outputs\": [\n        {\n          \"suspected_cause\": \"string\"\n        },\n        {\n          \"reproduction_steps\": \"string\"\n        },\n        {\n          \"affected_versions\": \"list[string]\"\n        }\n      ],\n      \"on_success\": \"develop\"\n    }\n  }\n}"
+      },
+      "id": "complete-debug",
+      "name": "Complete debug",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [
+        1860,
+        120
+      ],
+      "notesInFlow": true,
+      "notes": "Replace this state transition with a concrete agent/tool call when available."
+    },
+    {
+      "parameters": {
+        "method": "POST",
+        "url": "http://nexus-bridge-1:8091/api/v1/n8n/runs/update",
+        "authentication": "predefinedCredentialType",
+        "nodeCredentialType": "httpBearerAuth",
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "{\n  \"run_id\": \"={{$json.run?.run_id || $json.run_id}}\",\n  \"state\": \"develop\",\n  \"message\": \"Starting Nexus step develop\",\n  \"data\": {\n    \"step\": {\n      \"id\": \"develop\",\n      \"index\": 5,\n      \"name\": \"Implement Changes\",\n      \"description\": \"Implement code changes based on debug analysis or design proposal\",\n      \"agent_type\": \"developer\",\n      \"context_policy\": \"deep\",\n      \"tools\": [\n        \"vcs:read_issue\",\n        \"vcs:read_comments\",\n        \"vcs:add_comment\",\n        \"vcs:create_branch\",\n        \"vcs:edit_file\",\n        \"vcs:create_file\",\n        \"vcs:search_codebase\"\n      ],\n      \"inputs\": [\n        {\n          \"issue_url\": \"string\"\n        }\n      ],\n      \"outputs\": [\n        {\n          \"branch_name\": \"string\"\n        },\n        {\n          \"files_changed\": \"list[string]\"\n        },\n        {\n          \"implementation_summary\": \"string\"\n        }\n      ],\n      \"on_success\": \"review\",\n      \"audit_limit\": 50,\n      \"include_audit_history\": true\n    }\n  }\n}"
+      },
+      "id": "start-develop",
+      "name": "05 Start develop",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [
+        2000,
+        0
+      ],
+      "notesInFlow": true,
+      "notes": "Implement code changes based on debug analysis or design proposal"
+    },
+    {
+      "parameters": {
+        "method": "POST",
+        "url": "http://nexus-bridge-1:8091/api/v1/n8n/coding/execute",
+        "authentication": "predefinedCredentialType",
+        "nodeCredentialType": "httpBearerAuth",
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "{\n  \"run_id\": \"={{$json.run?.run_id || $json.run_id}}\",\n  \"task\": \"={{$json.task || $json.run?.task || \\\"Implement code changes based on debug analysis or design proposal\\\"}}\",\n  \"project_key\": \"={{$json.project_key || $json.run?.project_key || 'nexus'}}\",\n  \"worker\": \"opencode\",\n  \"agent\": \"build\",\n  \"base_branch\": \"develop\",\n  \"metadata\": {\n    \"step\": {\n      \"id\": \"develop\",\n      \"name\": \"Implement Changes\",\n      \"description\": \"Implement code changes based on debug analysis or design proposal\",\n      \"agent_type\": \"developer\",\n      \"context_policy\": \"deep\",\n      \"tools\": [\n        \"vcs:read_issue\",\n        \"vcs:read_comments\",\n        \"vcs:add_comment\",\n        \"vcs:create_branch\",\n        \"vcs:edit_file\",\n        \"vcs:create_file\",\n        \"vcs:search_codebase\"\n      ],\n      \"inputs\": [\n        {\n          \"issue_url\": \"string\"\n        }\n      ],\n      \"outputs\": [\n        {\n          \"branch_name\": \"string\"\n        },\n        {\n          \"files_changed\": \"list[string]\"\n        },\n        {\n          \"implementation_summary\": \"string\"\n        }\n      ],\n      \"on_success\": \"review\",\n      \"audit_limit\": 50,\n      \"include_audit_history\": true\n    }\n  }\n}"
+      },
+      "id": "execute-opencode-develop",
+      "name": "Execute OpenCode develop",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [
+        2220,
+        0
+      ],
+      "notesInFlow": true,
+      "notes": "Guarded Nexus endpoint: allowlist, isolated worktree, no push/merge/PR."
+    },
+    {
+      "parameters": {
+        "method": "POST",
+        "url": "http://nexus-bridge-1:8091/api/v1/n8n/runs/update",
+        "authentication": "predefinedCredentialType",
+        "nodeCredentialType": "httpBearerAuth",
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "{\n  \"run_id\": \"={{$json.run?.run_id || $json.run_id}}\",\n  \"state\": \"review\",\n  \"message\": \"Starting Nexus step review\",\n  \"data\": {\n    \"step\": {\n      \"id\": \"review\",\n      \"index\": 6,\n      \"name\": \"Review Implementation\",\n      \"description\": \"Review implementation quality and correctness; approve only after full regression (or equivalent full CI suite) passes\",\n      \"agent_type\": \"reviewer\",\n      \"context_policy\": \"standard\",\n      \"tools\": [\n        \"vcs:review_pr\",\n        \"vcs:suggest_changes\",\n        \"vcs:add_comment\",\n        \"vcs:request_changes\",\n        \"vcs:approve_pr\"\n      ],\n      \"inputs\": [\n        {\n          \"pr_urls\": \"list[string]\"\n        }\n      ],\n      \"outputs\": [\n        {\n          \"review_comments\": \"list[string]\"\n        },\n        {\n          \"approval_status\": \"enum[approved|changes_requested]\"\n        }\n      ],\n      \"on_success\": \"route_review\"\n    }\n  }\n}"
+      },
+      "id": "start-review",
+      "name": "06 Start review",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [
+        2360,
+        120
+      ],
+      "notesInFlow": true,
+      "notes": "Review implementation quality and correctness; approve only after full regression (or equivalent full CI suite) passes"
+    },
+    {
+      "parameters": {
+        "method": "POST",
+        "url": "http://nexus-bridge-1:8091/api/v1/n8n/runs/update",
+        "authentication": "predefinedCredentialType",
+        "nodeCredentialType": "httpBearerAuth",
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "{\n  \"run_id\": \"={{$json.run?.run_id || $json.run_id}}\",\n  \"state\": \"review_completed\",\n  \"message\": \"Completed Nexus step review\",\n  \"data\": {\n    \"step\": {\n      \"id\": \"review\",\n      \"name\": \"Review Implementation\",\n      \"description\": \"Review implementation quality and correctness; approve only after full regression (or equivalent full CI suite) passes\",\n      \"agent_type\": \"reviewer\",\n      \"context_policy\": \"standard\",\n      \"tools\": [\n        \"vcs:review_pr\",\n        \"vcs:suggest_changes\",\n        \"vcs:add_comment\",\n        \"vcs:request_changes\",\n        \"vcs:approve_pr\"\n      ],\n      \"inputs\": [\n        {\n          \"pr_urls\": \"list[string]\"\n        }\n      ],\n      \"outputs\": [\n        {\n          \"review_comments\": \"list[string]\"\n        },\n        {\n          \"approval_status\": \"enum[approved|changes_requested]\"\n        }\n      ],\n      \"on_success\": \"route_review\"\n    }\n  }\n}"
+      },
+      "id": "complete-review",
+      "name": "Complete review",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [
+        2580,
+        120
+      ],
+      "notesInFlow": true,
+      "notes": "Replace this state transition with a concrete agent/tool call when available."
+    },
+    {
+      "parameters": {
+        "method": "POST",
+        "url": "http://nexus-bridge-1:8091/api/v1/n8n/runs/update",
+        "authentication": "predefinedCredentialType",
+        "nodeCredentialType": "httpBearerAuth",
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "{\n  \"run_id\": \"={{$json.run?.run_id || $json.run_id}}\",\n  \"state\": \"route_review\",\n  \"message\": \"Starting Nexus step route_review\",\n  \"data\": {\n    \"step\": {\n      \"id\": \"route_review\",\n      \"index\": 7,\n      \"name\": \"Route After Review\",\n      \"agent_type\": \"router\",\n      \"context_policy\": \"minimal\",\n      \"routes\": [\n        {\n          \"when\": \"approval_status == 'approved'\",\n          \"then\": \"close_loop\"\n        },\n        {\n          \"default\": \"develop\"\n        }\n      ]\n    }\n  }\n}"
+      },
+      "id": "start-route_review",
+      "name": "07 Start route_review",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [
+        2720,
+        260
+      ]
+    },
+    {
+      "parameters": {
+        "jsCode": "const routes = [\n  {\n    \"when\": \"approval_status == 'approved'\",\n    \"then\": \"close_loop\"\n  },\n  {\n    \"default\": \"develop\"\n  }\n];\nconst state = $json;\n\nfunction toJsExpression(expr) {\n  return String(expr)\n    .replace(/\\band\\b/g, '&&')\n    .replace(/\\bor\\b/g, '||')\n    .replace(/\\bnot\\b/g, '!')\n    .replace(/\\bTrue\\b/g, 'true')\n    .replace(/\\bFalse\\b/g, 'false')\n    .replace(/\\bNone\\b/g, 'null');\n}\n\nfunction evaluate(expr) {\n  const keys = Object.keys(state);\n  const values = Object.values(state);\n  try {\n    return Boolean(Function(...keys, `return (${toJsExpression(expr)});`)(...values));\n  } catch (error) {\n    return false;\n  }\n}\n\nlet nextStep = null;\nfor (const route of routes) {\n  if (route.when && evaluate(route.when)) {\n    nextStep = route.then;\n    break;\n  }\n  if (!route.when && route.default && nextStep === null) {\n    nextStep = route.default;\n  }\n}\n\nreturn [{ json: { ...state, next_step: nextStep } }];\n"
+      },
+      "id": "route-route_review",
+      "name": "Route route_review",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [
+        2940,
+        260
+      ],
+      "notesInFlow": true,
+      "notes": "Evaluates Nexus route rules and writes next_step."
+    },
+    {
+      "parameters": {
+        "method": "POST",
+        "url": "http://nexus-bridge-1:8091/api/v1/n8n/runs/update",
+        "authentication": "predefinedCredentialType",
+        "nodeCredentialType": "httpBearerAuth",
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "{\n  \"run_id\": \"={{$json.run?.run_id || $json.run_id}}\",\n  \"state\": \"docs_update\",\n  \"message\": \"Starting Nexus step docs_update\",\n  \"data\": {\n    \"step\": {\n      \"id\": \"docs_update\",\n      \"index\": 8,\n      \"name\": \"Update Documentation\",\n      \"description\": \"For doc issues: update README/docs automatically\",\n      \"agent_type\": \"docs\",\n      \"context_policy\": \"standard\",\n      \"tools\": [\n        \"vcs:read_file\",\n        \"vcs:create_branch\",\n        \"vcs:edit_file\",\n        \"vcs:create_pr\"\n      ],\n      \"inputs\": [\n        {\n          \"issue_url\": \"string\"\n        }\n      ],\n      \"outputs\": [\n        {\n          \"docs_pr_url\": \"string\"\n        }\n      ],\n      \"on_success\": \"close_loop\"\n    }\n  }\n}"
+      },
+      "id": "start-docs_update",
+      "name": "08 Start docs_update",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [
+        3080,
+        120
+      ],
+      "notesInFlow": true,
+      "notes": "For doc issues: update README/docs automatically"
+    },
+    {
+      "parameters": {
+        "method": "POST",
+        "url": "http://nexus-bridge-1:8091/api/v1/n8n/runs/update",
+        "authentication": "predefinedCredentialType",
+        "nodeCredentialType": "httpBearerAuth",
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "{\n  \"run_id\": \"={{$json.run?.run_id || $json.run_id}}\",\n  \"state\": \"docs_update_completed\",\n  \"message\": \"Completed Nexus step docs_update\",\n  \"data\": {\n    \"step\": {\n      \"id\": \"docs_update\",\n      \"name\": \"Update Documentation\",\n      \"description\": \"For doc issues: update README/docs automatically\",\n      \"agent_type\": \"docs\",\n      \"context_policy\": \"standard\",\n      \"tools\": [\n        \"vcs:read_file\",\n        \"vcs:create_branch\",\n        \"vcs:edit_file\",\n        \"vcs:create_pr\"\n      ],\n      \"inputs\": [\n        {\n          \"issue_url\": \"string\"\n        }\n      ],\n      \"outputs\": [\n        {\n          \"docs_pr_url\": \"string\"\n        }\n      ],\n      \"on_success\": \"close_loop\"\n    }\n  }\n}"
+      },
+      "id": "complete-docs_update",
+      "name": "Complete docs_update",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [
+        3300,
+        120
+      ],
+      "notesInFlow": true,
+      "notes": "Replace this state transition with a concrete agent/tool call when available."
+    },
+    {
+      "parameters": {
+        "method": "POST",
+        "url": "http://nexus-bridge-1:8091/api/v1/n8n/runs/update",
+        "authentication": "predefinedCredentialType",
+        "nodeCredentialType": "httpBearerAuth",
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "{\n  \"run_id\": \"={{$json.run?.run_id || $json.run_id}}\",\n  \"state\": \"close_loop\",\n  \"message\": \"Starting Nexus step close_loop\",\n  \"data\": {\n    \"step\": {\n      \"id\": \"close_loop\",\n      \"index\": 9,\n      \"name\": \"Summarize & Close\",\n      \"description\": \"Final summary comment on original issue\",\n      \"agent_type\": \"summarizer\",\n      \"context_policy\": \"standard\",\n      \"tools\": [\n        \"vcs:add_comment\"\n      ],\n      \"inputs\": [\n        {\n          \"issue_url\": \"string\"\n        }\n      ],\n      \"outputs\": [\n        {\n          \"summary\": \"string\"\n        }\n      ],\n      \"final_step\": true,\n      \"audit_limit\": 10\n    }\n  }\n}"
+      },
+      "id": "start-close_loop",
+      "name": "09 Start close_loop",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [
+        3440,
+        0
+      ],
+      "notesInFlow": true,
+      "notes": "Final summary comment on original issue"
+    },
+    {
+      "parameters": {
+        "method": "POST",
+        "url": "http://nexus-bridge-1:8091/api/v1/n8n/runs/update",
+        "authentication": "predefinedCredentialType",
+        "nodeCredentialType": "httpBearerAuth",
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "{\n  \"run_id\": \"={{$json.run?.run_id || $json.run_id}}\",\n  \"state\": \"close_loop_completed\",\n  \"message\": \"Completed Nexus step close_loop\",\n  \"data\": {\n    \"step\": {\n      \"id\": \"close_loop\",\n      \"name\": \"Summarize & Close\",\n      \"description\": \"Final summary comment on original issue\",\n      \"agent_type\": \"summarizer\",\n      \"context_policy\": \"standard\",\n      \"tools\": [\n        \"vcs:add_comment\"\n      ],\n      \"inputs\": [\n        {\n          \"issue_url\": \"string\"\n        }\n      ],\n      \"outputs\": [\n        {\n          \"summary\": \"string\"\n        }\n      ],\n      \"final_step\": true,\n      \"audit_limit\": 10\n    }\n  }\n}"
+      },
+      "id": "complete-close_loop",
+      "name": "Complete close_loop",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [
+        3660,
+        0
+      ],
+      "notesInFlow": true,
+      "notes": "Replace this state transition with a concrete agent/tool call when available."
+    },
+    {
+      "parameters": {
+        "mode": "rules",
+        "rules": {
+          "values": [
+            {
+              "conditions": {
+                "conditions": [
+                  {
+                    "leftValue": "={{$json.next_step}}",
+                    "rightValue": "design",
+                    "operator": {
+                      "type": "string",
+                      "operation": "equals"
+                    }
+                  }
+                ],
+                "combinator": "and"
+              }
+            },
+            {
+              "conditions": {
+                "conditions": [
+                  {
+                    "leftValue": "={{$json.next_step}}",
+                    "rightValue": "debug",
+                    "operator": {
+                      "type": "string",
+                      "operation": "equals"
+                    }
+                  }
+                ],
+                "combinator": "and"
+              }
+            },
+            {
+              "conditions": {
+                "conditions": [
+                  {
+                    "leftValue": "={{$json.next_step}}",
+                    "rightValue": "docs_update",
+                    "operator": {
+                      "type": "string",
+                      "operation": "equals"
+                    }
+                  }
+                ],
+                "combinator": "and"
+              }
+            },
+            {
+              "conditions": {
+                "conditions": [
+                  {
+                    "leftValue": "={{$json.next_step}}",
+                    "rightValue": "close_loop",
+                    "operator": {
+                      "type": "string",
+                      "operation": "equals"
+                    }
+                  }
+                ],
+                "combinator": "and"
+              }
+            }
+          ]
+        },
+        "options": {}
+      },
+      "id": "switch-switch-route_by_type",
+      "name": "Switch route_by_type",
+      "type": "n8n-nodes-base.switch",
+      "typeVersion": 3,
+      "position": [
+        1360,
+        260
+      ],
+      "notesInFlow": true,
+      "notes": "Routes to the Nexus step selected by the preceding Code node."
+    },
+    {
+      "parameters": {
+        "mode": "rules",
+        "rules": {
+          "values": [
+            {
+              "conditions": {
+                "conditions": [
+                  {
+                    "leftValue": "={{$json.next_step}}",
+                    "rightValue": "close_loop",
+                    "operator": {
+                      "type": "string",
+                      "operation": "equals"
+                    }
+                  }
+                ],
+                "combinator": "and"
+              }
+            },
+            {
+              "conditions": {
+                "conditions": [
+                  {
+                    "leftValue": "={{$json.next_step}}",
+                    "rightValue": "develop",
+                    "operator": {
+                      "type": "string",
+                      "operation": "equals"
+                    }
+                  }
+                ],
+                "combinator": "and"
+              }
+            }
+          ]
+        },
+        "options": {}
+      },
+      "id": "switch-switch-route_review",
+      "name": "Switch route_review",
+      "type": "n8n-nodes-base.switch",
+      "typeVersion": 3,
+      "position": [
+        3160,
+        260
+      ],
+      "notesInFlow": true,
+      "notes": "Routes to the Nexus step selected by the preceding Code node."
+    }
+  ],
+  "connections": {
+    "01 Start triage": {
+      "main": [
+        [
+          {
+            "node": "Complete triage",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "02 Start route_by_type": {
+      "main": [
+        [
+          {
+            "node": "Route route_by_type",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "03 Start design": {
+      "main": [
+        [
+          {
+            "node": "Complete design",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "04 Start debug": {
+      "main": [
+        [
+          {
+            "node": "Complete debug",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "05 Start develop": {
+      "main": [
+        [
+          {
+            "node": "Execute OpenCode develop",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "06 Start review": {
+      "main": [
+        [
+          {
+            "node": "Complete review",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "07 Start route_review": {
+      "main": [
+        [
+          {
+            "node": "Route route_review",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "08 Start docs_update": {
+      "main": [
+        [
+          {
+            "node": "Complete docs_update",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "09 Start close_loop": {
+      "main": [
+        [
+          {
+            "node": "Complete close_loop",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Create Nexus Run": {
+      "main": [
+        [
+          {
+            "node": "01 Start triage",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Manual Trigger": {
+      "main": [
+        [
+          {
+            "node": "Create Nexus Run",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Complete triage": {
+      "main": [
+        [
+          {
+            "node": "02 Start route_by_type",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Route route_by_type": {
+      "main": [
+        [
+          {
+            "node": "Switch route_by_type",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Switch route_by_type": {
+      "main": [
+        [
+          {
+            "node": "03 Start design",
+            "type": "main",
+            "index": 0
+          }
+        ],
+        [
+          {
+            "node": "04 Start debug",
+            "type": "main",
+            "index": 0
+          }
+        ],
+        [
+          {
+            "node": "08 Start docs_update",
+            "type": "main",
+            "index": 0
+          }
+        ],
+        [
+          {
+            "node": "09 Start close_loop",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Complete design": {
+      "main": [
+        [
+          {
+            "node": "05 Start develop",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Complete debug": {
+      "main": [
+        [
+          {
+            "node": "05 Start develop",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Execute OpenCode develop": {
+      "main": [
+        [
+          {
+            "node": "06 Start review",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Complete review": {
+      "main": [
+        [
+          {
+            "node": "07 Start route_review",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Route route_review": {
+      "main": [
+        [
+          {
+            "node": "Switch route_review",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Switch route_review": {
+      "main": [
+        [
+          {
+            "node": "09 Start close_loop",
+            "type": "main",
+            "index": 0
+          }
+        ],
+        [
+          {
+            "node": "05 Start develop",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Complete docs_update": {
+      "main": [
+        [
+          {
+            "node": "09 Start close_loop",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    }
+  },
+  "settings": {
+    "executionOrder": "v1"
+  },
+  "staticData": null,
+  "tags": [
+    "nexus-arc",
+    "generated"
+  ],
+  "meta": {
+    "nexusArc": {
+      "source": "examples/workflows/development_full_workflow.yaml",
+      "workflowType": "full",
+      "converter": "nexus.translators.to_n8n"
+    }
+  }
+}

--- a/examples/workflows/n8n/development_shortened_workflow.json
+++ b/examples/workflows/n8n/development_shortened_workflow.json
@@ -1,0 +1,719 @@
+{
+  "name": "Development Shortened Workflow",
+  "nodes": [
+    {
+      "parameters": {},
+      "id": "manual-trigger",
+      "name": "Manual Trigger",
+      "type": "n8n-nodes-base.manualTrigger",
+      "typeVersion": 1,
+      "position": [
+        0,
+        0
+      ]
+    },
+    {
+      "parameters": {
+        "method": "POST",
+        "url": "http://nexus-bridge-1:8091/api/v1/n8n/runs",
+        "authentication": "predefinedCredentialType",
+        "nodeCredentialType": "httpBearerAuth",
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "{\n  \"task\": \"={{$json.task || $json.title || 'Run Nexus workflow'}}\",\n  \"project_key\": \"={{$json.project_key || $json.project || 'nexus'}}\",\n  \"issue_number\": \"={{$json.issue_number || $json.issue || ''}}\",\n  \"requester\": {\n    \"source\": \"n8n\",\n    \"workflow\": \"Development Shortened Workflow\"\n  },\n  \"metadata\": {\n    \"nexus_workflow\": {\n      \"name\": \"Development Shortened Workflow\",\n      \"description\": \"Expedited development path for lower-risk or time-sensitive work.\",\n      \"version\": \"0.1.0\"\n    },\n    \"workflow_type\": \"shortened\",\n    \"source\": \"examples/workflows/development_shortened_workflow.yaml\"\n  }\n}"
+      },
+      "id": "create-nexus-run",
+      "name": "Create Nexus Run",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [
+        260,
+        0
+      ],
+      "notesInFlow": true,
+      "notes": "Creates the durable Nexus run that n8n will advance."
+    },
+    {
+      "parameters": {
+        "method": "POST",
+        "url": "http://nexus-bridge-1:8091/api/v1/n8n/runs/update",
+        "authentication": "predefinedCredentialType",
+        "nodeCredentialType": "httpBearerAuth",
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "{\n  \"run_id\": \"={{$json.run?.run_id || $json.run_id}}\",\n  \"state\": \"triage\",\n  \"message\": \"Starting Nexus step triage\",\n  \"data\": {\n    \"step\": {\n      \"id\": \"triage\",\n      \"index\": 1,\n      \"name\": \"Intake & Triage\",\n      \"description\": \"Classify issue and priority\",\n      \"agent_type\": \"triage\",\n      \"context_policy\": \"minimal\",\n      \"tools\": [\n        \"vcs:read_issue\",\n        \"vcs:add_comment\",\n        \"vcs:add_label\"\n      ],\n      \"inputs\": [\n        {\n          \"issue_url\": \"string\"\n        }\n      ],\n      \"outputs\": [\n        {\n          \"classification\": \"enum[bug|feature|doc|support]\"\n        },\n        {\n          \"priority\": \"enum[p0|p1|p2|p3]\"\n        }\n      ],\n      \"on_success\": \"route\"\n    }\n  }\n}"
+      },
+      "id": "start-triage",
+      "name": "01 Start triage",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [
+        560,
+        0
+      ],
+      "notesInFlow": true,
+      "notes": "Classify issue and priority"
+    },
+    {
+      "parameters": {
+        "method": "POST",
+        "url": "http://nexus-bridge-1:8091/api/v1/n8n/runs/update",
+        "authentication": "predefinedCredentialType",
+        "nodeCredentialType": "httpBearerAuth",
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "{\n  \"run_id\": \"={{$json.run?.run_id || $json.run_id}}\",\n  \"state\": \"triage_completed\",\n  \"message\": \"Completed Nexus step triage\",\n  \"data\": {\n    \"step\": {\n      \"id\": \"triage\",\n      \"name\": \"Intake & Triage\",\n      \"description\": \"Classify issue and priority\",\n      \"agent_type\": \"triage\",\n      \"context_policy\": \"minimal\",\n      \"tools\": [\n        \"vcs:read_issue\",\n        \"vcs:add_comment\",\n        \"vcs:add_label\"\n      ],\n      \"inputs\": [\n        {\n          \"issue_url\": \"string\"\n        }\n      ],\n      \"outputs\": [\n        {\n          \"classification\": \"enum[bug|feature|doc|support]\"\n        },\n        {\n          \"priority\": \"enum[p0|p1|p2|p3]\"\n        }\n      ],\n      \"on_success\": \"route\"\n    }\n  }\n}"
+      },
+      "id": "complete-triage",
+      "name": "Complete triage",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [
+        780,
+        0
+      ],
+      "notesInFlow": true,
+      "notes": "Replace this state transition with a concrete agent/tool call when available."
+    },
+    {
+      "parameters": {
+        "method": "POST",
+        "url": "http://nexus-bridge-1:8091/api/v1/n8n/runs/update",
+        "authentication": "predefinedCredentialType",
+        "nodeCredentialType": "httpBearerAuth",
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "{\n  \"run_id\": \"={{$json.run?.run_id || $json.run_id}}\",\n  \"state\": \"route\",\n  \"message\": \"Starting Nexus step route\",\n  \"data\": {\n    \"step\": {\n      \"id\": \"route\",\n      \"index\": 2,\n      \"name\": \"Route\",\n      \"agent_type\": \"router\",\n      \"context_policy\": \"minimal\",\n      \"routes\": [\n        {\n          \"when\": \"classification == 'bug'\",\n          \"then\": \"debug\"\n        },\n        {\n          \"when\": \"classification == 'doc'\",\n          \"then\": \"docs_update\"\n        },\n        {\n          \"default\": \"develop\"\n        }\n      ]\n    }\n  }\n}"
+      },
+      "id": "start-route",
+      "name": "02 Start route",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [
+        920,
+        260
+      ]
+    },
+    {
+      "parameters": {
+        "jsCode": "const routes = [\n  {\n    \"when\": \"classification == 'bug'\",\n    \"then\": \"debug\"\n  },\n  {\n    \"when\": \"classification == 'doc'\",\n    \"then\": \"docs_update\"\n  },\n  {\n    \"default\": \"develop\"\n  }\n];\nconst state = $json;\n\nfunction toJsExpression(expr) {\n  return String(expr)\n    .replace(/\\band\\b/g, '&&')\n    .replace(/\\bor\\b/g, '||')\n    .replace(/\\bnot\\b/g, '!')\n    .replace(/\\bTrue\\b/g, 'true')\n    .replace(/\\bFalse\\b/g, 'false')\n    .replace(/\\bNone\\b/g, 'null');\n}\n\nfunction evaluate(expr) {\n  const keys = Object.keys(state);\n  const values = Object.values(state);\n  try {\n    return Boolean(Function(...keys, `return (${toJsExpression(expr)});`)(...values));\n  } catch (error) {\n    return false;\n  }\n}\n\nlet nextStep = null;\nfor (const route of routes) {\n  if (route.when && evaluate(route.when)) {\n    nextStep = route.then;\n    break;\n  }\n  if (!route.when && route.default && nextStep === null) {\n    nextStep = route.default;\n  }\n}\n\nreturn [{ json: { ...state, next_step: nextStep } }];\n"
+      },
+      "id": "route-route",
+      "name": "Route route",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [
+        1140,
+        260
+      ],
+      "notesInFlow": true,
+      "notes": "Evaluates Nexus route rules and writes next_step."
+    },
+    {
+      "parameters": {
+        "method": "POST",
+        "url": "http://nexus-bridge-1:8091/api/v1/n8n/runs/update",
+        "authentication": "predefinedCredentialType",
+        "nodeCredentialType": "httpBearerAuth",
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "{\n  \"run_id\": \"={{$json.run?.run_id || $json.run_id}}\",\n  \"state\": \"debug\",\n  \"message\": \"Starting Nexus step debug\",\n  \"data\": {\n    \"step\": {\n      \"id\": \"debug\",\n      \"index\": 3,\n      \"name\": \"Root Cause Analysis\",\n      \"description\": \"Identify likely root cause\",\n      \"agent_type\": \"debug\",\n      \"context_policy\": \"standard\",\n      \"tools\": [\n        \"vcs:search_codebase\",\n        \"vcs:add_comment\"\n      ],\n      \"inputs\": [\n        {\n          \"issue_url\": \"string\"\n        }\n      ],\n      \"outputs\": [\n        {\n          \"root_cause\": \"string\"\n        }\n      ],\n      \"on_success\": \"develop\"\n    }\n  }\n}"
+      },
+      "id": "start-debug",
+      "name": "03 Start debug",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [
+        1280,
+        0
+      ],
+      "notesInFlow": true,
+      "notes": "Identify likely root cause"
+    },
+    {
+      "parameters": {
+        "method": "POST",
+        "url": "http://nexus-bridge-1:8091/api/v1/n8n/runs/update",
+        "authentication": "predefinedCredentialType",
+        "nodeCredentialType": "httpBearerAuth",
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "{\n  \"run_id\": \"={{$json.run?.run_id || $json.run_id}}\",\n  \"state\": \"debug_completed\",\n  \"message\": \"Completed Nexus step debug\",\n  \"data\": {\n    \"step\": {\n      \"id\": \"debug\",\n      \"name\": \"Root Cause Analysis\",\n      \"description\": \"Identify likely root cause\",\n      \"agent_type\": \"debug\",\n      \"context_policy\": \"standard\",\n      \"tools\": [\n        \"vcs:search_codebase\",\n        \"vcs:add_comment\"\n      ],\n      \"inputs\": [\n        {\n          \"issue_url\": \"string\"\n        }\n      ],\n      \"outputs\": [\n        {\n          \"root_cause\": \"string\"\n        }\n      ],\n      \"on_success\": \"develop\"\n    }\n  }\n}"
+      },
+      "id": "complete-debug",
+      "name": "Complete debug",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [
+        1500,
+        0
+      ],
+      "notesInFlow": true,
+      "notes": "Replace this state transition with a concrete agent/tool call when available."
+    },
+    {
+      "parameters": {
+        "method": "POST",
+        "url": "http://nexus-bridge-1:8091/api/v1/n8n/runs/update",
+        "authentication": "predefinedCredentialType",
+        "nodeCredentialType": "httpBearerAuth",
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "{\n  \"run_id\": \"={{$json.run?.run_id || $json.run_id}}\",\n  \"state\": \"develop\",\n  \"message\": \"Starting Nexus step develop\",\n  \"data\": {\n    \"step\": {\n      \"id\": \"develop\",\n      \"index\": 4,\n      \"name\": \"Implement Change\",\n      \"description\": \"Implement and prepare PR\",\n      \"agent_type\": \"developer\",\n      \"context_policy\": \"deep\",\n      \"tools\": [\n        \"vcs:create_branch\",\n        \"vcs:edit_file\",\n        \"vcs:create_pr\",\n        \"vcs:add_comment\"\n      ],\n      \"inputs\": [\n        {\n          \"issue_url\": \"string\"\n        }\n      ],\n      \"outputs\": [\n        {\n          \"pr_url\": \"string\"\n        },\n        {\n          \"implementation_summary\": \"string\"\n        }\n      ],\n      \"on_success\": \"review\",\n      \"audit_limit\": 50,\n      \"include_audit_history\": true\n    }\n  }\n}"
+      },
+      "id": "start-develop",
+      "name": "04 Start develop",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [
+        1640,
+        120
+      ],
+      "notesInFlow": true,
+      "notes": "Implement and prepare PR"
+    },
+    {
+      "parameters": {
+        "method": "POST",
+        "url": "http://nexus-bridge-1:8091/api/v1/n8n/coding/execute",
+        "authentication": "predefinedCredentialType",
+        "nodeCredentialType": "httpBearerAuth",
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "{\n  \"run_id\": \"={{$json.run?.run_id || $json.run_id}}\",\n  \"task\": \"={{$json.task || $json.run?.task || \\\"Implement and prepare PR\\\"}}\",\n  \"project_key\": \"={{$json.project_key || $json.run?.project_key || 'nexus'}}\",\n  \"worker\": \"opencode\",\n  \"agent\": \"build\",\n  \"base_branch\": \"develop\",\n  \"metadata\": {\n    \"step\": {\n      \"id\": \"develop\",\n      \"name\": \"Implement Change\",\n      \"description\": \"Implement and prepare PR\",\n      \"agent_type\": \"developer\",\n      \"context_policy\": \"deep\",\n      \"tools\": [\n        \"vcs:create_branch\",\n        \"vcs:edit_file\",\n        \"vcs:create_pr\",\n        \"vcs:add_comment\"\n      ],\n      \"inputs\": [\n        {\n          \"issue_url\": \"string\"\n        }\n      ],\n      \"outputs\": [\n        {\n          \"pr_url\": \"string\"\n        },\n        {\n          \"implementation_summary\": \"string\"\n        }\n      ],\n      \"on_success\": \"review\",\n      \"audit_limit\": 50,\n      \"include_audit_history\": true\n    }\n  }\n}"
+      },
+      "id": "execute-opencode-develop",
+      "name": "Execute OpenCode develop",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [
+        1860,
+        120
+      ],
+      "notesInFlow": true,
+      "notes": "Guarded Nexus endpoint: allowlist, isolated worktree, no push/merge/PR."
+    },
+    {
+      "parameters": {
+        "method": "POST",
+        "url": "http://nexus-bridge-1:8091/api/v1/n8n/runs/update",
+        "authentication": "predefinedCredentialType",
+        "nodeCredentialType": "httpBearerAuth",
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "{\n  \"run_id\": \"={{$json.run?.run_id || $json.run_id}}\",\n  \"state\": \"review\",\n  \"message\": \"Starting Nexus step review\",\n  \"data\": {\n    \"step\": {\n      \"id\": \"review\",\n      \"index\": 5,\n      \"name\": \"Review\",\n      \"description\": \"Quick review with full CI/regression requirement\",\n      \"agent_type\": \"reviewer\",\n      \"context_policy\": \"standard\",\n      \"tools\": [\n        \"vcs:review_pr\",\n        \"vcs:approve_pr\",\n        \"vcs:request_changes\"\n      ],\n      \"inputs\": [\n        {\n          \"pr_urls\": \"list[string]\"\n        }\n      ],\n      \"outputs\": [\n        {\n          \"approval_status\": \"enum[approved|changes_requested]\"\n        }\n      ],\n      \"on_success\": \"route_review\"\n    }\n  }\n}"
+      },
+      "id": "start-review",
+      "name": "05 Start review",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [
+        2000,
+        0
+      ],
+      "notesInFlow": true,
+      "notes": "Quick review with full CI/regression requirement"
+    },
+    {
+      "parameters": {
+        "method": "POST",
+        "url": "http://nexus-bridge-1:8091/api/v1/n8n/runs/update",
+        "authentication": "predefinedCredentialType",
+        "nodeCredentialType": "httpBearerAuth",
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "{\n  \"run_id\": \"={{$json.run?.run_id || $json.run_id}}\",\n  \"state\": \"review_completed\",\n  \"message\": \"Completed Nexus step review\",\n  \"data\": {\n    \"step\": {\n      \"id\": \"review\",\n      \"name\": \"Review\",\n      \"description\": \"Quick review with full CI/regression requirement\",\n      \"agent_type\": \"reviewer\",\n      \"context_policy\": \"standard\",\n      \"tools\": [\n        \"vcs:review_pr\",\n        \"vcs:approve_pr\",\n        \"vcs:request_changes\"\n      ],\n      \"inputs\": [\n        {\n          \"pr_urls\": \"list[string]\"\n        }\n      ],\n      \"outputs\": [\n        {\n          \"approval_status\": \"enum[approved|changes_requested]\"\n        }\n      ],\n      \"on_success\": \"route_review\"\n    }\n  }\n}"
+      },
+      "id": "complete-review",
+      "name": "Complete review",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [
+        2220,
+        0
+      ],
+      "notesInFlow": true,
+      "notes": "Replace this state transition with a concrete agent/tool call when available."
+    },
+    {
+      "parameters": {
+        "method": "POST",
+        "url": "http://nexus-bridge-1:8091/api/v1/n8n/runs/update",
+        "authentication": "predefinedCredentialType",
+        "nodeCredentialType": "httpBearerAuth",
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "{\n  \"run_id\": \"={{$json.run?.run_id || $json.run_id}}\",\n  \"state\": \"route_review\",\n  \"message\": \"Starting Nexus step route_review\",\n  \"data\": {\n    \"step\": {\n      \"id\": \"route_review\",\n      \"index\": 6,\n      \"name\": \"Route After Review\",\n      \"agent_type\": \"router\",\n      \"context_policy\": \"minimal\",\n      \"routes\": [\n        {\n          \"when\": \"approval_status == 'approved'\",\n          \"then\": \"close_loop\"\n        },\n        {\n          \"default\": \"develop\"\n        }\n      ]\n    }\n  }\n}"
+      },
+      "id": "start-route_review",
+      "name": "06 Start route_review",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [
+        2360,
+        260
+      ]
+    },
+    {
+      "parameters": {
+        "jsCode": "const routes = [\n  {\n    \"when\": \"approval_status == 'approved'\",\n    \"then\": \"close_loop\"\n  },\n  {\n    \"default\": \"develop\"\n  }\n];\nconst state = $json;\n\nfunction toJsExpression(expr) {\n  return String(expr)\n    .replace(/\\band\\b/g, '&&')\n    .replace(/\\bor\\b/g, '||')\n    .replace(/\\bnot\\b/g, '!')\n    .replace(/\\bTrue\\b/g, 'true')\n    .replace(/\\bFalse\\b/g, 'false')\n    .replace(/\\bNone\\b/g, 'null');\n}\n\nfunction evaluate(expr) {\n  const keys = Object.keys(state);\n  const values = Object.values(state);\n  try {\n    return Boolean(Function(...keys, `return (${toJsExpression(expr)});`)(...values));\n  } catch (error) {\n    return false;\n  }\n}\n\nlet nextStep = null;\nfor (const route of routes) {\n  if (route.when && evaluate(route.when)) {\n    nextStep = route.then;\n    break;\n  }\n  if (!route.when && route.default && nextStep === null) {\n    nextStep = route.default;\n  }\n}\n\nreturn [{ json: { ...state, next_step: nextStep } }];\n"
+      },
+      "id": "route-route_review",
+      "name": "Route route_review",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [
+        2580,
+        260
+      ],
+      "notesInFlow": true,
+      "notes": "Evaluates Nexus route rules and writes next_step."
+    },
+    {
+      "parameters": {
+        "method": "POST",
+        "url": "http://nexus-bridge-1:8091/api/v1/n8n/runs/update",
+        "authentication": "predefinedCredentialType",
+        "nodeCredentialType": "httpBearerAuth",
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "{\n  \"run_id\": \"={{$json.run?.run_id || $json.run_id}}\",\n  \"state\": \"docs_update\",\n  \"message\": \"Starting Nexus step docs_update\",\n  \"data\": {\n    \"step\": {\n      \"id\": \"docs_update\",\n      \"index\": 7,\n      \"name\": \"Update Documentation\",\n      \"description\": \"Documentation-only workflow branch\",\n      \"agent_type\": \"docs\",\n      \"context_policy\": \"standard\",\n      \"tools\": [\n        \"vcs:read_file\",\n        \"vcs:edit_file\",\n        \"vcs:create_pr\"\n      ],\n      \"inputs\": [\n        {\n          \"issue_url\": \"string\"\n        }\n      ],\n      \"outputs\": [\n        {\n          \"docs_pr_url\": \"string\"\n        }\n      ],\n      \"on_success\": \"close_loop\"\n    }\n  }\n}"
+      },
+      "id": "start-docs_update",
+      "name": "07 Start docs_update",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [
+        2720,
+        0
+      ],
+      "notesInFlow": true,
+      "notes": "Documentation-only workflow branch"
+    },
+    {
+      "parameters": {
+        "method": "POST",
+        "url": "http://nexus-bridge-1:8091/api/v1/n8n/runs/update",
+        "authentication": "predefinedCredentialType",
+        "nodeCredentialType": "httpBearerAuth",
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "{\n  \"run_id\": \"={{$json.run?.run_id || $json.run_id}}\",\n  \"state\": \"docs_update_completed\",\n  \"message\": \"Completed Nexus step docs_update\",\n  \"data\": {\n    \"step\": {\n      \"id\": \"docs_update\",\n      \"name\": \"Update Documentation\",\n      \"description\": \"Documentation-only workflow branch\",\n      \"agent_type\": \"docs\",\n      \"context_policy\": \"standard\",\n      \"tools\": [\n        \"vcs:read_file\",\n        \"vcs:edit_file\",\n        \"vcs:create_pr\"\n      ],\n      \"inputs\": [\n        {\n          \"issue_url\": \"string\"\n        }\n      ],\n      \"outputs\": [\n        {\n          \"docs_pr_url\": \"string\"\n        }\n      ],\n      \"on_success\": \"close_loop\"\n    }\n  }\n}"
+      },
+      "id": "complete-docs_update",
+      "name": "Complete docs_update",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [
+        2940,
+        0
+      ],
+      "notesInFlow": true,
+      "notes": "Replace this state transition with a concrete agent/tool call when available."
+    },
+    {
+      "parameters": {
+        "method": "POST",
+        "url": "http://nexus-bridge-1:8091/api/v1/n8n/runs/update",
+        "authentication": "predefinedCredentialType",
+        "nodeCredentialType": "httpBearerAuth",
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "{\n  \"run_id\": \"={{$json.run?.run_id || $json.run_id}}\",\n  \"state\": \"close_loop\",\n  \"message\": \"Starting Nexus step close_loop\",\n  \"data\": {\n    \"step\": {\n      \"id\": \"close_loop\",\n      \"index\": 8,\n      \"name\": \"Summarize & Close\",\n      \"description\": \"Post summary and close\",\n      \"agent_type\": \"summarizer\",\n      \"context_policy\": \"standard\",\n      \"tools\": [\n        \"vcs:add_comment\"\n      ],\n      \"inputs\": [\n        {\n          \"issue_url\": \"string\"\n        }\n      ],\n      \"outputs\": [\n        {\n          \"summary\": \"string\"\n        }\n      ],\n      \"final_step\": true,\n      \"audit_limit\": 10\n    }\n  }\n}"
+      },
+      "id": "start-close_loop",
+      "name": "08 Start close_loop",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [
+        3080,
+        120
+      ],
+      "notesInFlow": true,
+      "notes": "Post summary and close"
+    },
+    {
+      "parameters": {
+        "method": "POST",
+        "url": "http://nexus-bridge-1:8091/api/v1/n8n/runs/update",
+        "authentication": "predefinedCredentialType",
+        "nodeCredentialType": "httpBearerAuth",
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "{\n  \"run_id\": \"={{$json.run?.run_id || $json.run_id}}\",\n  \"state\": \"close_loop_completed\",\n  \"message\": \"Completed Nexus step close_loop\",\n  \"data\": {\n    \"step\": {\n      \"id\": \"close_loop\",\n      \"name\": \"Summarize & Close\",\n      \"description\": \"Post summary and close\",\n      \"agent_type\": \"summarizer\",\n      \"context_policy\": \"standard\",\n      \"tools\": [\n        \"vcs:add_comment\"\n      ],\n      \"inputs\": [\n        {\n          \"issue_url\": \"string\"\n        }\n      ],\n      \"outputs\": [\n        {\n          \"summary\": \"string\"\n        }\n      ],\n      \"final_step\": true,\n      \"audit_limit\": 10\n    }\n  }\n}"
+      },
+      "id": "complete-close_loop",
+      "name": "Complete close_loop",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [
+        3300,
+        120
+      ],
+      "notesInFlow": true,
+      "notes": "Replace this state transition with a concrete agent/tool call when available."
+    },
+    {
+      "parameters": {
+        "mode": "rules",
+        "rules": {
+          "values": [
+            {
+              "conditions": {
+                "conditions": [
+                  {
+                    "leftValue": "={{$json.next_step}}",
+                    "rightValue": "debug",
+                    "operator": {
+                      "type": "string",
+                      "operation": "equals"
+                    }
+                  }
+                ],
+                "combinator": "and"
+              }
+            },
+            {
+              "conditions": {
+                "conditions": [
+                  {
+                    "leftValue": "={{$json.next_step}}",
+                    "rightValue": "docs_update",
+                    "operator": {
+                      "type": "string",
+                      "operation": "equals"
+                    }
+                  }
+                ],
+                "combinator": "and"
+              }
+            },
+            {
+              "conditions": {
+                "conditions": [
+                  {
+                    "leftValue": "={{$json.next_step}}",
+                    "rightValue": "develop",
+                    "operator": {
+                      "type": "string",
+                      "operation": "equals"
+                    }
+                  }
+                ],
+                "combinator": "and"
+              }
+            }
+          ]
+        },
+        "options": {}
+      },
+      "id": "switch-switch-route",
+      "name": "Switch route",
+      "type": "n8n-nodes-base.switch",
+      "typeVersion": 3,
+      "position": [
+        1360,
+        260
+      ],
+      "notesInFlow": true,
+      "notes": "Routes to the Nexus step selected by the preceding Code node."
+    },
+    {
+      "parameters": {
+        "mode": "rules",
+        "rules": {
+          "values": [
+            {
+              "conditions": {
+                "conditions": [
+                  {
+                    "leftValue": "={{$json.next_step}}",
+                    "rightValue": "close_loop",
+                    "operator": {
+                      "type": "string",
+                      "operation": "equals"
+                    }
+                  }
+                ],
+                "combinator": "and"
+              }
+            },
+            {
+              "conditions": {
+                "conditions": [
+                  {
+                    "leftValue": "={{$json.next_step}}",
+                    "rightValue": "develop",
+                    "operator": {
+                      "type": "string",
+                      "operation": "equals"
+                    }
+                  }
+                ],
+                "combinator": "and"
+              }
+            }
+          ]
+        },
+        "options": {}
+      },
+      "id": "switch-switch-route_review",
+      "name": "Switch route_review",
+      "type": "n8n-nodes-base.switch",
+      "typeVersion": 3,
+      "position": [
+        2800,
+        260
+      ],
+      "notesInFlow": true,
+      "notes": "Routes to the Nexus step selected by the preceding Code node."
+    }
+  ],
+  "connections": {
+    "01 Start triage": {
+      "main": [
+        [
+          {
+            "node": "Complete triage",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "02 Start route": {
+      "main": [
+        [
+          {
+            "node": "Route route",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "03 Start debug": {
+      "main": [
+        [
+          {
+            "node": "Complete debug",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "04 Start develop": {
+      "main": [
+        [
+          {
+            "node": "Execute OpenCode develop",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "05 Start review": {
+      "main": [
+        [
+          {
+            "node": "Complete review",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "06 Start route_review": {
+      "main": [
+        [
+          {
+            "node": "Route route_review",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "07 Start docs_update": {
+      "main": [
+        [
+          {
+            "node": "Complete docs_update",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "08 Start close_loop": {
+      "main": [
+        [
+          {
+            "node": "Complete close_loop",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Create Nexus Run": {
+      "main": [
+        [
+          {
+            "node": "01 Start triage",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Manual Trigger": {
+      "main": [
+        [
+          {
+            "node": "Create Nexus Run",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Complete triage": {
+      "main": [
+        [
+          {
+            "node": "02 Start route",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Route route": {
+      "main": [
+        [
+          {
+            "node": "Switch route",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Switch route": {
+      "main": [
+        [
+          {
+            "node": "03 Start debug",
+            "type": "main",
+            "index": 0
+          }
+        ],
+        [
+          {
+            "node": "07 Start docs_update",
+            "type": "main",
+            "index": 0
+          }
+        ],
+        [
+          {
+            "node": "04 Start develop",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Complete debug": {
+      "main": [
+        [
+          {
+            "node": "04 Start develop",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Execute OpenCode develop": {
+      "main": [
+        [
+          {
+            "node": "05 Start review",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Complete review": {
+      "main": [
+        [
+          {
+            "node": "06 Start route_review",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Route route_review": {
+      "main": [
+        [
+          {
+            "node": "Switch route_review",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Switch route_review": {
+      "main": [
+        [
+          {
+            "node": "08 Start close_loop",
+            "type": "main",
+            "index": 0
+          }
+        ],
+        [
+          {
+            "node": "04 Start develop",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Complete docs_update": {
+      "main": [
+        [
+          {
+            "node": "08 Start close_loop",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    }
+  },
+  "settings": {
+    "executionOrder": "v1"
+  },
+  "staticData": null,
+  "tags": [
+    "nexus-arc",
+    "generated"
+  ],
+  "meta": {
+    "nexusArc": {
+      "source": "examples/workflows/development_shortened_workflow.yaml",
+      "workflowType": "shortened",
+      "converter": "nexus.translators.to_n8n"
+    }
+  }
+}

--- a/examples/workflows/n8n/development_workflow.json
+++ b/examples/workflows/n8n/development_workflow.json
@@ -1,0 +1,263 @@
+{
+  "name": "Development Workflow Router",
+  "nodes": [
+    {
+      "parameters": {},
+      "id": "manual-trigger",
+      "name": "Manual Trigger",
+      "type": "n8n-nodes-base.manualTrigger",
+      "typeVersion": 1,
+      "position": [
+        0,
+        0
+      ]
+    },
+    {
+      "parameters": {
+        "method": "POST",
+        "url": "http://nexus-bridge-1:8091/api/v1/n8n/runs",
+        "authentication": "predefinedCredentialType",
+        "nodeCredentialType": "httpBearerAuth",
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "{\n  \"task\": \"={{$json.task || $json.title || 'Run Nexus workflow'}}\",\n  \"project_key\": \"={{$json.project_key || $json.project || 'nexus'}}\",\n  \"issue_number\": \"={{$json.issue_number || $json.issue || ''}}\",\n  \"requester\": {\n    \"source\": \"n8n\",\n    \"workflow\": \"Development Workflow Router\"\n  },\n  \"metadata\": {\n    \"nexus_workflow\": {\n      \"name\": \"Development Workflow Router\",\n      \"description\": \"Router workflow for development full/shortened/fast-track tiers.\",\n      \"version\": \"0.1.0\"\n    },\n    \"workflow_type\": \"orchestrator\",\n    \"source\": \"examples/workflows/development_workflow.yaml\"\n  }\n}"
+      },
+      "id": "create-nexus-run",
+      "name": "Create Nexus Run",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [
+        260,
+        0
+      ],
+      "notesInFlow": true,
+      "notes": "Creates the durable Nexus run that n8n will advance."
+    },
+    {
+      "parameters": {
+        "method": "POST",
+        "url": "http://nexus-bridge-1:8091/api/v1/n8n/runs/update",
+        "authentication": "predefinedCredentialType",
+        "nodeCredentialType": "httpBearerAuth",
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "{\n  \"run_id\": \"={{$json.run?.run_id || $json.run_id}}\",\n  \"state\": \"triage\",\n  \"message\": \"Starting Nexus step triage\",\n  \"data\": {\n    \"step\": {\n      \"id\": \"triage\",\n      \"index\": 1,\n      \"name\": \"Development Tier Selection\",\n      \"description\": \"Classify the request and choose full, shortened, or fast-track\",\n      \"agent_type\": \"triage\",\n      \"context_policy\": \"minimal\",\n      \"tools\": [\n        \"vcs:read_issue\"\n      ],\n      \"inputs\": [\n        {\n          \"issue_url\": \"string\"\n        },\n        {\n          \"request_context\": \"string\"\n        }\n      ],\n      \"outputs\": [\n        {\n          \"selected_workflow\": \"enum[development_full, development_shortened, development_fast_track]\"\n        },\n        {\n          \"initial_analysis\": \"string\"\n        }\n      ],\n      \"on_success\": \"dispatch\"\n    }\n  }\n}"
+      },
+      "id": "start-triage",
+      "name": "01 Start triage",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [
+        560,
+        0
+      ],
+      "notesInFlow": true,
+      "notes": "Classify the request and choose full, shortened, or fast-track"
+    },
+    {
+      "parameters": {
+        "method": "POST",
+        "url": "http://nexus-bridge-1:8091/api/v1/n8n/runs/update",
+        "authentication": "predefinedCredentialType",
+        "nodeCredentialType": "httpBearerAuth",
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "{\n  \"run_id\": \"={{$json.run?.run_id || $json.run_id}}\",\n  \"state\": \"triage_completed\",\n  \"message\": \"Completed Nexus step triage\",\n  \"data\": {\n    \"step\": {\n      \"id\": \"triage\",\n      \"name\": \"Development Tier Selection\",\n      \"description\": \"Classify the request and choose full, shortened, or fast-track\",\n      \"agent_type\": \"triage\",\n      \"context_policy\": \"minimal\",\n      \"tools\": [\n        \"vcs:read_issue\"\n      ],\n      \"inputs\": [\n        {\n          \"issue_url\": \"string\"\n        },\n        {\n          \"request_context\": \"string\"\n        }\n      ],\n      \"outputs\": [\n        {\n          \"selected_workflow\": \"enum[development_full, development_shortened, development_fast_track]\"\n        },\n        {\n          \"initial_analysis\": \"string\"\n        }\n      ],\n      \"on_success\": \"dispatch\"\n    }\n  }\n}"
+      },
+      "id": "complete-triage",
+      "name": "Complete triage",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [
+        780,
+        0
+      ],
+      "notesInFlow": true,
+      "notes": "Replace this state transition with a concrete agent/tool call when available."
+    },
+    {
+      "parameters": {
+        "method": "POST",
+        "url": "http://nexus-bridge-1:8091/api/v1/n8n/runs/update",
+        "authentication": "predefinedCredentialType",
+        "nodeCredentialType": "httpBearerAuth",
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "{\n  \"run_id\": \"={{$json.run?.run_id || $json.run_id}}\",\n  \"state\": \"dispatch\",\n  \"message\": \"Starting Nexus step dispatch\",\n  \"data\": {\n    \"step\": {\n      \"id\": \"dispatch\",\n      \"index\": 2,\n      \"name\": \"Dispatch\",\n      \"description\": \"Trigger selected development sub-workflow\",\n      \"agent_type\": \"triage\",\n      \"context_policy\": \"minimal\",\n      \"inputs\": [\n        {\n          \"selected_workflow\": \"string\"\n        }\n      ],\n      \"routes\": [\n        {\n          \"when\": \"selected_workflow == 'development_full'\",\n          \"then\": \"development_full_workflow\"\n        },\n        {\n          \"when\": \"selected_workflow == 'development_shortened'\",\n          \"then\": \"development_shortened_workflow\"\n        },\n        {\n          \"when\": \"selected_workflow == 'development_fast_track'\",\n          \"then\": \"development_fast_track_workflow\"\n        },\n        {\n          \"default\": \"development_full_workflow\"\n        }\n      ]\n    }\n  }\n}"
+      },
+      "id": "start-dispatch",
+      "name": "02 Start dispatch",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [
+        920,
+        120
+      ],
+      "notesInFlow": true,
+      "notes": "Trigger selected development sub-workflow"
+    },
+    {
+      "parameters": {
+        "jsCode": "const routes = [\n  {\n    \"when\": \"selected_workflow == 'development_full'\",\n    \"then\": \"development_full_workflow\"\n  },\n  {\n    \"when\": \"selected_workflow == 'development_shortened'\",\n    \"then\": \"development_shortened_workflow\"\n  },\n  {\n    \"when\": \"selected_workflow == 'development_fast_track'\",\n    \"then\": \"development_fast_track_workflow\"\n  },\n  {\n    \"default\": \"development_full_workflow\"\n  }\n];\nconst state = $json;\n\nfunction toJsExpression(expr) {\n  return String(expr)\n    .replace(/\\band\\b/g, '&&')\n    .replace(/\\bor\\b/g, '||')\n    .replace(/\\bnot\\b/g, '!')\n    .replace(/\\bTrue\\b/g, 'true')\n    .replace(/\\bFalse\\b/g, 'false')\n    .replace(/\\bNone\\b/g, 'null');\n}\n\nfunction evaluate(expr) {\n  const keys = Object.keys(state);\n  const values = Object.values(state);\n  try {\n    return Boolean(Function(...keys, `return (${toJsExpression(expr)});`)(...values));\n  } catch (error) {\n    return false;\n  }\n}\n\nlet nextStep = null;\nfor (const route of routes) {\n  if (route.when && evaluate(route.when)) {\n    nextStep = route.then;\n    break;\n  }\n  if (!route.when && route.default && nextStep === null) {\n    nextStep = route.default;\n  }\n}\n\nreturn [{ json: { ...state, next_step: nextStep } }];\n"
+      },
+      "id": "route-dispatch",
+      "name": "Route dispatch",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [
+        1140,
+        120
+      ],
+      "notesInFlow": true,
+      "notes": "Evaluates Nexus route rules and writes next_step."
+    },
+    {
+      "parameters": {
+        "mode": "rules",
+        "rules": {
+          "values": [
+            {
+              "conditions": {
+                "conditions": [
+                  {
+                    "leftValue": "={{$json.next_step}}",
+                    "rightValue": "development_full_workflow",
+                    "operator": {
+                      "type": "string",
+                      "operation": "equals"
+                    }
+                  }
+                ],
+                "combinator": "and"
+              }
+            },
+            {
+              "conditions": {
+                "conditions": [
+                  {
+                    "leftValue": "={{$json.next_step}}",
+                    "rightValue": "development_shortened_workflow",
+                    "operator": {
+                      "type": "string",
+                      "operation": "equals"
+                    }
+                  }
+                ],
+                "combinator": "and"
+              }
+            },
+            {
+              "conditions": {
+                "conditions": [
+                  {
+                    "leftValue": "={{$json.next_step}}",
+                    "rightValue": "development_fast_track_workflow",
+                    "operator": {
+                      "type": "string",
+                      "operation": "equals"
+                    }
+                  }
+                ],
+                "combinator": "and"
+              }
+            }
+          ]
+        },
+        "options": {}
+      },
+      "id": "switch-switch-dispatch",
+      "name": "Switch dispatch",
+      "type": "n8n-nodes-base.switch",
+      "typeVersion": 3,
+      "position": [
+        1360,
+        120
+      ],
+      "notesInFlow": true,
+      "notes": "Routes to the Nexus step selected by the preceding Code node."
+    }
+  ],
+  "connections": {
+    "01 Start triage": {
+      "main": [
+        [
+          {
+            "node": "Complete triage",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "02 Start dispatch": {
+      "main": [
+        [
+          {
+            "node": "Route dispatch",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Create Nexus Run": {
+      "main": [
+        [
+          {
+            "node": "01 Start triage",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Manual Trigger": {
+      "main": [
+        [
+          {
+            "node": "Create Nexus Run",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Complete triage": {
+      "main": [
+        [
+          {
+            "node": "02 Start dispatch",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Route dispatch": {
+      "main": [
+        [
+          {
+            "node": "Switch dispatch",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    }
+  },
+  "settings": {
+    "executionOrder": "v1"
+  },
+  "staticData": null,
+  "tags": [
+    "nexus-arc",
+    "generated"
+  ],
+  "meta": {
+    "nexusArc": {
+      "source": "examples/workflows/development_workflow.yaml",
+      "workflowType": "orchestrator",
+      "converter": "nexus.translators.to_n8n"
+    }
+  }
+}

--- a/examples/workflows/n8n/enterprise_fast_track_workflow.json
+++ b/examples/workflows/n8n/enterprise_fast_track_workflow.json
@@ -1,0 +1,445 @@
+{
+  "name": "Enterprise Fast-Track Workflow",
+  "nodes": [
+    {
+      "parameters": {},
+      "id": "manual-trigger",
+      "name": "Manual Trigger",
+      "type": "n8n-nodes-base.manualTrigger",
+      "typeVersion": 1,
+      "position": [
+        0,
+        0
+      ]
+    },
+    {
+      "parameters": {
+        "method": "POST",
+        "url": "http://nexus-bridge-1:8091/api/v1/n8n/runs",
+        "authentication": "predefinedCredentialType",
+        "nodeCredentialType": "httpBearerAuth",
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "{\n  \"task\": \"={{$json.task || $json.title || 'Run Nexus workflow'}}\",\n  \"project_key\": \"={{$json.project_key || $json.project || 'nexus'}}\",\n  \"issue_number\": \"={{$json.issue_number || $json.issue || ''}}\",\n  \"requester\": {\n    \"source\": \"n8n\",\n    \"workflow\": \"Enterprise Fast-Track Workflow\"\n  },\n  \"metadata\": {\n    \"nexus_workflow\": {\n      \"name\": \"Enterprise Fast-Track Workflow\",\n      \"description\": \"Critical hotfix path with emergency triage, rapid implementation, and guarded deploy.\",\n      \"version\": \"1.0.0\"\n    },\n    \"workflow_type\": \"fast-track\",\n    \"source\": \"examples/workflows/enterprise_fast_track_workflow.yaml\"\n  }\n}"
+      },
+      "id": "create-nexus-run",
+      "name": "Create Nexus Run",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [
+        260,
+        0
+      ],
+      "notesInFlow": true,
+      "notes": "Creates the durable Nexus run that n8n will advance."
+    },
+    {
+      "parameters": {
+        "method": "POST",
+        "url": "http://nexus-bridge-1:8091/api/v1/n8n/runs/update",
+        "authentication": "predefinedCredentialType",
+        "nodeCredentialType": "httpBearerAuth",
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "{\n  \"run_id\": \"={{$json.run?.run_id || $json.run_id}}\",\n  \"state\": \"triage\",\n  \"message\": \"Starting Nexus step triage\",\n  \"data\": {\n    \"step\": {\n      \"id\": \"triage\",\n      \"index\": 1,\n      \"name\": \"Emergency Triage\",\n      \"description\": \"Rapid assessment of the critical issue\",\n      \"agent_type\": \"triage\",\n      \"context_policy\": \"minimal\",\n      \"tools\": [\n        \"vcs:read_issue\",\n        \"vcs:add_label\",\n        \"vcs:add_comment\"\n      ],\n      \"inputs\": [\n        {\n          \"issue_url\": \"string\"\n        }\n      ],\n      \"outputs\": [\n        {\n          \"urgency\": \"enum[critical|urgent]\"\n        },\n        {\n          \"impact\": \"string\"\n        }\n      ],\n      \"on_success\": \"develop\"\n    }\n  }\n}"
+      },
+      "id": "start-triage",
+      "name": "01 Start triage",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [
+        560,
+        0
+      ],
+      "notesInFlow": true,
+      "notes": "Rapid assessment of the critical issue"
+    },
+    {
+      "parameters": {
+        "method": "POST",
+        "url": "http://nexus-bridge-1:8091/api/v1/n8n/runs/update",
+        "authentication": "predefinedCredentialType",
+        "nodeCredentialType": "httpBearerAuth",
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "{\n  \"run_id\": \"={{$json.run?.run_id || $json.run_id}}\",\n  \"state\": \"triage_completed\",\n  \"message\": \"Completed Nexus step triage\",\n  \"data\": {\n    \"step\": {\n      \"id\": \"triage\",\n      \"name\": \"Emergency Triage\",\n      \"description\": \"Rapid assessment of the critical issue\",\n      \"agent_type\": \"triage\",\n      \"context_policy\": \"minimal\",\n      \"tools\": [\n        \"vcs:read_issue\",\n        \"vcs:add_label\",\n        \"vcs:add_comment\"\n      ],\n      \"inputs\": [\n        {\n          \"issue_url\": \"string\"\n        }\n      ],\n      \"outputs\": [\n        {\n          \"urgency\": \"enum[critical|urgent]\"\n        },\n        {\n          \"impact\": \"string\"\n        }\n      ],\n      \"on_success\": \"develop\"\n    }\n  }\n}"
+      },
+      "id": "complete-triage",
+      "name": "Complete triage",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [
+        780,
+        0
+      ],
+      "notesInFlow": true,
+      "notes": "Replace this state transition with a concrete agent/tool call when available."
+    },
+    {
+      "parameters": {
+        "method": "POST",
+        "url": "http://nexus-bridge-1:8091/api/v1/n8n/runs/update",
+        "authentication": "predefinedCredentialType",
+        "nodeCredentialType": "httpBearerAuth",
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "{\n  \"run_id\": \"={{$json.run?.run_id || $json.run_id}}\",\n  \"state\": \"develop\",\n  \"message\": \"Starting Nexus step develop\",\n  \"data\": {\n    \"step\": {\n      \"id\": \"develop\",\n      \"index\": 2,\n      \"name\": \"Fast-Track Implementation\",\n      \"description\": \"Rapidly implement minimal change\",\n      \"agent_type\": \"developer\",\n      \"context_policy\": \"deep\",\n      \"tools\": [\n        \"vcs:create_branch\",\n        \"vcs:commit_changes\",\n        \"vcs:create_pr\",\n        \"vcs:add_comment\"\n      ],\n      \"inputs\": [\n        {\n          \"issue_url\": \"string\"\n        },\n        {\n          \"urgency\": \"string\"\n        }\n      ],\n      \"outputs\": [\n        {\n          \"fast_track_pr_url\": \"string\"\n        },\n        {\n          \"fix_description\": \"string\"\n        }\n      ],\n      \"on_success\": \"review\",\n      \"audit_limit\": 50,\n      \"include_audit_history\": true\n    }\n  }\n}"
+      },
+      "id": "start-develop",
+      "name": "02 Start develop",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [
+        920,
+        120
+      ],
+      "notesInFlow": true,
+      "notes": "Rapidly implement minimal change"
+    },
+    {
+      "parameters": {
+        "method": "POST",
+        "url": "http://nexus-bridge-1:8091/api/v1/n8n/coding/execute",
+        "authentication": "predefinedCredentialType",
+        "nodeCredentialType": "httpBearerAuth",
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "{\n  \"run_id\": \"={{$json.run?.run_id || $json.run_id}}\",\n  \"task\": \"={{$json.task || $json.run?.task || \\\"Rapidly implement minimal change\\\"}}\",\n  \"project_key\": \"={{$json.project_key || $json.run?.project_key || 'nexus'}}\",\n  \"worker\": \"opencode\",\n  \"agent\": \"build\",\n  \"base_branch\": \"develop\",\n  \"metadata\": {\n    \"step\": {\n      \"id\": \"develop\",\n      \"name\": \"Fast-Track Implementation\",\n      \"description\": \"Rapidly implement minimal change\",\n      \"agent_type\": \"developer\",\n      \"context_policy\": \"deep\",\n      \"tools\": [\n        \"vcs:create_branch\",\n        \"vcs:commit_changes\",\n        \"vcs:create_pr\",\n        \"vcs:add_comment\"\n      ],\n      \"inputs\": [\n        {\n          \"issue_url\": \"string\"\n        },\n        {\n          \"urgency\": \"string\"\n        }\n      ],\n      \"outputs\": [\n        {\n          \"fast_track_pr_url\": \"string\"\n        },\n        {\n          \"fix_description\": \"string\"\n        }\n      ],\n      \"on_success\": \"review\",\n      \"audit_limit\": 50,\n      \"include_audit_history\": true\n    }\n  }\n}"
+      },
+      "id": "execute-opencode-develop",
+      "name": "Execute OpenCode develop",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [
+        1140,
+        120
+      ],
+      "notesInFlow": true,
+      "notes": "Guarded Nexus endpoint: allowlist, isolated worktree, no push/merge/PR."
+    },
+    {
+      "parameters": {
+        "method": "POST",
+        "url": "http://nexus-bridge-1:8091/api/v1/n8n/runs/update",
+        "authentication": "predefinedCredentialType",
+        "nodeCredentialType": "httpBearerAuth",
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "{\n  \"run_id\": \"={{$json.run?.run_id || $json.run_id}}\",\n  \"state\": \"review\",\n  \"message\": \"Starting Nexus step review\",\n  \"data\": {\n    \"step\": {\n      \"id\": \"review\",\n      \"index\": 3,\n      \"name\": \"Quick Verification\",\n      \"description\": \"Rapid review of the hotfix with full regression (or equivalent full CI suite) required before approval\",\n      \"agent_type\": \"reviewer\",\n      \"context_policy\": \"standard\",\n      \"tools\": [\n        \"vcs:review_pr\",\n        \"vcs:approve_pr\"\n      ],\n      \"inputs\": [\n        {\n          \"pr_urls\": \"list[string]\"\n        }\n      ],\n      \"outputs\": [\n        {\n          \"review_status\": \"enum[approved|rejected]\"\n        }\n      ],\n      \"on_success\": \"route_review\"\n    }\n  }\n}"
+      },
+      "id": "start-review",
+      "name": "03 Start review",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [
+        1280,
+        0
+      ],
+      "notesInFlow": true,
+      "notes": "Rapid review of the hotfix with full regression (or equivalent full CI suite) required before approval"
+    },
+    {
+      "parameters": {
+        "method": "POST",
+        "url": "http://nexus-bridge-1:8091/api/v1/n8n/runs/update",
+        "authentication": "predefinedCredentialType",
+        "nodeCredentialType": "httpBearerAuth",
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "{\n  \"run_id\": \"={{$json.run?.run_id || $json.run_id}}\",\n  \"state\": \"review_completed\",\n  \"message\": \"Completed Nexus step review\",\n  \"data\": {\n    \"step\": {\n      \"id\": \"review\",\n      \"name\": \"Quick Verification\",\n      \"description\": \"Rapid review of the hotfix with full regression (or equivalent full CI suite) required before approval\",\n      \"agent_type\": \"reviewer\",\n      \"context_policy\": \"standard\",\n      \"tools\": [\n        \"vcs:review_pr\",\n        \"vcs:approve_pr\"\n      ],\n      \"inputs\": [\n        {\n          \"pr_urls\": \"list[string]\"\n        }\n      ],\n      \"outputs\": [\n        {\n          \"review_status\": \"enum[approved|rejected]\"\n        }\n      ],\n      \"on_success\": \"route_review\"\n    }\n  }\n}"
+      },
+      "id": "complete-review",
+      "name": "Complete review",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [
+        1500,
+        0
+      ],
+      "notesInFlow": true,
+      "notes": "Replace this state transition with a concrete agent/tool call when available."
+    },
+    {
+      "parameters": {
+        "method": "POST",
+        "url": "http://nexus-bridge-1:8091/api/v1/n8n/runs/update",
+        "authentication": "predefinedCredentialType",
+        "nodeCredentialType": "httpBearerAuth",
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "{\n  \"run_id\": \"={{$json.run?.run_id || $json.run_id}}\",\n  \"state\": \"route_review\",\n  \"message\": \"Starting Nexus step route_review\",\n  \"data\": {\n    \"step\": {\n      \"id\": \"route_review\",\n      \"index\": 4,\n      \"name\": \"Route After Verification\",\n      \"agent_type\": \"router\",\n      \"context_policy\": \"minimal\",\n      \"routes\": [\n        {\n          \"when\": \"review_status == 'approved'\",\n          \"then\": \"deploy\"\n        },\n        {\n          \"default\": \"develop\"\n        }\n      ]\n    }\n  }\n}"
+      },
+      "id": "start-route_review",
+      "name": "04 Start route_review",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [
+        1640,
+        260
+      ]
+    },
+    {
+      "parameters": {
+        "jsCode": "const routes = [\n  {\n    \"when\": \"review_status == 'approved'\",\n    \"then\": \"deploy\"\n  },\n  {\n    \"default\": \"develop\"\n  }\n];\nconst state = $json;\n\nfunction toJsExpression(expr) {\n  return String(expr)\n    .replace(/\\band\\b/g, '&&')\n    .replace(/\\bor\\b/g, '||')\n    .replace(/\\bnot\\b/g, '!')\n    .replace(/\\bTrue\\b/g, 'true')\n    .replace(/\\bFalse\\b/g, 'false')\n    .replace(/\\bNone\\b/g, 'null');\n}\n\nfunction evaluate(expr) {\n  const keys = Object.keys(state);\n  const values = Object.values(state);\n  try {\n    return Boolean(Function(...keys, `return (${toJsExpression(expr)});`)(...values));\n  } catch (error) {\n    return false;\n  }\n}\n\nlet nextStep = null;\nfor (const route of routes) {\n  if (route.when && evaluate(route.when)) {\n    nextStep = route.then;\n    break;\n  }\n  if (!route.when && route.default && nextStep === null) {\n    nextStep = route.default;\n  }\n}\n\nreturn [{ json: { ...state, next_step: nextStep } }];\n"
+      },
+      "id": "route-route_review",
+      "name": "Route route_review",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [
+        1860,
+        260
+      ],
+      "notesInFlow": true,
+      "notes": "Evaluates Nexus route rules and writes next_step."
+    },
+    {
+      "parameters": {
+        "method": "POST",
+        "url": "http://nexus-bridge-1:8091/api/v1/n8n/runs/update",
+        "authentication": "predefinedCredentialType",
+        "nodeCredentialType": "httpBearerAuth",
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "{\n  \"run_id\": \"={{$json.run?.run_id || $json.run_id}}\",\n  \"state\": \"deploy\",\n  \"message\": \"Starting Nexus step deploy\",\n  \"data\": {\n    \"step\": {\n      \"id\": \"deploy\",\n      \"index\": 5,\n      \"name\": \"Emergency Deploy\",\n      \"description\": \"Merge fast-track changes and deploy immediately\",\n      \"agent_type\": \"deployer\",\n      \"context_policy\": \"standard\",\n      \"tools\": [\n        \"vcs:merge_pr\",\n        \"vcs:create_release\",\n        \"vcs:add_comment\",\n        \"vcs:close_issue\"\n      ],\n      \"inputs\": [\n        {\n          \"fast_track_pr_url\": \"string\"\n        }\n      ],\n      \"outputs\": [\n        {\n          \"deployment_status\": \"string\"\n        },\n        {\n          \"rollback_plan\": \"string\"\n        }\n      ],\n      \"final_step\": true\n    }\n  }\n}"
+      },
+      "id": "start-deploy",
+      "name": "05 Start deploy",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [
+        2000,
+        0
+      ],
+      "notesInFlow": true,
+      "notes": "Merge fast-track changes and deploy immediately"
+    },
+    {
+      "parameters": {
+        "method": "POST",
+        "url": "http://nexus-bridge-1:8091/api/v1/n8n/runs/update",
+        "authentication": "predefinedCredentialType",
+        "nodeCredentialType": "httpBearerAuth",
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "{\n  \"run_id\": \"={{$json.run?.run_id || $json.run_id}}\",\n  \"state\": \"deploy_completed\",\n  \"message\": \"Completed Nexus step deploy\",\n  \"data\": {\n    \"step\": {\n      \"id\": \"deploy\",\n      \"name\": \"Emergency Deploy\",\n      \"description\": \"Merge fast-track changes and deploy immediately\",\n      \"agent_type\": \"deployer\",\n      \"context_policy\": \"standard\",\n      \"tools\": [\n        \"vcs:merge_pr\",\n        \"vcs:create_release\",\n        \"vcs:add_comment\",\n        \"vcs:close_issue\"\n      ],\n      \"inputs\": [\n        {\n          \"fast_track_pr_url\": \"string\"\n        }\n      ],\n      \"outputs\": [\n        {\n          \"deployment_status\": \"string\"\n        },\n        {\n          \"rollback_plan\": \"string\"\n        }\n      ],\n      \"final_step\": true\n    }\n  }\n}"
+      },
+      "id": "complete-deploy",
+      "name": "Complete deploy",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [
+        2220,
+        0
+      ],
+      "notesInFlow": true,
+      "notes": "Replace this state transition with a concrete agent/tool call when available."
+    },
+    {
+      "parameters": {
+        "mode": "rules",
+        "rules": {
+          "values": [
+            {
+              "conditions": {
+                "conditions": [
+                  {
+                    "leftValue": "={{$json.next_step}}",
+                    "rightValue": "deploy",
+                    "operator": {
+                      "type": "string",
+                      "operation": "equals"
+                    }
+                  }
+                ],
+                "combinator": "and"
+              }
+            },
+            {
+              "conditions": {
+                "conditions": [
+                  {
+                    "leftValue": "={{$json.next_step}}",
+                    "rightValue": "develop",
+                    "operator": {
+                      "type": "string",
+                      "operation": "equals"
+                    }
+                  }
+                ],
+                "combinator": "and"
+              }
+            }
+          ]
+        },
+        "options": {}
+      },
+      "id": "switch-switch-route_review",
+      "name": "Switch route_review",
+      "type": "n8n-nodes-base.switch",
+      "typeVersion": 3,
+      "position": [
+        2080,
+        260
+      ],
+      "notesInFlow": true,
+      "notes": "Routes to the Nexus step selected by the preceding Code node."
+    }
+  ],
+  "connections": {
+    "01 Start triage": {
+      "main": [
+        [
+          {
+            "node": "Complete triage",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "02 Start develop": {
+      "main": [
+        [
+          {
+            "node": "Execute OpenCode develop",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "03 Start review": {
+      "main": [
+        [
+          {
+            "node": "Complete review",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "04 Start route_review": {
+      "main": [
+        [
+          {
+            "node": "Route route_review",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "05 Start deploy": {
+      "main": [
+        [
+          {
+            "node": "Complete deploy",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Create Nexus Run": {
+      "main": [
+        [
+          {
+            "node": "01 Start triage",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Manual Trigger": {
+      "main": [
+        [
+          {
+            "node": "Create Nexus Run",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Complete triage": {
+      "main": [
+        [
+          {
+            "node": "02 Start develop",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Execute OpenCode develop": {
+      "main": [
+        [
+          {
+            "node": "03 Start review",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Complete review": {
+      "main": [
+        [
+          {
+            "node": "04 Start route_review",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Route route_review": {
+      "main": [
+        [
+          {
+            "node": "Switch route_review",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Switch route_review": {
+      "main": [
+        [
+          {
+            "node": "05 Start deploy",
+            "type": "main",
+            "index": 0
+          }
+        ],
+        [
+          {
+            "node": "02 Start develop",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    }
+  },
+  "settings": {
+    "executionOrder": "v1"
+  },
+  "staticData": null,
+  "tags": [
+    "nexus-arc",
+    "generated"
+  ],
+  "meta": {
+    "nexusArc": {
+      "source": "examples/workflows/enterprise_fast_track_workflow.yaml",
+      "workflowType": "fast-track",
+      "converter": "nexus.translators.to_n8n"
+    }
+  }
+}

--- a/examples/workflows/n8n/enterprise_full_workflow.json
+++ b/examples/workflows/n8n/enterprise_full_workflow.json
@@ -1,0 +1,1024 @@
+{
+  "name": "Enterprise Full Workflow",
+  "nodes": [
+    {
+      "parameters": {},
+      "id": "manual-trigger",
+      "name": "Manual Trigger",
+      "type": "n8n-nodes-base.manualTrigger",
+      "typeVersion": 1,
+      "position": [
+        0,
+        0
+      ]
+    },
+    {
+      "parameters": {
+        "method": "POST",
+        "url": "http://nexus-bridge-1:8091/api/v1/n8n/runs",
+        "authentication": "predefinedCredentialType",
+        "nodeCredentialType": "httpBearerAuth",
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "{\n  \"task\": \"={{$json.task || $json.title || 'Run Nexus workflow'}}\",\n  \"project_key\": \"={{$json.project_key || $json.project || 'nexus'}}\",\n  \"issue_number\": \"={{$json.issue_number || $json.issue || ''}}\",\n  \"requester\": {\n    \"source\": \"n8n\",\n    \"workflow\": \"Enterprise Full Workflow\"\n  },\n  \"metadata\": {\n    \"nexus_workflow\": {\n      \"name\": \"Enterprise Full Workflow\",\n      \"description\": \"Full enterprise delivery with design, review, compliance, and deploy gates.\",\n      \"version\": \"1.0.0\"\n    },\n    \"workflow_type\": \"full\",\n    \"source\": \"examples/workflows/enterprise_full_workflow.yaml\"\n  }\n}"
+      },
+      "id": "create-nexus-run",
+      "name": "Create Nexus Run",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [
+        260,
+        0
+      ],
+      "notesInFlow": true,
+      "notes": "Creates the durable Nexus run that n8n will advance."
+    },
+    {
+      "parameters": {
+        "method": "POST",
+        "url": "http://nexus-bridge-1:8091/api/v1/n8n/runs/update",
+        "authentication": "predefinedCredentialType",
+        "nodeCredentialType": "httpBearerAuth",
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "{\n  \"run_id\": \"={{$json.run?.run_id || $json.run_id}}\",\n  \"state\": \"triage\",\n  \"message\": \"Starting Nexus step triage\",\n  \"data\": {\n    \"step\": {\n      \"id\": \"triage\",\n      \"index\": 1,\n      \"name\": \"Triage & Classification\",\n      \"description\": \"Classify the issue, assign priority, and decide the path\",\n      \"agent_type\": \"triage\",\n      \"context_policy\": \"minimal\",\n      \"tools\": [\n        \"vcs:read_issue\",\n        \"vcs:add_label\",\n        \"vcs:search_codebase\"\n      ],\n      \"inputs\": [\n        {\n          \"issue_url\": \"string\"\n        }\n      ],\n      \"outputs\": [\n        {\n          \"classification\": \"enum[feature|bug|doc|support]\"\n        },\n        {\n          \"priority\": \"enum[p0-critical|p1-high|p2-medium|p3-low]\"\n        },\n        {\n          \"needs_design\": \"boolean\"\n        }\n      ],\n      \"on_success\": \"route_triage\"\n    }\n  }\n}"
+      },
+      "id": "start-triage",
+      "name": "01 Start triage",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [
+        560,
+        0
+      ],
+      "notesInFlow": true,
+      "notes": "Classify the issue, assign priority, and decide the path"
+    },
+    {
+      "parameters": {
+        "method": "POST",
+        "url": "http://nexus-bridge-1:8091/api/v1/n8n/runs/update",
+        "authentication": "predefinedCredentialType",
+        "nodeCredentialType": "httpBearerAuth",
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "{\n  \"run_id\": \"={{$json.run?.run_id || $json.run_id}}\",\n  \"state\": \"triage_completed\",\n  \"message\": \"Completed Nexus step triage\",\n  \"data\": {\n    \"step\": {\n      \"id\": \"triage\",\n      \"name\": \"Triage & Classification\",\n      \"description\": \"Classify the issue, assign priority, and decide the path\",\n      \"agent_type\": \"triage\",\n      \"context_policy\": \"minimal\",\n      \"tools\": [\n        \"vcs:read_issue\",\n        \"vcs:add_label\",\n        \"vcs:search_codebase\"\n      ],\n      \"inputs\": [\n        {\n          \"issue_url\": \"string\"\n        }\n      ],\n      \"outputs\": [\n        {\n          \"classification\": \"enum[feature|bug|doc|support]\"\n        },\n        {\n          \"priority\": \"enum[p0-critical|p1-high|p2-medium|p3-low]\"\n        },\n        {\n          \"needs_design\": \"boolean\"\n        }\n      ],\n      \"on_success\": \"route_triage\"\n    }\n  }\n}"
+      },
+      "id": "complete-triage",
+      "name": "Complete triage",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [
+        780,
+        0
+      ],
+      "notesInFlow": true,
+      "notes": "Replace this state transition with a concrete agent/tool call when available."
+    },
+    {
+      "parameters": {
+        "method": "POST",
+        "url": "http://nexus-bridge-1:8091/api/v1/n8n/runs/update",
+        "authentication": "predefinedCredentialType",
+        "nodeCredentialType": "httpBearerAuth",
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "{\n  \"run_id\": \"={{$json.run?.run_id || $json.run_id}}\",\n  \"state\": \"route_triage\",\n  \"message\": \"Starting Nexus step route_triage\",\n  \"data\": {\n    \"step\": {\n      \"id\": \"route_triage\",\n      \"index\": 2,\n      \"name\": \"Route After Triage\",\n      \"agent_type\": \"router\",\n      \"context_policy\": \"minimal\",\n      \"routes\": [\n        {\n          \"when\": \"classification == 'feature' and needs_design == false\",\n          \"then\": \"develop\"\n        },\n        {\n          \"when\": \"classification == 'feature'\",\n          \"then\": \"design\"\n        },\n        {\n          \"default\": \"develop\"\n        }\n      ]\n    }\n  }\n}"
+      },
+      "id": "start-route_triage",
+      "name": "02 Start route_triage",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [
+        920,
+        260
+      ]
+    },
+    {
+      "parameters": {
+        "jsCode": "const routes = [\n  {\n    \"when\": \"classification == 'feature' and needs_design == false\",\n    \"then\": \"develop\"\n  },\n  {\n    \"when\": \"classification == 'feature'\",\n    \"then\": \"design\"\n  },\n  {\n    \"default\": \"develop\"\n  }\n];\nconst state = $json;\n\nfunction toJsExpression(expr) {\n  return String(expr)\n    .replace(/\\band\\b/g, '&&')\n    .replace(/\\bor\\b/g, '||')\n    .replace(/\\bnot\\b/g, '!')\n    .replace(/\\bTrue\\b/g, 'true')\n    .replace(/\\bFalse\\b/g, 'false')\n    .replace(/\\bNone\\b/g, 'null');\n}\n\nfunction evaluate(expr) {\n  const keys = Object.keys(state);\n  const values = Object.values(state);\n  try {\n    return Boolean(Function(...keys, `return (${toJsExpression(expr)});`)(...values));\n  } catch (error) {\n    return false;\n  }\n}\n\nlet nextStep = null;\nfor (const route of routes) {\n  if (route.when && evaluate(route.when)) {\n    nextStep = route.then;\n    break;\n  }\n  if (!route.when && route.default && nextStep === null) {\n    nextStep = route.default;\n  }\n}\n\nreturn [{ json: { ...state, next_step: nextStep } }];\n"
+      },
+      "id": "route-route_triage",
+      "name": "Route route_triage",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [
+        1140,
+        260
+      ],
+      "notesInFlow": true,
+      "notes": "Evaluates Nexus route rules and writes next_step."
+    },
+    {
+      "parameters": {
+        "method": "POST",
+        "url": "http://nexus-bridge-1:8091/api/v1/n8n/runs/update",
+        "authentication": "predefinedCredentialType",
+        "nodeCredentialType": "httpBearerAuth",
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "{\n  \"run_id\": \"={{$json.run?.run_id || $json.run_id}}\",\n  \"state\": \"design\",\n  \"message\": \"Starting Nexus step design\",\n  \"data\": {\n    \"step\": {\n      \"id\": \"design\",\n      \"index\": 3,\n      \"name\": \"Architecture & Design\",\n      \"description\": \"Create a design proposal covering API contracts and ADRs\",\n      \"agent_type\": \"designer\",\n      \"context_policy\": \"standard\",\n      \"tools\": [\n        \"vcs:create_branch\",\n        \"vcs:create_file\",\n        \"vcs:create_pr\"\n      ],\n      \"inputs\": [\n        {\n          \"issue_url\": \"string\"\n        },\n        {\n          \"classification\": \"string\"\n        }\n      ],\n      \"outputs\": [\n        {\n          \"design_pr_url\": \"string\"\n        },\n        {\n          \"design_patterns\": \"list[string]\"\n        },\n        {\n          \"estimated_effort\": \"string\"\n        }\n      ],\n      \"on_success\": \"develop\"\n    }\n  }\n}"
+      },
+      "id": "start-design",
+      "name": "03 Start design",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [
+        1280,
+        0
+      ],
+      "notesInFlow": true,
+      "notes": "Create a design proposal covering API contracts and ADRs"
+    },
+    {
+      "parameters": {
+        "method": "POST",
+        "url": "http://nexus-bridge-1:8091/api/v1/n8n/runs/update",
+        "authentication": "predefinedCredentialType",
+        "nodeCredentialType": "httpBearerAuth",
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "{\n  \"run_id\": \"={{$json.run?.run_id || $json.run_id}}\",\n  \"state\": \"design_completed\",\n  \"message\": \"Completed Nexus step design\",\n  \"data\": {\n    \"step\": {\n      \"id\": \"design\",\n      \"name\": \"Architecture & Design\",\n      \"description\": \"Create a design proposal covering API contracts and ADRs\",\n      \"agent_type\": \"designer\",\n      \"context_policy\": \"standard\",\n      \"tools\": [\n        \"vcs:create_branch\",\n        \"vcs:create_file\",\n        \"vcs:create_pr\"\n      ],\n      \"inputs\": [\n        {\n          \"issue_url\": \"string\"\n        },\n        {\n          \"classification\": \"string\"\n        }\n      ],\n      \"outputs\": [\n        {\n          \"design_pr_url\": \"string\"\n        },\n        {\n          \"design_patterns\": \"list[string]\"\n        },\n        {\n          \"estimated_effort\": \"string\"\n        }\n      ],\n      \"on_success\": \"develop\"\n    }\n  }\n}"
+      },
+      "id": "complete-design",
+      "name": "Complete design",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [
+        1500,
+        0
+      ],
+      "notesInFlow": true,
+      "notes": "Replace this state transition with a concrete agent/tool call when available."
+    },
+    {
+      "parameters": {
+        "method": "POST",
+        "url": "http://nexus-bridge-1:8091/api/v1/n8n/runs/update",
+        "authentication": "predefinedCredentialType",
+        "nodeCredentialType": "httpBearerAuth",
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "{\n  \"run_id\": \"={{$json.run?.run_id || $json.run_id}}\",\n  \"state\": \"develop\",\n  \"message\": \"Starting Nexus step develop\",\n  \"data\": {\n    \"step\": {\n      \"id\": \"develop\",\n      \"index\": 4,\n      \"name\": \"Implementation\",\n      \"description\": \"Implement code changes based on design or triage output\",\n      \"agent_type\": \"developer\",\n      \"context_policy\": \"deep\",\n      \"tools\": [\n        \"vcs:create_branch\",\n        \"vcs:commit_changes\",\n        \"vcs:create_pr\"\n      ],\n      \"inputs\": [\n        {\n          \"issue_url\": \"string\"\n        }\n      ],\n      \"outputs\": [\n        {\n          \"implementation_pr_url\": \"string\"\n        },\n        {\n          \"test_coverage\": \"string\"\n        },\n        {\n          \"implementation_notes\": \"string\"\n        }\n      ],\n      \"on_success\": \"review\",\n      \"audit_limit\": 50,\n      \"include_audit_history\": true\n    }\n  }\n}"
+      },
+      "id": "start-develop",
+      "name": "04 Start develop",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [
+        1640,
+        120
+      ],
+      "notesInFlow": true,
+      "notes": "Implement code changes based on design or triage output"
+    },
+    {
+      "parameters": {
+        "method": "POST",
+        "url": "http://nexus-bridge-1:8091/api/v1/n8n/coding/execute",
+        "authentication": "predefinedCredentialType",
+        "nodeCredentialType": "httpBearerAuth",
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "{\n  \"run_id\": \"={{$json.run?.run_id || $json.run_id}}\",\n  \"task\": \"={{$json.task || $json.run?.task || \\\"Implement code changes based on design or triage output\\\"}}\",\n  \"project_key\": \"={{$json.project_key || $json.run?.project_key || 'nexus'}}\",\n  \"worker\": \"opencode\",\n  \"agent\": \"build\",\n  \"base_branch\": \"develop\",\n  \"metadata\": {\n    \"step\": {\n      \"id\": \"develop\",\n      \"name\": \"Implementation\",\n      \"description\": \"Implement code changes based on design or triage output\",\n      \"agent_type\": \"developer\",\n      \"context_policy\": \"deep\",\n      \"tools\": [\n        \"vcs:create_branch\",\n        \"vcs:commit_changes\",\n        \"vcs:create_pr\"\n      ],\n      \"inputs\": [\n        {\n          \"issue_url\": \"string\"\n        }\n      ],\n      \"outputs\": [\n        {\n          \"implementation_pr_url\": \"string\"\n        },\n        {\n          \"test_coverage\": \"string\"\n        },\n        {\n          \"implementation_notes\": \"string\"\n        }\n      ],\n      \"on_success\": \"review\",\n      \"audit_limit\": 50,\n      \"include_audit_history\": true\n    }\n  }\n}"
+      },
+      "id": "execute-opencode-develop",
+      "name": "Execute OpenCode develop",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [
+        1860,
+        120
+      ],
+      "notesInFlow": true,
+      "notes": "Guarded Nexus endpoint: allowlist, isolated worktree, no push/merge/PR."
+    },
+    {
+      "parameters": {
+        "method": "POST",
+        "url": "http://nexus-bridge-1:8091/api/v1/n8n/runs/update",
+        "authentication": "predefinedCredentialType",
+        "nodeCredentialType": "httpBearerAuth",
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "{\n  \"run_id\": \"={{$json.run?.run_id || $json.run_id}}\",\n  \"state\": \"review\",\n  \"message\": \"Starting Nexus step review\",\n  \"data\": {\n    \"step\": {\n      \"id\": \"review\",\n      \"index\": 5,\n      \"name\": \"Code Review\",\n      \"description\": \"Review implementation for correctness, quality, and standards; approve only after full regression (or equivalent full CI suite) passes\",\n      \"agent_type\": \"reviewer\",\n      \"context_policy\": \"standard\",\n      \"tools\": [\n        \"vcs:review_pr\",\n        \"vcs:request_changes\",\n        \"vcs:approve_pr\"\n      ],\n      \"inputs\": [\n        {\n          \"pr_urls\": \"list[string]\"\n        }\n      ],\n      \"outputs\": [\n        {\n          \"review_status\": \"enum[approved|changes_requested|rejected]\"\n        },\n        {\n          \"review_comments\": \"list[string]\"\n        }\n      ],\n      \"on_success\": \"route_review\"\n    }\n  }\n}"
+      },
+      "id": "start-review",
+      "name": "05 Start review",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [
+        2000,
+        0
+      ],
+      "notesInFlow": true,
+      "notes": "Review implementation for correctness, quality, and standards; approve only after full regression (or equivalent full CI suite) passes"
+    },
+    {
+      "parameters": {
+        "method": "POST",
+        "url": "http://nexus-bridge-1:8091/api/v1/n8n/runs/update",
+        "authentication": "predefinedCredentialType",
+        "nodeCredentialType": "httpBearerAuth",
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "{\n  \"run_id\": \"={{$json.run?.run_id || $json.run_id}}\",\n  \"state\": \"review_completed\",\n  \"message\": \"Completed Nexus step review\",\n  \"data\": {\n    \"step\": {\n      \"id\": \"review\",\n      \"name\": \"Code Review\",\n      \"description\": \"Review implementation for correctness, quality, and standards; approve only after full regression (or equivalent full CI suite) passes\",\n      \"agent_type\": \"reviewer\",\n      \"context_policy\": \"standard\",\n      \"tools\": [\n        \"vcs:review_pr\",\n        \"vcs:request_changes\",\n        \"vcs:approve_pr\"\n      ],\n      \"inputs\": [\n        {\n          \"pr_urls\": \"list[string]\"\n        }\n      ],\n      \"outputs\": [\n        {\n          \"review_status\": \"enum[approved|changes_requested|rejected]\"\n        },\n        {\n          \"review_comments\": \"list[string]\"\n        }\n      ],\n      \"on_success\": \"route_review\"\n    }\n  }\n}"
+      },
+      "id": "complete-review",
+      "name": "Complete review",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [
+        2220,
+        0
+      ],
+      "notesInFlow": true,
+      "notes": "Replace this state transition with a concrete agent/tool call when available."
+    },
+    {
+      "parameters": {
+        "method": "POST",
+        "url": "http://nexus-bridge-1:8091/api/v1/n8n/runs/update",
+        "authentication": "predefinedCredentialType",
+        "nodeCredentialType": "httpBearerAuth",
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "{\n  \"run_id\": \"={{$json.run?.run_id || $json.run_id}}\",\n  \"state\": \"route_review\",\n  \"message\": \"Starting Nexus step route_review\",\n  \"data\": {\n    \"step\": {\n      \"id\": \"route_review\",\n      \"index\": 6,\n      \"name\": \"Route After Review\",\n      \"agent_type\": \"router\",\n      \"context_policy\": \"minimal\",\n      \"routes\": [\n        {\n          \"when\": \"review_status == 'approved'\",\n          \"then\": \"compliance\"\n        },\n        {\n          \"when\": \"review_status == 'changes_requested'\",\n          \"then\": \"develop\"\n        },\n        {\n          \"default\": \"close_rejected\"\n        }\n      ]\n    }\n  }\n}"
+      },
+      "id": "start-route_review",
+      "name": "06 Start route_review",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [
+        2360,
+        260
+      ]
+    },
+    {
+      "parameters": {
+        "jsCode": "const routes = [\n  {\n    \"when\": \"review_status == 'approved'\",\n    \"then\": \"compliance\"\n  },\n  {\n    \"when\": \"review_status == 'changes_requested'\",\n    \"then\": \"develop\"\n  },\n  {\n    \"default\": \"close_rejected\"\n  }\n];\nconst state = $json;\n\nfunction toJsExpression(expr) {\n  return String(expr)\n    .replace(/\\band\\b/g, '&&')\n    .replace(/\\bor\\b/g, '||')\n    .replace(/\\bnot\\b/g, '!')\n    .replace(/\\bTrue\\b/g, 'true')\n    .replace(/\\bFalse\\b/g, 'false')\n    .replace(/\\bNone\\b/g, 'null');\n}\n\nfunction evaluate(expr) {\n  const keys = Object.keys(state);\n  const values = Object.values(state);\n  try {\n    return Boolean(Function(...keys, `return (${toJsExpression(expr)});`)(...values));\n  } catch (error) {\n    return false;\n  }\n}\n\nlet nextStep = null;\nfor (const route of routes) {\n  if (route.when && evaluate(route.when)) {\n    nextStep = route.then;\n    break;\n  }\n  if (!route.when && route.default && nextStep === null) {\n    nextStep = route.default;\n  }\n}\n\nreturn [{ json: { ...state, next_step: nextStep } }];\n"
+      },
+      "id": "route-route_review",
+      "name": "Route route_review",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [
+        2580,
+        260
+      ],
+      "notesInFlow": true,
+      "notes": "Evaluates Nexus route rules and writes next_step."
+    },
+    {
+      "parameters": {
+        "method": "POST",
+        "url": "http://nexus-bridge-1:8091/api/v1/n8n/runs/update",
+        "authentication": "predefinedCredentialType",
+        "nodeCredentialType": "httpBearerAuth",
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "{\n  \"run_id\": \"={{$json.run?.run_id || $json.run_id}}\",\n  \"state\": \"compliance\",\n  \"message\": \"Starting Nexus step compliance\",\n  \"data\": {\n    \"step\": {\n      \"id\": \"compliance\",\n      \"index\": 7,\n      \"name\": \"Compliance & Security Review\",\n      \"description\": \"Verify privacy, security, and regulatory compliance\",\n      \"agent_type\": \"compliance\",\n      \"context_policy\": \"standard\",\n      \"tools\": [\n        \"vcs:review_pr\"\n      ],\n      \"inputs\": [\n        {\n          \"implementation_pr_url\": \"string\"\n        }\n      ],\n      \"outputs\": [\n        {\n          \"compliance_status\": \"enum[approved|blocked]\"\n        },\n        {\n          \"compliance_issues\": \"list[string]\"\n        }\n      ],\n      \"on_success\": \"route_compliance\",\n      \"require_human_approval\": true\n    }\n  }\n}"
+      },
+      "id": "start-compliance",
+      "name": "07 Start compliance",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [
+        2720,
+        -180
+      ],
+      "notesInFlow": true,
+      "notes": "Verify privacy, security, and regulatory compliance"
+    },
+    {
+      "parameters": {
+        "method": "POST",
+        "url": "http://nexus-bridge-1:8091/api/v1/n8n/runs/update",
+        "authentication": "predefinedCredentialType",
+        "nodeCredentialType": "httpBearerAuth",
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "{\n  \"run_id\": \"={{$json.run?.run_id || $json.run_id}}\",\n  \"state\": \"compliance_awaiting_approval\",\n  \"message\": \"Human approval required before compliance\",\n  \"data\": {\n    \"step_id\": \"compliance\",\n    \"agent_type\": \"compliance\"\n  }\n}"
+      },
+      "id": "approval-compliance",
+      "name": "Approval Gate compliance",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [
+        2940,
+        -300
+      ],
+      "notesInFlow": true,
+      "notes": "Connect this node to an n8n approval/wait mechanism if the gate must pause."
+    },
+    {
+      "parameters": {
+        "method": "POST",
+        "url": "http://nexus-bridge-1:8091/api/v1/n8n/runs/update",
+        "authentication": "predefinedCredentialType",
+        "nodeCredentialType": "httpBearerAuth",
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "{\n  \"run_id\": \"={{$json.run?.run_id || $json.run_id}}\",\n  \"state\": \"compliance_completed\",\n  \"message\": \"Completed Nexus step compliance\",\n  \"data\": {\n    \"step\": {\n      \"id\": \"compliance\",\n      \"name\": \"Compliance & Security Review\",\n      \"description\": \"Verify privacy, security, and regulatory compliance\",\n      \"agent_type\": \"compliance\",\n      \"context_policy\": \"standard\",\n      \"tools\": [\n        \"vcs:review_pr\"\n      ],\n      \"inputs\": [\n        {\n          \"implementation_pr_url\": \"string\"\n        }\n      ],\n      \"outputs\": [\n        {\n          \"compliance_status\": \"enum[approved|blocked]\"\n        },\n        {\n          \"compliance_issues\": \"list[string]\"\n        }\n      ],\n      \"on_success\": \"route_compliance\",\n      \"require_human_approval\": true\n    }\n  }\n}"
+      },
+      "id": "complete-compliance",
+      "name": "Complete compliance",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [
+        2940,
+        -180
+      ],
+      "notesInFlow": true,
+      "notes": "Replace this state transition with a concrete agent/tool call when available."
+    },
+    {
+      "parameters": {
+        "method": "POST",
+        "url": "http://nexus-bridge-1:8091/api/v1/n8n/runs/update",
+        "authentication": "predefinedCredentialType",
+        "nodeCredentialType": "httpBearerAuth",
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "{\n  \"run_id\": \"={{$json.run?.run_id || $json.run_id}}\",\n  \"state\": \"route_compliance\",\n  \"message\": \"Starting Nexus step route_compliance\",\n  \"data\": {\n    \"step\": {\n      \"id\": \"route_compliance\",\n      \"index\": 8,\n      \"name\": \"Route After Compliance\",\n      \"agent_type\": \"router\",\n      \"context_policy\": \"minimal\",\n      \"routes\": [\n        {\n          \"when\": \"compliance_status == 'approved'\",\n          \"then\": \"deploy\"\n        },\n        {\n          \"default\": \"develop\"\n        }\n      ]\n    }\n  }\n}"
+      },
+      "id": "start-route_compliance",
+      "name": "08 Start route_compliance",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [
+        3080,
+        260
+      ]
+    },
+    {
+      "parameters": {
+        "jsCode": "const routes = [\n  {\n    \"when\": \"compliance_status == 'approved'\",\n    \"then\": \"deploy\"\n  },\n  {\n    \"default\": \"develop\"\n  }\n];\nconst state = $json;\n\nfunction toJsExpression(expr) {\n  return String(expr)\n    .replace(/\\band\\b/g, '&&')\n    .replace(/\\bor\\b/g, '||')\n    .replace(/\\bnot\\b/g, '!')\n    .replace(/\\bTrue\\b/g, 'true')\n    .replace(/\\bFalse\\b/g, 'false')\n    .replace(/\\bNone\\b/g, 'null');\n}\n\nfunction evaluate(expr) {\n  const keys = Object.keys(state);\n  const values = Object.values(state);\n  try {\n    return Boolean(Function(...keys, `return (${toJsExpression(expr)});`)(...values));\n  } catch (error) {\n    return false;\n  }\n}\n\nlet nextStep = null;\nfor (const route of routes) {\n  if (route.when && evaluate(route.when)) {\n    nextStep = route.then;\n    break;\n  }\n  if (!route.when && route.default && nextStep === null) {\n    nextStep = route.default;\n  }\n}\n\nreturn [{ json: { ...state, next_step: nextStep } }];\n"
+      },
+      "id": "route-route_compliance",
+      "name": "Route route_compliance",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [
+        3300,
+        260
+      ],
+      "notesInFlow": true,
+      "notes": "Evaluates Nexus route rules and writes next_step."
+    },
+    {
+      "parameters": {
+        "method": "POST",
+        "url": "http://nexus-bridge-1:8091/api/v1/n8n/runs/update",
+        "authentication": "predefinedCredentialType",
+        "nodeCredentialType": "httpBearerAuth",
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "{\n  \"run_id\": \"={{$json.run?.run_id || $json.run_id}}\",\n  \"state\": \"deploy\",\n  \"message\": \"Starting Nexus step deploy\",\n  \"data\": {\n    \"step\": {\n      \"id\": \"deploy\",\n      \"index\": 9,\n      \"name\": \"Merge & Deploy\",\n      \"description\": \"Merge approved PR and create a release\",\n      \"agent_type\": \"deployer\",\n      \"context_policy\": \"standard\",\n      \"tools\": [\n        \"vcs:merge_pr\",\n        \"vcs:create_release\"\n      ],\n      \"inputs\": [\n        {\n          \"implementation_pr_url\": \"string\"\n        }\n      ],\n      \"outputs\": [\n        {\n          \"deployment_status\": \"string\"\n        },\n        {\n          \"release_url\": \"string\"\n        }\n      ],\n      \"on_success\": \"close_loop\",\n      \"require_human_approval\": true\n    }\n  }\n}"
+      },
+      "id": "start-deploy",
+      "name": "09 Start deploy",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [
+        3440,
+        -180
+      ],
+      "notesInFlow": true,
+      "notes": "Merge approved PR and create a release"
+    },
+    {
+      "parameters": {
+        "method": "POST",
+        "url": "http://nexus-bridge-1:8091/api/v1/n8n/runs/update",
+        "authentication": "predefinedCredentialType",
+        "nodeCredentialType": "httpBearerAuth",
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "{\n  \"run_id\": \"={{$json.run?.run_id || $json.run_id}}\",\n  \"state\": \"deploy_awaiting_approval\",\n  \"message\": \"Human approval required before deploy\",\n  \"data\": {\n    \"step_id\": \"deploy\",\n    \"agent_type\": \"deployer\"\n  }\n}"
+      },
+      "id": "approval-deploy",
+      "name": "Approval Gate deploy",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [
+        3660,
+        -300
+      ],
+      "notesInFlow": true,
+      "notes": "Connect this node to an n8n approval/wait mechanism if the gate must pause."
+    },
+    {
+      "parameters": {
+        "method": "POST",
+        "url": "http://nexus-bridge-1:8091/api/v1/n8n/runs/update",
+        "authentication": "predefinedCredentialType",
+        "nodeCredentialType": "httpBearerAuth",
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "{\n  \"run_id\": \"={{$json.run?.run_id || $json.run_id}}\",\n  \"state\": \"deploy_completed\",\n  \"message\": \"Completed Nexus step deploy\",\n  \"data\": {\n    \"step\": {\n      \"id\": \"deploy\",\n      \"name\": \"Merge & Deploy\",\n      \"description\": \"Merge approved PR and create a release\",\n      \"agent_type\": \"deployer\",\n      \"context_policy\": \"standard\",\n      \"tools\": [\n        \"vcs:merge_pr\",\n        \"vcs:create_release\"\n      ],\n      \"inputs\": [\n        {\n          \"implementation_pr_url\": \"string\"\n        }\n      ],\n      \"outputs\": [\n        {\n          \"deployment_status\": \"string\"\n        },\n        {\n          \"release_url\": \"string\"\n        }\n      ],\n      \"on_success\": \"close_loop\",\n      \"require_human_approval\": true\n    }\n  }\n}"
+      },
+      "id": "complete-deploy",
+      "name": "Complete deploy",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [
+        3660,
+        -180
+      ],
+      "notesInFlow": true,
+      "notes": "Replace this state transition with a concrete agent/tool call when available."
+    },
+    {
+      "parameters": {
+        "method": "POST",
+        "url": "http://nexus-bridge-1:8091/api/v1/n8n/runs/update",
+        "authentication": "predefinedCredentialType",
+        "nodeCredentialType": "httpBearerAuth",
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "{\n  \"run_id\": \"={{$json.run?.run_id || $json.run_id}}\",\n  \"state\": \"close_loop\",\n  \"message\": \"Starting Nexus step close_loop\",\n  \"data\": {\n    \"step\": {\n      \"id\": \"close_loop\",\n      \"index\": 10,\n      \"name\": \"Document & Close\",\n      \"description\": \"Check compliance status, update docs if clear, close issue only if no unresolved blockers\",\n      \"agent_type\": \"writer\",\n      \"context_policy\": \"standard\",\n      \"tools\": [\n        \"vcs:create_file\",\n        \"vcs:edit_file\",\n        \"vcs:close_issue\"\n      ],\n      \"inputs\": [\n        {\n          \"issue_url\": \"string\"\n        },\n        {\n          \"deployment_status\": \"string\"\n        }\n      ],\n      \"outputs\": [\n        {\n          \"documentation_url\": \"string\"\n        },\n        {\n          \"changelog_entry\": \"string\"\n        },\n        {\n          \"close_status\": \"enum[closed,blocked]\"\n        }\n      ],\n      \"final_step\": true,\n      \"audit_limit\": 10\n    }\n  }\n}"
+      },
+      "id": "start-close_loop",
+      "name": "10 Start close_loop",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [
+        3800,
+        120
+      ],
+      "notesInFlow": true,
+      "notes": "Check compliance status, update docs if clear, close issue only if no unresolved blockers"
+    },
+    {
+      "parameters": {
+        "method": "POST",
+        "url": "http://nexus-bridge-1:8091/api/v1/n8n/runs/update",
+        "authentication": "predefinedCredentialType",
+        "nodeCredentialType": "httpBearerAuth",
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "{\n  \"run_id\": \"={{$json.run?.run_id || $json.run_id}}\",\n  \"state\": \"close_loop_completed\",\n  \"message\": \"Completed Nexus step close_loop\",\n  \"data\": {\n    \"step\": {\n      \"id\": \"close_loop\",\n      \"name\": \"Document & Close\",\n      \"description\": \"Check compliance status, update docs if clear, close issue only if no unresolved blockers\",\n      \"agent_type\": \"writer\",\n      \"context_policy\": \"standard\",\n      \"tools\": [\n        \"vcs:create_file\",\n        \"vcs:edit_file\",\n        \"vcs:close_issue\"\n      ],\n      \"inputs\": [\n        {\n          \"issue_url\": \"string\"\n        },\n        {\n          \"deployment_status\": \"string\"\n        }\n      ],\n      \"outputs\": [\n        {\n          \"documentation_url\": \"string\"\n        },\n        {\n          \"changelog_entry\": \"string\"\n        },\n        {\n          \"close_status\": \"enum[closed,blocked]\"\n        }\n      ],\n      \"final_step\": true,\n      \"audit_limit\": 10\n    }\n  }\n}"
+      },
+      "id": "complete-close_loop",
+      "name": "Complete close_loop",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [
+        4020,
+        120
+      ],
+      "notesInFlow": true,
+      "notes": "Replace this state transition with a concrete agent/tool call when available."
+    },
+    {
+      "parameters": {
+        "method": "POST",
+        "url": "http://nexus-bridge-1:8091/api/v1/n8n/runs/update",
+        "authentication": "predefinedCredentialType",
+        "nodeCredentialType": "httpBearerAuth",
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "{\n  \"run_id\": \"={{$json.run?.run_id || $json.run_id}}\",\n  \"state\": \"close_rejected\",\n  \"message\": \"Starting Nexus step close_rejected\",\n  \"data\": {\n    \"step\": {\n      \"id\": \"close_rejected\",\n      \"index\": 11,\n      \"name\": \"Close Rejected Issue\",\n      \"description\": \"Post summary and close issues that failed review\",\n      \"agent_type\": \"finalizer\",\n      \"context_policy\": \"minimal\",\n      \"tools\": [\n        \"vcs:close_issue\"\n      ],\n      \"inputs\": [\n        {\n          \"issue_url\": \"string\"\n        },\n        {\n          \"review_comments\": \"list[string]\"\n        }\n      ],\n      \"final_step\": true\n    }\n  }\n}"
+      },
+      "id": "start-close_rejected",
+      "name": "11 Start close_rejected",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [
+        4160,
+        0
+      ],
+      "notesInFlow": true,
+      "notes": "Post summary and close issues that failed review"
+    },
+    {
+      "parameters": {
+        "method": "POST",
+        "url": "http://nexus-bridge-1:8091/api/v1/n8n/runs/update",
+        "authentication": "predefinedCredentialType",
+        "nodeCredentialType": "httpBearerAuth",
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "{\n  \"run_id\": \"={{$json.run?.run_id || $json.run_id}}\",\n  \"state\": \"close_rejected_completed\",\n  \"message\": \"Completed Nexus step close_rejected\",\n  \"data\": {\n    \"step\": {\n      \"id\": \"close_rejected\",\n      \"name\": \"Close Rejected Issue\",\n      \"description\": \"Post summary and close issues that failed review\",\n      \"agent_type\": \"finalizer\",\n      \"context_policy\": \"minimal\",\n      \"tools\": [\n        \"vcs:close_issue\"\n      ],\n      \"inputs\": [\n        {\n          \"issue_url\": \"string\"\n        },\n        {\n          \"review_comments\": \"list[string]\"\n        }\n      ],\n      \"final_step\": true\n    }\n  }\n}"
+      },
+      "id": "complete-close_rejected",
+      "name": "Complete close_rejected",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [
+        4380,
+        0
+      ],
+      "notesInFlow": true,
+      "notes": "Replace this state transition with a concrete agent/tool call when available."
+    },
+    {
+      "parameters": {
+        "mode": "rules",
+        "rules": {
+          "values": [
+            {
+              "conditions": {
+                "conditions": [
+                  {
+                    "leftValue": "={{$json.next_step}}",
+                    "rightValue": "develop",
+                    "operator": {
+                      "type": "string",
+                      "operation": "equals"
+                    }
+                  }
+                ],
+                "combinator": "and"
+              }
+            },
+            {
+              "conditions": {
+                "conditions": [
+                  {
+                    "leftValue": "={{$json.next_step}}",
+                    "rightValue": "design",
+                    "operator": {
+                      "type": "string",
+                      "operation": "equals"
+                    }
+                  }
+                ],
+                "combinator": "and"
+              }
+            }
+          ]
+        },
+        "options": {}
+      },
+      "id": "switch-switch-route_triage",
+      "name": "Switch route_triage",
+      "type": "n8n-nodes-base.switch",
+      "typeVersion": 3,
+      "position": [
+        1360,
+        260
+      ],
+      "notesInFlow": true,
+      "notes": "Routes to the Nexus step selected by the preceding Code node."
+    },
+    {
+      "parameters": {
+        "mode": "rules",
+        "rules": {
+          "values": [
+            {
+              "conditions": {
+                "conditions": [
+                  {
+                    "leftValue": "={{$json.next_step}}",
+                    "rightValue": "compliance",
+                    "operator": {
+                      "type": "string",
+                      "operation": "equals"
+                    }
+                  }
+                ],
+                "combinator": "and"
+              }
+            },
+            {
+              "conditions": {
+                "conditions": [
+                  {
+                    "leftValue": "={{$json.next_step}}",
+                    "rightValue": "develop",
+                    "operator": {
+                      "type": "string",
+                      "operation": "equals"
+                    }
+                  }
+                ],
+                "combinator": "and"
+              }
+            },
+            {
+              "conditions": {
+                "conditions": [
+                  {
+                    "leftValue": "={{$json.next_step}}",
+                    "rightValue": "close_rejected",
+                    "operator": {
+                      "type": "string",
+                      "operation": "equals"
+                    }
+                  }
+                ],
+                "combinator": "and"
+              }
+            }
+          ]
+        },
+        "options": {}
+      },
+      "id": "switch-switch-route_review",
+      "name": "Switch route_review",
+      "type": "n8n-nodes-base.switch",
+      "typeVersion": 3,
+      "position": [
+        2800,
+        260
+      ],
+      "notesInFlow": true,
+      "notes": "Routes to the Nexus step selected by the preceding Code node."
+    },
+    {
+      "parameters": {
+        "mode": "rules",
+        "rules": {
+          "values": [
+            {
+              "conditions": {
+                "conditions": [
+                  {
+                    "leftValue": "={{$json.next_step}}",
+                    "rightValue": "deploy",
+                    "operator": {
+                      "type": "string",
+                      "operation": "equals"
+                    }
+                  }
+                ],
+                "combinator": "and"
+              }
+            },
+            {
+              "conditions": {
+                "conditions": [
+                  {
+                    "leftValue": "={{$json.next_step}}",
+                    "rightValue": "develop",
+                    "operator": {
+                      "type": "string",
+                      "operation": "equals"
+                    }
+                  }
+                ],
+                "combinator": "and"
+              }
+            }
+          ]
+        },
+        "options": {}
+      },
+      "id": "switch-switch-route_compliance",
+      "name": "Switch route_compliance",
+      "type": "n8n-nodes-base.switch",
+      "typeVersion": 3,
+      "position": [
+        3520,
+        260
+      ],
+      "notesInFlow": true,
+      "notes": "Routes to the Nexus step selected by the preceding Code node."
+    }
+  ],
+  "connections": {
+    "01 Start triage": {
+      "main": [
+        [
+          {
+            "node": "Complete triage",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "02 Start route_triage": {
+      "main": [
+        [
+          {
+            "node": "Route route_triage",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "03 Start design": {
+      "main": [
+        [
+          {
+            "node": "Complete design",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "04 Start develop": {
+      "main": [
+        [
+          {
+            "node": "Execute OpenCode develop",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "05 Start review": {
+      "main": [
+        [
+          {
+            "node": "Complete review",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "06 Start route_review": {
+      "main": [
+        [
+          {
+            "node": "Route route_review",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "07 Start compliance": {
+      "main": [
+        [
+          {
+            "node": "Approval Gate compliance",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Approval Gate compliance": {
+      "main": [
+        [
+          {
+            "node": "Complete compliance",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "08 Start route_compliance": {
+      "main": [
+        [
+          {
+            "node": "Route route_compliance",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "09 Start deploy": {
+      "main": [
+        [
+          {
+            "node": "Approval Gate deploy",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Approval Gate deploy": {
+      "main": [
+        [
+          {
+            "node": "Complete deploy",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "10 Start close_loop": {
+      "main": [
+        [
+          {
+            "node": "Complete close_loop",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "11 Start close_rejected": {
+      "main": [
+        [
+          {
+            "node": "Complete close_rejected",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Create Nexus Run": {
+      "main": [
+        [
+          {
+            "node": "01 Start triage",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Manual Trigger": {
+      "main": [
+        [
+          {
+            "node": "Create Nexus Run",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Complete triage": {
+      "main": [
+        [
+          {
+            "node": "02 Start route_triage",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Route route_triage": {
+      "main": [
+        [
+          {
+            "node": "Switch route_triage",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Switch route_triage": {
+      "main": [
+        [
+          {
+            "node": "04 Start develop",
+            "type": "main",
+            "index": 0
+          }
+        ],
+        [
+          {
+            "node": "03 Start design",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Complete design": {
+      "main": [
+        [
+          {
+            "node": "04 Start develop",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Execute OpenCode develop": {
+      "main": [
+        [
+          {
+            "node": "05 Start review",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Complete review": {
+      "main": [
+        [
+          {
+            "node": "06 Start route_review",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Route route_review": {
+      "main": [
+        [
+          {
+            "node": "Switch route_review",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Switch route_review": {
+      "main": [
+        [
+          {
+            "node": "07 Start compliance",
+            "type": "main",
+            "index": 0
+          }
+        ],
+        [
+          {
+            "node": "04 Start develop",
+            "type": "main",
+            "index": 0
+          }
+        ],
+        [
+          {
+            "node": "11 Start close_rejected",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Complete compliance": {
+      "main": [
+        [
+          {
+            "node": "08 Start route_compliance",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Route route_compliance": {
+      "main": [
+        [
+          {
+            "node": "Switch route_compliance",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Switch route_compliance": {
+      "main": [
+        [
+          {
+            "node": "09 Start deploy",
+            "type": "main",
+            "index": 0
+          }
+        ],
+        [
+          {
+            "node": "04 Start develop",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Complete deploy": {
+      "main": [
+        [
+          {
+            "node": "10 Start close_loop",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    }
+  },
+  "settings": {
+    "executionOrder": "v1"
+  },
+  "staticData": null,
+  "tags": [
+    "nexus-arc",
+    "generated"
+  ],
+  "meta": {
+    "nexusArc": {
+      "source": "examples/workflows/enterprise_full_workflow.yaml",
+      "workflowType": "full",
+      "converter": "nexus.translators.to_n8n"
+    }
+  }
+}

--- a/examples/workflows/n8n/enterprise_shortened_workflow.json
+++ b/examples/workflows/n8n/enterprise_shortened_workflow.json
@@ -1,0 +1,573 @@
+{
+  "name": "Enterprise Shortened Workflow",
+  "nodes": [
+    {
+      "parameters": {},
+      "id": "manual-trigger",
+      "name": "Manual Trigger",
+      "type": "n8n-nodes-base.manualTrigger",
+      "typeVersion": 1,
+      "position": [
+        0,
+        0
+      ]
+    },
+    {
+      "parameters": {
+        "method": "POST",
+        "url": "http://nexus-bridge-1:8091/api/v1/n8n/runs",
+        "authentication": "predefinedCredentialType",
+        "nodeCredentialType": "httpBearerAuth",
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "{\n  \"task\": \"={{$json.task || $json.title || 'Run Nexus workflow'}}\",\n  \"project_key\": \"={{$json.project_key || $json.project || 'nexus'}}\",\n  \"issue_number\": \"={{$json.issue_number || $json.issue || ''}}\",\n  \"requester\": {\n    \"source\": \"n8n\",\n    \"workflow\": \"Enterprise Shortened Workflow\"\n  },\n  \"metadata\": {\n    \"nexus_workflow\": {\n      \"name\": \"Enterprise Shortened Workflow\",\n      \"description\": \"Expedited enterprise delivery pipeline with rapid debug, review, and deploy.\",\n      \"version\": \"1.0.0\"\n    },\n    \"workflow_type\": \"shortened\",\n    \"source\": \"examples/workflows/enterprise_shortened_workflow.yaml\"\n  }\n}"
+      },
+      "id": "create-nexus-run",
+      "name": "Create Nexus Run",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [
+        260,
+        0
+      ],
+      "notesInFlow": true,
+      "notes": "Creates the durable Nexus run that n8n will advance."
+    },
+    {
+      "parameters": {
+        "method": "POST",
+        "url": "http://nexus-bridge-1:8091/api/v1/n8n/runs/update",
+        "authentication": "predefinedCredentialType",
+        "nodeCredentialType": "httpBearerAuth",
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "{\n  \"run_id\": \"={{$json.run?.run_id || $json.run_id}}\",\n  \"state\": \"triage\",\n  \"message\": \"Starting Nexus step triage\",\n  \"data\": {\n    \"step\": {\n      \"id\": \"triage\",\n      \"index\": 1,\n      \"name\": \"Intake & Triage\",\n      \"description\": \"Classify priority, scope, and affected components\",\n      \"agent_type\": \"triage\",\n      \"context_policy\": \"minimal\",\n      \"tools\": [\n        \"vcs:read_issue\",\n        \"vcs:add_label\",\n        \"vcs:add_comment\"\n      ],\n      \"inputs\": [\n        {\n          \"issue_url\": \"string\"\n        }\n      ],\n      \"outputs\": [\n        {\n          \"severity\": \"enum[critical|high|medium|low]\"\n        },\n        {\n          \"priority\": \"enum[p0|p1|p2|p3]\"\n        }\n      ],\n      \"on_success\": \"debug\"\n    }\n  }\n}"
+      },
+      "id": "start-triage",
+      "name": "01 Start triage",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [
+        560,
+        0
+      ],
+      "notesInFlow": true,
+      "notes": "Classify priority, scope, and affected components"
+    },
+    {
+      "parameters": {
+        "method": "POST",
+        "url": "http://nexus-bridge-1:8091/api/v1/n8n/runs/update",
+        "authentication": "predefinedCredentialType",
+        "nodeCredentialType": "httpBearerAuth",
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "{\n  \"run_id\": \"={{$json.run?.run_id || $json.run_id}}\",\n  \"state\": \"triage_completed\",\n  \"message\": \"Completed Nexus step triage\",\n  \"data\": {\n    \"step\": {\n      \"id\": \"triage\",\n      \"name\": \"Intake & Triage\",\n      \"description\": \"Classify priority, scope, and affected components\",\n      \"agent_type\": \"triage\",\n      \"context_policy\": \"minimal\",\n      \"tools\": [\n        \"vcs:read_issue\",\n        \"vcs:add_label\",\n        \"vcs:add_comment\"\n      ],\n      \"inputs\": [\n        {\n          \"issue_url\": \"string\"\n        }\n      ],\n      \"outputs\": [\n        {\n          \"severity\": \"enum[critical|high|medium|low]\"\n        },\n        {\n          \"priority\": \"enum[p0|p1|p2|p3]\"\n        }\n      ],\n      \"on_success\": \"debug\"\n    }\n  }\n}"
+      },
+      "id": "complete-triage",
+      "name": "Complete triage",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [
+        780,
+        0
+      ],
+      "notesInFlow": true,
+      "notes": "Replace this state transition with a concrete agent/tool call when available."
+    },
+    {
+      "parameters": {
+        "method": "POST",
+        "url": "http://nexus-bridge-1:8091/api/v1/n8n/runs/update",
+        "authentication": "predefinedCredentialType",
+        "nodeCredentialType": "httpBearerAuth",
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "{\n  \"run_id\": \"={{$json.run?.run_id || $json.run_id}}\",\n  \"state\": \"debug\",\n  \"message\": \"Starting Nexus step debug\",\n  \"data\": {\n    \"step\": {\n      \"id\": \"debug\",\n      \"index\": 2,\n      \"name\": \"Root Cause Analysis\",\n      \"description\": \"Investigate the issue and identify root cause\",\n      \"agent_type\": \"debug\",\n      \"context_policy\": \"standard\",\n      \"tools\": [\n        \"vcs:search_codebase\",\n        \"vcs:read_file\",\n        \"vcs:add_comment\"\n      ],\n      \"inputs\": [\n        {\n          \"issue_url\": \"string\"\n        },\n        {\n          \"severity\": \"string\"\n        }\n      ],\n      \"outputs\": [\n        {\n          \"root_cause\": \"string\"\n        },\n        {\n          \"affected_components\": \"list[string]\"\n        },\n        {\n          \"fix_approach\": \"string\"\n        }\n      ],\n      \"on_success\": \"develop\"\n    }\n  }\n}"
+      },
+      "id": "start-debug",
+      "name": "02 Start debug",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [
+        920,
+        120
+      ],
+      "notesInFlow": true,
+      "notes": "Investigate the issue and identify root cause"
+    },
+    {
+      "parameters": {
+        "method": "POST",
+        "url": "http://nexus-bridge-1:8091/api/v1/n8n/runs/update",
+        "authentication": "predefinedCredentialType",
+        "nodeCredentialType": "httpBearerAuth",
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "{\n  \"run_id\": \"={{$json.run?.run_id || $json.run_id}}\",\n  \"state\": \"debug_completed\",\n  \"message\": \"Completed Nexus step debug\",\n  \"data\": {\n    \"step\": {\n      \"id\": \"debug\",\n      \"name\": \"Root Cause Analysis\",\n      \"description\": \"Investigate the issue and identify root cause\",\n      \"agent_type\": \"debug\",\n      \"context_policy\": \"standard\",\n      \"tools\": [\n        \"vcs:search_codebase\",\n        \"vcs:read_file\",\n        \"vcs:add_comment\"\n      ],\n      \"inputs\": [\n        {\n          \"issue_url\": \"string\"\n        },\n        {\n          \"severity\": \"string\"\n        }\n      ],\n      \"outputs\": [\n        {\n          \"root_cause\": \"string\"\n        },\n        {\n          \"affected_components\": \"list[string]\"\n        },\n        {\n          \"fix_approach\": \"string\"\n        }\n      ],\n      \"on_success\": \"develop\"\n    }\n  }\n}"
+      },
+      "id": "complete-debug",
+      "name": "Complete debug",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [
+        1140,
+        120
+      ],
+      "notesInFlow": true,
+      "notes": "Replace this state transition with a concrete agent/tool call when available."
+    },
+    {
+      "parameters": {
+        "method": "POST",
+        "url": "http://nexus-bridge-1:8091/api/v1/n8n/runs/update",
+        "authentication": "predefinedCredentialType",
+        "nodeCredentialType": "httpBearerAuth",
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "{\n  \"run_id\": \"={{$json.run?.run_id || $json.run_id}}\",\n  \"state\": \"develop\",\n  \"message\": \"Starting Nexus step develop\",\n  \"data\": {\n    \"step\": {\n      \"id\": \"develop\",\n      \"index\": 3,\n      \"name\": \"Implement Change\",\n      \"description\": \"Implement the change and open a PR\",\n      \"agent_type\": \"developer\",\n      \"context_policy\": \"deep\",\n      \"tools\": [\n        \"vcs:create_branch\",\n        \"vcs:commit_changes\",\n        \"vcs:create_pr\"\n      ],\n      \"inputs\": [\n        {\n          \"issue_url\": \"string\"\n        },\n        {\n          \"root_cause\": \"string\"\n        },\n        {\n          \"fix_approach\": \"string\"\n        }\n      ],\n      \"outputs\": [\n        {\n          \"fix_pr_url\": \"string\"\n        },\n        {\n          \"test_coverage\": \"string\"\n        }\n      ],\n      \"on_success\": \"review\",\n      \"audit_limit\": 50,\n      \"include_audit_history\": true\n    }\n  }\n}"
+      },
+      "id": "start-develop",
+      "name": "03 Start develop",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [
+        1280,
+        0
+      ],
+      "notesInFlow": true,
+      "notes": "Implement the change and open a PR"
+    },
+    {
+      "parameters": {
+        "method": "POST",
+        "url": "http://nexus-bridge-1:8091/api/v1/n8n/coding/execute",
+        "authentication": "predefinedCredentialType",
+        "nodeCredentialType": "httpBearerAuth",
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "{\n  \"run_id\": \"={{$json.run?.run_id || $json.run_id}}\",\n  \"task\": \"={{$json.task || $json.run?.task || \\\"Implement the change and open a PR\\\"}}\",\n  \"project_key\": \"={{$json.project_key || $json.run?.project_key || 'nexus'}}\",\n  \"worker\": \"opencode\",\n  \"agent\": \"build\",\n  \"base_branch\": \"develop\",\n  \"metadata\": {\n    \"step\": {\n      \"id\": \"develop\",\n      \"name\": \"Implement Change\",\n      \"description\": \"Implement the change and open a PR\",\n      \"agent_type\": \"developer\",\n      \"context_policy\": \"deep\",\n      \"tools\": [\n        \"vcs:create_branch\",\n        \"vcs:commit_changes\",\n        \"vcs:create_pr\"\n      ],\n      \"inputs\": [\n        {\n          \"issue_url\": \"string\"\n        },\n        {\n          \"root_cause\": \"string\"\n        },\n        {\n          \"fix_approach\": \"string\"\n        }\n      ],\n      \"outputs\": [\n        {\n          \"fix_pr_url\": \"string\"\n        },\n        {\n          \"test_coverage\": \"string\"\n        }\n      ],\n      \"on_success\": \"review\",\n      \"audit_limit\": 50,\n      \"include_audit_history\": true\n    }\n  }\n}"
+      },
+      "id": "execute-opencode-develop",
+      "name": "Execute OpenCode develop",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [
+        1500,
+        0
+      ],
+      "notesInFlow": true,
+      "notes": "Guarded Nexus endpoint: allowlist, isolated worktree, no push/merge/PR."
+    },
+    {
+      "parameters": {
+        "method": "POST",
+        "url": "http://nexus-bridge-1:8091/api/v1/n8n/runs/update",
+        "authentication": "predefinedCredentialType",
+        "nodeCredentialType": "httpBearerAuth",
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "{\n  \"run_id\": \"={{$json.run?.run_id || $json.run_id}}\",\n  \"state\": \"review\",\n  \"message\": \"Starting Nexus step review\",\n  \"data\": {\n    \"step\": {\n      \"id\": \"review\",\n      \"index\": 4,\n      \"name\": \"Verify Change\",\n      \"description\": \"Review the change for correctness and approve only after full regression (or equivalent full CI suite) passes\",\n      \"agent_type\": \"reviewer\",\n      \"context_policy\": \"standard\",\n      \"tools\": [\n        \"vcs:review_pr\",\n        \"vcs:approve_pr\",\n        \"vcs:add_comment\"\n      ],\n      \"inputs\": [\n        {\n          \"pr_urls\": \"list[string]\"\n        }\n      ],\n      \"outputs\": [\n        {\n          \"review_status\": \"enum[approved|changes_requested]\"\n        }\n      ],\n      \"on_success\": \"route_review\"\n    }\n  }\n}"
+      },
+      "id": "start-review",
+      "name": "04 Start review",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [
+        1640,
+        120
+      ],
+      "notesInFlow": true,
+      "notes": "Review the change for correctness and approve only after full regression (or equivalent full CI suite) passes"
+    },
+    {
+      "parameters": {
+        "method": "POST",
+        "url": "http://nexus-bridge-1:8091/api/v1/n8n/runs/update",
+        "authentication": "predefinedCredentialType",
+        "nodeCredentialType": "httpBearerAuth",
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "{\n  \"run_id\": \"={{$json.run?.run_id || $json.run_id}}\",\n  \"state\": \"review_completed\",\n  \"message\": \"Completed Nexus step review\",\n  \"data\": {\n    \"step\": {\n      \"id\": \"review\",\n      \"name\": \"Verify Change\",\n      \"description\": \"Review the change for correctness and approve only after full regression (or equivalent full CI suite) passes\",\n      \"agent_type\": \"reviewer\",\n      \"context_policy\": \"standard\",\n      \"tools\": [\n        \"vcs:review_pr\",\n        \"vcs:approve_pr\",\n        \"vcs:add_comment\"\n      ],\n      \"inputs\": [\n        {\n          \"pr_urls\": \"list[string]\"\n        }\n      ],\n      \"outputs\": [\n        {\n          \"review_status\": \"enum[approved|changes_requested]\"\n        }\n      ],\n      \"on_success\": \"route_review\"\n    }\n  }\n}"
+      },
+      "id": "complete-review",
+      "name": "Complete review",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [
+        1860,
+        120
+      ],
+      "notesInFlow": true,
+      "notes": "Replace this state transition with a concrete agent/tool call when available."
+    },
+    {
+      "parameters": {
+        "method": "POST",
+        "url": "http://nexus-bridge-1:8091/api/v1/n8n/runs/update",
+        "authentication": "predefinedCredentialType",
+        "nodeCredentialType": "httpBearerAuth",
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "{\n  \"run_id\": \"={{$json.run?.run_id || $json.run_id}}\",\n  \"state\": \"route_review\",\n  \"message\": \"Starting Nexus step route_review\",\n  \"data\": {\n    \"step\": {\n      \"id\": \"route_review\",\n      \"index\": 5,\n      \"name\": \"Route After Verification\",\n      \"agent_type\": \"router\",\n      \"context_policy\": \"minimal\",\n      \"routes\": [\n        {\n          \"when\": \"review_status == 'approved'\",\n          \"then\": \"deploy\"\n        },\n        {\n          \"default\": \"develop\"\n        }\n      ]\n    }\n  }\n}"
+      },
+      "id": "start-route_review",
+      "name": "05 Start route_review",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [
+        2000,
+        260
+      ]
+    },
+    {
+      "parameters": {
+        "jsCode": "const routes = [\n  {\n    \"when\": \"review_status == 'approved'\",\n    \"then\": \"deploy\"\n  },\n  {\n    \"default\": \"develop\"\n  }\n];\nconst state = $json;\n\nfunction toJsExpression(expr) {\n  return String(expr)\n    .replace(/\\band\\b/g, '&&')\n    .replace(/\\bor\\b/g, '||')\n    .replace(/\\bnot\\b/g, '!')\n    .replace(/\\bTrue\\b/g, 'true')\n    .replace(/\\bFalse\\b/g, 'false')\n    .replace(/\\bNone\\b/g, 'null');\n}\n\nfunction evaluate(expr) {\n  const keys = Object.keys(state);\n  const values = Object.values(state);\n  try {\n    return Boolean(Function(...keys, `return (${toJsExpression(expr)});`)(...values));\n  } catch (error) {\n    return false;\n  }\n}\n\nlet nextStep = null;\nfor (const route of routes) {\n  if (route.when && evaluate(route.when)) {\n    nextStep = route.then;\n    break;\n  }\n  if (!route.when && route.default && nextStep === null) {\n    nextStep = route.default;\n  }\n}\n\nreturn [{ json: { ...state, next_step: nextStep } }];\n"
+      },
+      "id": "route-route_review",
+      "name": "Route route_review",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [
+        2220,
+        260
+      ],
+      "notesInFlow": true,
+      "notes": "Evaluates Nexus route rules and writes next_step."
+    },
+    {
+      "parameters": {
+        "method": "POST",
+        "url": "http://nexus-bridge-1:8091/api/v1/n8n/runs/update",
+        "authentication": "predefinedCredentialType",
+        "nodeCredentialType": "httpBearerAuth",
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "{\n  \"run_id\": \"={{$json.run?.run_id || $json.run_id}}\",\n  \"state\": \"deploy\",\n  \"message\": \"Starting Nexus step deploy\",\n  \"data\": {\n    \"step\": {\n      \"id\": \"deploy\",\n      \"index\": 6,\n      \"name\": \"Deploy Change\",\n      \"description\": \"Merge the change and create a release\",\n      \"agent_type\": \"deployer\",\n      \"context_policy\": \"standard\",\n      \"tools\": [\n        \"vcs:merge_pr\",\n        \"vcs:create_release\",\n        \"vcs:add_comment\"\n      ],\n      \"inputs\": [\n        {\n          \"fix_pr_url\": \"string\"\n        }\n      ],\n      \"outputs\": [\n        {\n          \"deployment_status\": \"string\"\n        }\n      ],\n      \"on_success\": \"close_loop\"\n    }\n  }\n}"
+      },
+      "id": "start-deploy",
+      "name": "06 Start deploy",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [
+        2360,
+        120
+      ],
+      "notesInFlow": true,
+      "notes": "Merge the change and create a release"
+    },
+    {
+      "parameters": {
+        "method": "POST",
+        "url": "http://nexus-bridge-1:8091/api/v1/n8n/runs/update",
+        "authentication": "predefinedCredentialType",
+        "nodeCredentialType": "httpBearerAuth",
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "{\n  \"run_id\": \"={{$json.run?.run_id || $json.run_id}}\",\n  \"state\": \"deploy_completed\",\n  \"message\": \"Completed Nexus step deploy\",\n  \"data\": {\n    \"step\": {\n      \"id\": \"deploy\",\n      \"name\": \"Deploy Change\",\n      \"description\": \"Merge the change and create a release\",\n      \"agent_type\": \"deployer\",\n      \"context_policy\": \"standard\",\n      \"tools\": [\n        \"vcs:merge_pr\",\n        \"vcs:create_release\",\n        \"vcs:add_comment\"\n      ],\n      \"inputs\": [\n        {\n          \"fix_pr_url\": \"string\"\n        }\n      ],\n      \"outputs\": [\n        {\n          \"deployment_status\": \"string\"\n        }\n      ],\n      \"on_success\": \"close_loop\"\n    }\n  }\n}"
+      },
+      "id": "complete-deploy",
+      "name": "Complete deploy",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [
+        2580,
+        120
+      ],
+      "notesInFlow": true,
+      "notes": "Replace this state transition with a concrete agent/tool call when available."
+    },
+    {
+      "parameters": {
+        "method": "POST",
+        "url": "http://nexus-bridge-1:8091/api/v1/n8n/runs/update",
+        "authentication": "predefinedCredentialType",
+        "nodeCredentialType": "httpBearerAuth",
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "{\n  \"run_id\": \"={{$json.run?.run_id || $json.run_id}}\",\n  \"state\": \"close_loop\",\n  \"message\": \"Starting Nexus step close_loop\",\n  \"data\": {\n    \"step\": {\n      \"id\": \"close_loop\",\n      \"index\": 7,\n      \"name\": \"Document & Close\",\n      \"description\": \"Write summary and close the issue\",\n      \"agent_type\": \"writer\",\n      \"context_policy\": \"standard\",\n      \"tools\": [\n        \"vcs:add_comment\",\n        \"vcs:close_issue\"\n      ],\n      \"inputs\": [\n        {\n          \"issue_url\": \"string\"\n        },\n        {\n          \"root_cause\": \"string\"\n        }\n      ],\n      \"outputs\": [\n        {\n          \"postmortem\": \"string\"\n        }\n      ],\n      \"final_step\": true,\n      \"audit_limit\": 10\n    }\n  }\n}"
+      },
+      "id": "start-close_loop",
+      "name": "07 Start close_loop",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [
+        2720,
+        0
+      ],
+      "notesInFlow": true,
+      "notes": "Write summary and close the issue"
+    },
+    {
+      "parameters": {
+        "method": "POST",
+        "url": "http://nexus-bridge-1:8091/api/v1/n8n/runs/update",
+        "authentication": "predefinedCredentialType",
+        "nodeCredentialType": "httpBearerAuth",
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "{\n  \"run_id\": \"={{$json.run?.run_id || $json.run_id}}\",\n  \"state\": \"close_loop_completed\",\n  \"message\": \"Completed Nexus step close_loop\",\n  \"data\": {\n    \"step\": {\n      \"id\": \"close_loop\",\n      \"name\": \"Document & Close\",\n      \"description\": \"Write summary and close the issue\",\n      \"agent_type\": \"writer\",\n      \"context_policy\": \"standard\",\n      \"tools\": [\n        \"vcs:add_comment\",\n        \"vcs:close_issue\"\n      ],\n      \"inputs\": [\n        {\n          \"issue_url\": \"string\"\n        },\n        {\n          \"root_cause\": \"string\"\n        }\n      ],\n      \"outputs\": [\n        {\n          \"postmortem\": \"string\"\n        }\n      ],\n      \"final_step\": true,\n      \"audit_limit\": 10\n    }\n  }\n}"
+      },
+      "id": "complete-close_loop",
+      "name": "Complete close_loop",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [
+        2940,
+        0
+      ],
+      "notesInFlow": true,
+      "notes": "Replace this state transition with a concrete agent/tool call when available."
+    },
+    {
+      "parameters": {
+        "mode": "rules",
+        "rules": {
+          "values": [
+            {
+              "conditions": {
+                "conditions": [
+                  {
+                    "leftValue": "={{$json.next_step}}",
+                    "rightValue": "deploy",
+                    "operator": {
+                      "type": "string",
+                      "operation": "equals"
+                    }
+                  }
+                ],
+                "combinator": "and"
+              }
+            },
+            {
+              "conditions": {
+                "conditions": [
+                  {
+                    "leftValue": "={{$json.next_step}}",
+                    "rightValue": "develop",
+                    "operator": {
+                      "type": "string",
+                      "operation": "equals"
+                    }
+                  }
+                ],
+                "combinator": "and"
+              }
+            }
+          ]
+        },
+        "options": {}
+      },
+      "id": "switch-switch-route_review",
+      "name": "Switch route_review",
+      "type": "n8n-nodes-base.switch",
+      "typeVersion": 3,
+      "position": [
+        2440,
+        260
+      ],
+      "notesInFlow": true,
+      "notes": "Routes to the Nexus step selected by the preceding Code node."
+    }
+  ],
+  "connections": {
+    "01 Start triage": {
+      "main": [
+        [
+          {
+            "node": "Complete triage",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "02 Start debug": {
+      "main": [
+        [
+          {
+            "node": "Complete debug",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "03 Start develop": {
+      "main": [
+        [
+          {
+            "node": "Execute OpenCode develop",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "04 Start review": {
+      "main": [
+        [
+          {
+            "node": "Complete review",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "05 Start route_review": {
+      "main": [
+        [
+          {
+            "node": "Route route_review",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "06 Start deploy": {
+      "main": [
+        [
+          {
+            "node": "Complete deploy",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "07 Start close_loop": {
+      "main": [
+        [
+          {
+            "node": "Complete close_loop",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Create Nexus Run": {
+      "main": [
+        [
+          {
+            "node": "01 Start triage",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Manual Trigger": {
+      "main": [
+        [
+          {
+            "node": "Create Nexus Run",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Complete triage": {
+      "main": [
+        [
+          {
+            "node": "02 Start debug",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Complete debug": {
+      "main": [
+        [
+          {
+            "node": "03 Start develop",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Execute OpenCode develop": {
+      "main": [
+        [
+          {
+            "node": "04 Start review",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Complete review": {
+      "main": [
+        [
+          {
+            "node": "05 Start route_review",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Route route_review": {
+      "main": [
+        [
+          {
+            "node": "Switch route_review",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Switch route_review": {
+      "main": [
+        [
+          {
+            "node": "06 Start deploy",
+            "type": "main",
+            "index": 0
+          }
+        ],
+        [
+          {
+            "node": "03 Start develop",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Complete deploy": {
+      "main": [
+        [
+          {
+            "node": "07 Start close_loop",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    }
+  },
+  "settings": {
+    "executionOrder": "v1"
+  },
+  "staticData": null,
+  "tags": [
+    "nexus-arc",
+    "generated"
+  ],
+  "meta": {
+    "nexusArc": {
+      "source": "examples/workflows/enterprise_shortened_workflow.yaml",
+      "workflowType": "shortened",
+      "converter": "nexus.translators.to_n8n"
+    }
+  }
+}

--- a/examples/workflows/n8n/enterprise_workflow.json
+++ b/examples/workflows/n8n/enterprise_workflow.json
@@ -1,0 +1,263 @@
+{
+  "name": "Enterprise Workflow Router",
+  "nodes": [
+    {
+      "parameters": {},
+      "id": "manual-trigger",
+      "name": "Manual Trigger",
+      "type": "n8n-nodes-base.manualTrigger",
+      "typeVersion": 1,
+      "position": [
+        0,
+        0
+      ]
+    },
+    {
+      "parameters": {
+        "method": "POST",
+        "url": "http://nexus-bridge-1:8091/api/v1/n8n/runs",
+        "authentication": "predefinedCredentialType",
+        "nodeCredentialType": "httpBearerAuth",
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "{\n  \"task\": \"={{$json.task || $json.title || 'Run Nexus workflow'}}\",\n  \"project_key\": \"={{$json.project_key || $json.project || 'nexus'}}\",\n  \"issue_number\": \"={{$json.issue_number || $json.issue || ''}}\",\n  \"requester\": {\n    \"source\": \"n8n\",\n    \"workflow\": \"Enterprise Workflow Router\"\n  },\n  \"metadata\": {\n    \"nexus_workflow\": {\n      \"name\": \"Enterprise Workflow Router\",\n      \"description\": \"Router workflow for enterprise tiers.\",\n      \"version\": \"1.0.0\"\n    },\n    \"workflow_type\": \"orchestrator\",\n    \"source\": \"examples/workflows/enterprise_workflow.yaml\"\n  }\n}"
+      },
+      "id": "create-nexus-run",
+      "name": "Create Nexus Run",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [
+        260,
+        0
+      ],
+      "notesInFlow": true,
+      "notes": "Creates the durable Nexus run that n8n will advance."
+    },
+    {
+      "parameters": {
+        "method": "POST",
+        "url": "http://nexus-bridge-1:8091/api/v1/n8n/runs/update",
+        "authentication": "predefinedCredentialType",
+        "nodeCredentialType": "httpBearerAuth",
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "{\n  \"run_id\": \"={{$json.run?.run_id || $json.run_id}}\",\n  \"state\": \"triage\",\n  \"message\": \"Starting Nexus step triage\",\n  \"data\": {\n    \"step\": {\n      \"id\": \"triage\",\n      \"index\": 1,\n      \"name\": \"Enterprise Tier Selection\",\n      \"description\": \"Classify the request and choose full, shortened, or fast-track flow\",\n      \"agent_type\": \"triage\",\n      \"context_policy\": \"minimal\",\n      \"tools\": [\n        \"vcs:read_issue\"\n      ],\n      \"inputs\": [\n        {\n          \"issue_url\": \"string\"\n        },\n        {\n          \"request_context\": \"string\"\n        }\n      ],\n      \"outputs\": [\n        {\n          \"selected_workflow\": \"enum[enterprise_full, enterprise_shortened, enterprise_fast_track]\"\n        },\n        {\n          \"initial_analysis\": \"string\"\n        }\n      ],\n      \"on_success\": \"dispatch\"\n    }\n  }\n}"
+      },
+      "id": "start-triage",
+      "name": "01 Start triage",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [
+        560,
+        0
+      ],
+      "notesInFlow": true,
+      "notes": "Classify the request and choose full, shortened, or fast-track flow"
+    },
+    {
+      "parameters": {
+        "method": "POST",
+        "url": "http://nexus-bridge-1:8091/api/v1/n8n/runs/update",
+        "authentication": "predefinedCredentialType",
+        "nodeCredentialType": "httpBearerAuth",
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "{\n  \"run_id\": \"={{$json.run?.run_id || $json.run_id}}\",\n  \"state\": \"triage_completed\",\n  \"message\": \"Completed Nexus step triage\",\n  \"data\": {\n    \"step\": {\n      \"id\": \"triage\",\n      \"name\": \"Enterprise Tier Selection\",\n      \"description\": \"Classify the request and choose full, shortened, or fast-track flow\",\n      \"agent_type\": \"triage\",\n      \"context_policy\": \"minimal\",\n      \"tools\": [\n        \"vcs:read_issue\"\n      ],\n      \"inputs\": [\n        {\n          \"issue_url\": \"string\"\n        },\n        {\n          \"request_context\": \"string\"\n        }\n      ],\n      \"outputs\": [\n        {\n          \"selected_workflow\": \"enum[enterprise_full, enterprise_shortened, enterprise_fast_track]\"\n        },\n        {\n          \"initial_analysis\": \"string\"\n        }\n      ],\n      \"on_success\": \"dispatch\"\n    }\n  }\n}"
+      },
+      "id": "complete-triage",
+      "name": "Complete triage",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [
+        780,
+        0
+      ],
+      "notesInFlow": true,
+      "notes": "Replace this state transition with a concrete agent/tool call when available."
+    },
+    {
+      "parameters": {
+        "method": "POST",
+        "url": "http://nexus-bridge-1:8091/api/v1/n8n/runs/update",
+        "authentication": "predefinedCredentialType",
+        "nodeCredentialType": "httpBearerAuth",
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "{\n  \"run_id\": \"={{$json.run?.run_id || $json.run_id}}\",\n  \"state\": \"dispatch\",\n  \"message\": \"Starting Nexus step dispatch\",\n  \"data\": {\n    \"step\": {\n      \"id\": \"dispatch\",\n      \"index\": 2,\n      \"name\": \"Dispatch\",\n      \"description\": \"Trigger the selected enterprise sub-workflow\",\n      \"agent_type\": \"triage\",\n      \"context_policy\": \"minimal\",\n      \"inputs\": [\n        {\n          \"selected_workflow\": \"string\"\n        }\n      ],\n      \"routes\": [\n        {\n          \"when\": \"selected_workflow == 'enterprise_full'\",\n          \"then\": \"enterprise_full_workflow\"\n        },\n        {\n          \"when\": \"selected_workflow == 'enterprise_shortened'\",\n          \"then\": \"enterprise_shortened_workflow\"\n        },\n        {\n          \"when\": \"selected_workflow == 'enterprise_fast_track'\",\n          \"then\": \"enterprise_fast_track_workflow\"\n        },\n        {\n          \"default\": \"enterprise_full_workflow\"\n        }\n      ]\n    }\n  }\n}"
+      },
+      "id": "start-dispatch",
+      "name": "02 Start dispatch",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [
+        920,
+        120
+      ],
+      "notesInFlow": true,
+      "notes": "Trigger the selected enterprise sub-workflow"
+    },
+    {
+      "parameters": {
+        "jsCode": "const routes = [\n  {\n    \"when\": \"selected_workflow == 'enterprise_full'\",\n    \"then\": \"enterprise_full_workflow\"\n  },\n  {\n    \"when\": \"selected_workflow == 'enterprise_shortened'\",\n    \"then\": \"enterprise_shortened_workflow\"\n  },\n  {\n    \"when\": \"selected_workflow == 'enterprise_fast_track'\",\n    \"then\": \"enterprise_fast_track_workflow\"\n  },\n  {\n    \"default\": \"enterprise_full_workflow\"\n  }\n];\nconst state = $json;\n\nfunction toJsExpression(expr) {\n  return String(expr)\n    .replace(/\\band\\b/g, '&&')\n    .replace(/\\bor\\b/g, '||')\n    .replace(/\\bnot\\b/g, '!')\n    .replace(/\\bTrue\\b/g, 'true')\n    .replace(/\\bFalse\\b/g, 'false')\n    .replace(/\\bNone\\b/g, 'null');\n}\n\nfunction evaluate(expr) {\n  const keys = Object.keys(state);\n  const values = Object.values(state);\n  try {\n    return Boolean(Function(...keys, `return (${toJsExpression(expr)});`)(...values));\n  } catch (error) {\n    return false;\n  }\n}\n\nlet nextStep = null;\nfor (const route of routes) {\n  if (route.when && evaluate(route.when)) {\n    nextStep = route.then;\n    break;\n  }\n  if (!route.when && route.default && nextStep === null) {\n    nextStep = route.default;\n  }\n}\n\nreturn [{ json: { ...state, next_step: nextStep } }];\n"
+      },
+      "id": "route-dispatch",
+      "name": "Route dispatch",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [
+        1140,
+        120
+      ],
+      "notesInFlow": true,
+      "notes": "Evaluates Nexus route rules and writes next_step."
+    },
+    {
+      "parameters": {
+        "mode": "rules",
+        "rules": {
+          "values": [
+            {
+              "conditions": {
+                "conditions": [
+                  {
+                    "leftValue": "={{$json.next_step}}",
+                    "rightValue": "enterprise_full_workflow",
+                    "operator": {
+                      "type": "string",
+                      "operation": "equals"
+                    }
+                  }
+                ],
+                "combinator": "and"
+              }
+            },
+            {
+              "conditions": {
+                "conditions": [
+                  {
+                    "leftValue": "={{$json.next_step}}",
+                    "rightValue": "enterprise_shortened_workflow",
+                    "operator": {
+                      "type": "string",
+                      "operation": "equals"
+                    }
+                  }
+                ],
+                "combinator": "and"
+              }
+            },
+            {
+              "conditions": {
+                "conditions": [
+                  {
+                    "leftValue": "={{$json.next_step}}",
+                    "rightValue": "enterprise_fast_track_workflow",
+                    "operator": {
+                      "type": "string",
+                      "operation": "equals"
+                    }
+                  }
+                ],
+                "combinator": "and"
+              }
+            }
+          ]
+        },
+        "options": {}
+      },
+      "id": "switch-switch-dispatch",
+      "name": "Switch dispatch",
+      "type": "n8n-nodes-base.switch",
+      "typeVersion": 3,
+      "position": [
+        1360,
+        120
+      ],
+      "notesInFlow": true,
+      "notes": "Routes to the Nexus step selected by the preceding Code node."
+    }
+  ],
+  "connections": {
+    "01 Start triage": {
+      "main": [
+        [
+          {
+            "node": "Complete triage",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "02 Start dispatch": {
+      "main": [
+        [
+          {
+            "node": "Route dispatch",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Create Nexus Run": {
+      "main": [
+        [
+          {
+            "node": "01 Start triage",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Manual Trigger": {
+      "main": [
+        [
+          {
+            "node": "Create Nexus Run",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Complete triage": {
+      "main": [
+        [
+          {
+            "node": "02 Start dispatch",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Route dispatch": {
+      "main": [
+        [
+          {
+            "node": "Switch dispatch",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    }
+  },
+  "settings": {
+    "executionOrder": "v1"
+  },
+  "staticData": null,
+  "tags": [
+    "nexus-arc",
+    "generated"
+  ],
+  "meta": {
+    "nexusArc": {
+      "source": "examples/workflows/enterprise_workflow.yaml",
+      "workflowType": "orchestrator",
+      "converter": "nexus.translators.to_n8n"
+    }
+  }
+}

--- a/examples/workflows/n8n/instagram_post_workflow.json
+++ b/examples/workflows/n8n/instagram_post_workflow.json
@@ -1,0 +1,541 @@
+{
+  "name": "Instagram Post Workflow",
+  "nodes": [
+    {
+      "parameters": {},
+      "id": "manual-trigger",
+      "name": "Manual Trigger",
+      "type": "n8n-nodes-base.manualTrigger",
+      "typeVersion": 1,
+      "position": [
+        0,
+        0
+      ]
+    },
+    {
+      "parameters": {
+        "method": "POST",
+        "url": "http://nexus-bridge-1:8091/api/v1/n8n/runs",
+        "authentication": "predefinedCredentialType",
+        "nodeCredentialType": "httpBearerAuth",
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "{\n  \"task\": \"={{$json.task || $json.title || 'Run Nexus workflow'}}\",\n  \"project_key\": \"={{$json.project_key || $json.project || 'nexus'}}\",\n  \"issue_number\": \"={{$json.issue_number || $json.issue || ''}}\",\n  \"requester\": {\n    \"source\": \"n8n\",\n    \"workflow\": \"Instagram Post Workflow\"\n  },\n  \"metadata\": {\n    \"nexus_workflow\": {\n      \"name\": \"Instagram Post Workflow\",\n      \"description\": \"Research a topic, write an Instagram caption, validate it, and publish via Meta adapter.\",\n      \"version\": \"1.0.0\"\n    },\n    \"workflow_type\": \"social-post\",\n    \"source\": \"examples/workflows/instagram_post_workflow.yaml\"\n  }\n}"
+      },
+      "id": "create-nexus-run",
+      "name": "Create Nexus Run",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [
+        260,
+        0
+      ],
+      "notesInFlow": true,
+      "notes": "Creates the durable Nexus run that n8n will advance."
+    },
+    {
+      "parameters": {
+        "method": "POST",
+        "url": "http://nexus-bridge-1:8091/api/v1/n8n/runs/update",
+        "authentication": "predefinedCredentialType",
+        "nodeCredentialType": "httpBearerAuth",
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "{\n  \"run_id\": \"={{$json.run?.run_id || $json.run_id}}\",\n  \"state\": \"research\",\n  \"message\": \"Starting Nexus step research\",\n  \"data\": {\n    \"step\": {\n      \"id\": \"research\",\n      \"index\": 1,\n      \"name\": \"Research\",\n      \"description\": \"Gather context about the topic for Instagram. Identify: visual concept (what image/video would work), caption hook, tone (authentic, aspirational, or educational), and 10\\u201320 relevant hashtags. Instagram audience is visual-first \\u2014 the caption supports the image.\\n\",\n      \"agent_type\": \"researcher\",\n      \"context_policy\": \"minimal\",\n      \"tools\": [\n        \"vcs:read_issue\",\n        \"vcs:add_comment\"\n      ],\n      \"inputs\": [\n        {\n          \"topic\": \"string\"\n        },\n        {\n          \"audience\": \"string\"\n        },\n        {\n          \"image_url\": \"string\"\n        }\n      ],\n      \"outputs\": [\n        {\n          \"research_brief\": \"string\"\n        },\n        {\n          \"visual_concept\": \"string\"\n        },\n        {\n          \"suggested_hashtags\": \"list[string]\"\n        }\n      ],\n      \"on_success\": \"write\"\n    }\n  }\n}"
+      },
+      "id": "start-research",
+      "name": "01 Start research",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [
+        560,
+        0
+      ],
+      "notesInFlow": true,
+      "notes": "Gather context about the topic for Instagram. Identify: visual concept (what image/video would work), caption hook, tone (authentic, aspirational, or educational), and 10\u201320 relevant hashtags. Instagram audience is visual-first \u2014 the caption supports the image.\n"
+    },
+    {
+      "parameters": {
+        "method": "POST",
+        "url": "http://nexus-bridge-1:8091/api/v1/n8n/runs/update",
+        "authentication": "predefinedCredentialType",
+        "nodeCredentialType": "httpBearerAuth",
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "{\n  \"run_id\": \"={{$json.run?.run_id || $json.run_id}}\",\n  \"state\": \"research_completed\",\n  \"message\": \"Completed Nexus step research\",\n  \"data\": {\n    \"step\": {\n      \"id\": \"research\",\n      \"name\": \"Research\",\n      \"description\": \"Gather context about the topic for Instagram. Identify: visual concept (what image/video would work), caption hook, tone (authentic, aspirational, or educational), and 10\\u201320 relevant hashtags. Instagram audience is visual-first \\u2014 the caption supports the image.\\n\",\n      \"agent_type\": \"researcher\",\n      \"context_policy\": \"minimal\",\n      \"tools\": [\n        \"vcs:read_issue\",\n        \"vcs:add_comment\"\n      ],\n      \"inputs\": [\n        {\n          \"topic\": \"string\"\n        },\n        {\n          \"audience\": \"string\"\n        },\n        {\n          \"image_url\": \"string\"\n        }\n      ],\n      \"outputs\": [\n        {\n          \"research_brief\": \"string\"\n        },\n        {\n          \"visual_concept\": \"string\"\n        },\n        {\n          \"suggested_hashtags\": \"list[string]\"\n        }\n      ],\n      \"on_success\": \"write\"\n    }\n  }\n}"
+      },
+      "id": "complete-research",
+      "name": "Complete research",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [
+        780,
+        0
+      ],
+      "notesInFlow": true,
+      "notes": "Replace this state transition with a concrete agent/tool call when available."
+    },
+    {
+      "parameters": {
+        "method": "POST",
+        "url": "http://nexus-bridge-1:8091/api/v1/n8n/runs/update",
+        "authentication": "predefinedCredentialType",
+        "nodeCredentialType": "httpBearerAuth",
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "{\n  \"run_id\": \"={{$json.run?.run_id || $json.run_id}}\",\n  \"state\": \"write\",\n  \"message\": \"Starting Nexus step write\",\n  \"data\": {\n    \"step\": {\n      \"id\": \"write\",\n      \"index\": 2,\n      \"name\": \"Write Instagram Caption\",\n      \"description\": \"Write the Instagram caption based on the research brief. Format: hook (1\\u20132 sentences) \\u2192 body (story or insight) \\u2192 CTA \\u2192 hashtag block. Max 2200 characters. Hashtags: 10\\u201320, grouped at the end. Tone: authentic, human, platform-native. No corporate speak. Note: the image must be provided separately via image_url in the issue.\\n\",\n      \"agent_type\": \"writer\",\n      \"context_policy\": \"standard\",\n      \"tools\": [\n        \"vcs:read_comments\",\n        \"vcs:add_comment\"\n      ],\n      \"inputs\": [\n        {\n          \"research_brief\": \"string\"\n        },\n        {\n          \"visual_concept\": \"string\"\n        },\n        {\n          \"suggested_hashtags\": \"list[string]\"\n        },\n        {\n          \"image_url\": \"string\"\n        }\n      ],\n      \"outputs\": [\n        {\n          \"post_text\": \"string\"\n        },\n        {\n          \"post_platform\": \"string\"\n        },\n        {\n          \"image_url\": \"string\"\n        },\n        {\n          \"hashtag_count\": \"integer\"\n        }\n      ],\n      \"on_success\": \"review\",\n      \"audit_limit\": 10,\n      \"include_audit_history\": true\n    }\n  }\n}"
+      },
+      "id": "start-write",
+      "name": "02 Start write",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [
+        920,
+        120
+      ],
+      "notesInFlow": true,
+      "notes": "Write the Instagram caption based on the research brief. Format: hook (1\u20132 sentences) \u2192 body (story or insight) \u2192 CTA \u2192 hashtag block. Max 2200 characters. Hashtags: 10\u201320, grouped at the end. Tone: authentic, human, platform-native. No corporate speak. Note: the image must be provided separately via image_url in the issue.\n"
+    },
+    {
+      "parameters": {
+        "method": "POST",
+        "url": "http://nexus-bridge-1:8091/api/v1/n8n/runs/update",
+        "authentication": "predefinedCredentialType",
+        "nodeCredentialType": "httpBearerAuth",
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "{\n  \"run_id\": \"={{$json.run?.run_id || $json.run_id}}\",\n  \"state\": \"write_completed\",\n  \"message\": \"Completed Nexus step write\",\n  \"data\": {\n    \"step\": {\n      \"id\": \"write\",\n      \"name\": \"Write Instagram Caption\",\n      \"description\": \"Write the Instagram caption based on the research brief. Format: hook (1\\u20132 sentences) \\u2192 body (story or insight) \\u2192 CTA \\u2192 hashtag block. Max 2200 characters. Hashtags: 10\\u201320, grouped at the end. Tone: authentic, human, platform-native. No corporate speak. Note: the image must be provided separately via image_url in the issue.\\n\",\n      \"agent_type\": \"writer\",\n      \"context_policy\": \"standard\",\n      \"tools\": [\n        \"vcs:read_comments\",\n        \"vcs:add_comment\"\n      ],\n      \"inputs\": [\n        {\n          \"research_brief\": \"string\"\n        },\n        {\n          \"visual_concept\": \"string\"\n        },\n        {\n          \"suggested_hashtags\": \"list[string]\"\n        },\n        {\n          \"image_url\": \"string\"\n        }\n      ],\n      \"outputs\": [\n        {\n          \"post_text\": \"string\"\n        },\n        {\n          \"post_platform\": \"string\"\n        },\n        {\n          \"image_url\": \"string\"\n        },\n        {\n          \"hashtag_count\": \"integer\"\n        }\n      ],\n      \"on_success\": \"review\",\n      \"audit_limit\": 10,\n      \"include_audit_history\": true\n    }\n  }\n}"
+      },
+      "id": "complete-write",
+      "name": "Complete write",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [
+        1140,
+        120
+      ],
+      "notesInFlow": true,
+      "notes": "Replace this state transition with a concrete agent/tool call when available."
+    },
+    {
+      "parameters": {
+        "method": "POST",
+        "url": "http://nexus-bridge-1:8091/api/v1/n8n/runs/update",
+        "authentication": "predefinedCredentialType",
+        "nodeCredentialType": "httpBearerAuth",
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "{\n  \"run_id\": \"={{$json.run?.run_id || $json.run_id}}\",\n  \"state\": \"review\",\n  \"message\": \"Starting Nexus step review\",\n  \"data\": {\n    \"step\": {\n      \"id\": \"review\",\n      \"index\": 3,\n      \"name\": \"Review & Validate\",\n      \"description\": \"Review caption for: character limit (\\u22642200), hashtag count (10\\u201320), tone (authentic, not corporate), no unverified claims, image_url present. Approve or request specific changes.\\n\",\n      \"agent_type\": \"reviewer\",\n      \"context_policy\": \"standard\",\n      \"tools\": [\n        \"vcs:read_comments\",\n        \"vcs:add_comment\"\n      ],\n      \"inputs\": [\n        {\n          \"post_text\": \"string\"\n        },\n        {\n          \"image_url\": \"string\"\n        }\n      ],\n      \"outputs\": [\n        {\n          \"review_status\": \"enum[approved|changes_requested]\"\n        },\n        {\n          \"review_notes\": \"string\"\n        }\n      ],\n      \"on_success\": \"route_review\",\n      \"audit_limit\": 20,\n      \"include_audit_history\": true\n    }\n  }\n}"
+      },
+      "id": "start-review",
+      "name": "03 Start review",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [
+        1280,
+        0
+      ],
+      "notesInFlow": true,
+      "notes": "Review caption for: character limit (\u22642200), hashtag count (10\u201320), tone (authentic, not corporate), no unverified claims, image_url present. Approve or request specific changes.\n"
+    },
+    {
+      "parameters": {
+        "method": "POST",
+        "url": "http://nexus-bridge-1:8091/api/v1/n8n/runs/update",
+        "authentication": "predefinedCredentialType",
+        "nodeCredentialType": "httpBearerAuth",
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "{\n  \"run_id\": \"={{$json.run?.run_id || $json.run_id}}\",\n  \"state\": \"review_completed\",\n  \"message\": \"Completed Nexus step review\",\n  \"data\": {\n    \"step\": {\n      \"id\": \"review\",\n      \"name\": \"Review & Validate\",\n      \"description\": \"Review caption for: character limit (\\u22642200), hashtag count (10\\u201320), tone (authentic, not corporate), no unverified claims, image_url present. Approve or request specific changes.\\n\",\n      \"agent_type\": \"reviewer\",\n      \"context_policy\": \"standard\",\n      \"tools\": [\n        \"vcs:read_comments\",\n        \"vcs:add_comment\"\n      ],\n      \"inputs\": [\n        {\n          \"post_text\": \"string\"\n        },\n        {\n          \"image_url\": \"string\"\n        }\n      ],\n      \"outputs\": [\n        {\n          \"review_status\": \"enum[approved|changes_requested]\"\n        },\n        {\n          \"review_notes\": \"string\"\n        }\n      ],\n      \"on_success\": \"route_review\",\n      \"audit_limit\": 20,\n      \"include_audit_history\": true\n    }\n  }\n}"
+      },
+      "id": "complete-review",
+      "name": "Complete review",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [
+        1500,
+        0
+      ],
+      "notesInFlow": true,
+      "notes": "Replace this state transition with a concrete agent/tool call when available."
+    },
+    {
+      "parameters": {
+        "method": "POST",
+        "url": "http://nexus-bridge-1:8091/api/v1/n8n/runs/update",
+        "authentication": "predefinedCredentialType",
+        "nodeCredentialType": "httpBearerAuth",
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "{\n  \"run_id\": \"={{$json.run?.run_id || $json.run_id}}\",\n  \"state\": \"route_review\",\n  \"message\": \"Starting Nexus step route_review\",\n  \"data\": {\n    \"step\": {\n      \"id\": \"route_review\",\n      \"index\": 4,\n      \"name\": \"Route After Review\",\n      \"agent_type\": \"router\",\n      \"context_policy\": \"minimal\",\n      \"routes\": [\n        {\n          \"when\": \"review_status == 'approved'\",\n          \"then\": \"publish\"\n        },\n        {\n          \"when\": \"review_status == 'changes_requested'\",\n          \"then\": \"write\"\n        },\n        {\n          \"default\": \"write\"\n        }\n      ]\n    }\n  }\n}"
+      },
+      "id": "start-route_review",
+      "name": "04 Start route_review",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [
+        1640,
+        260
+      ]
+    },
+    {
+      "parameters": {
+        "jsCode": "const routes = [\n  {\n    \"when\": \"review_status == 'approved'\",\n    \"then\": \"publish\"\n  },\n  {\n    \"when\": \"review_status == 'changes_requested'\",\n    \"then\": \"write\"\n  },\n  {\n    \"default\": \"write\"\n  }\n];\nconst state = $json;\n\nfunction toJsExpression(expr) {\n  return String(expr)\n    .replace(/\\band\\b/g, '&&')\n    .replace(/\\bor\\b/g, '||')\n    .replace(/\\bnot\\b/g, '!')\n    .replace(/\\bTrue\\b/g, 'true')\n    .replace(/\\bFalse\\b/g, 'false')\n    .replace(/\\bNone\\b/g, 'null');\n}\n\nfunction evaluate(expr) {\n  const keys = Object.keys(state);\n  const values = Object.values(state);\n  try {\n    return Boolean(Function(...keys, `return (${toJsExpression(expr)});`)(...values));\n  } catch (error) {\n    return false;\n  }\n}\n\nlet nextStep = null;\nfor (const route of routes) {\n  if (route.when && evaluate(route.when)) {\n    nextStep = route.then;\n    break;\n  }\n  if (!route.when && route.default && nextStep === null) {\n    nextStep = route.default;\n  }\n}\n\nreturn [{ json: { ...state, next_step: nextStep } }];\n"
+      },
+      "id": "route-route_review",
+      "name": "Route route_review",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [
+        1860,
+        260
+      ],
+      "notesInFlow": true,
+      "notes": "Evaluates Nexus route rules and writes next_step."
+    },
+    {
+      "parameters": {
+        "method": "POST",
+        "url": "http://nexus-bridge-1:8091/api/v1/n8n/runs/update",
+        "authentication": "predefinedCredentialType",
+        "nodeCredentialType": "httpBearerAuth",
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "{\n  \"run_id\": \"={{$json.run?.run_id || $json.run_id}}\",\n  \"state\": \"publish\",\n  \"message\": \"Starting Nexus step publish\",\n  \"data\": {\n    \"step\": {\n      \"id\": \"publish\",\n      \"index\": 5,\n      \"name\": \"Publish to Instagram\",\n      \"description\": \"Publish the approved caption + image to Instagram via the Meta adapter (target=instagram, instagram_account_id required). First run a dry_run to validate credentials, image_url, and caption length. If dry_run passes: publish. Post the result (IG post URL) as a comment. NOTE: image_url must be a public HTTPS URL accessible by Meta's servers.\\n\",\n      \"agent_type\": \"publisher\",\n      \"context_policy\": \"standard\",\n      \"tools\": [\n        \"vcs:read_comments\",\n        \"vcs:add_comment\"\n      ],\n      \"inputs\": [\n        {\n          \"post_text\": \"string\"\n        },\n        {\n          \"post_platform\": \"string\"\n        },\n        {\n          \"image_url\": \"string\"\n        }\n      ],\n      \"outputs\": [\n        {\n          \"publish_status\": \"enum[published|dry_run_only|failed]\"\n        },\n        {\n          \"publish_url\": \"string\"\n        },\n        {\n          \"publish_platform\": \"string\"\n        }\n      ],\n      \"on_success\": \"close_loop\",\n      \"require_human_approval\": true,\n      \"audit_limit\": 20,\n      \"include_audit_history\": true\n    }\n  }\n}"
+      },
+      "id": "start-publish",
+      "name": "05 Start publish",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [
+        2000,
+        -180
+      ],
+      "notesInFlow": true,
+      "notes": "Publish the approved caption + image to Instagram via the Meta adapter (target=instagram, instagram_account_id required). First run a dry_run to validate credentials, image_url, and caption length. If dry_run passes: publish. Post the result (IG post URL) as a comment. NOTE: image_url must be a public HTTPS URL accessible by Meta's servers.\n"
+    },
+    {
+      "parameters": {
+        "method": "POST",
+        "url": "http://nexus-bridge-1:8091/api/v1/n8n/runs/update",
+        "authentication": "predefinedCredentialType",
+        "nodeCredentialType": "httpBearerAuth",
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "{\n  \"run_id\": \"={{$json.run?.run_id || $json.run_id}}\",\n  \"state\": \"publish_awaiting_approval\",\n  \"message\": \"Human approval required before publish\",\n  \"data\": {\n    \"step_id\": \"publish\",\n    \"agent_type\": \"publisher\"\n  }\n}"
+      },
+      "id": "approval-publish",
+      "name": "Approval Gate publish",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [
+        2220,
+        -300
+      ],
+      "notesInFlow": true,
+      "notes": "Connect this node to an n8n approval/wait mechanism if the gate must pause."
+    },
+    {
+      "parameters": {
+        "method": "POST",
+        "url": "http://nexus-bridge-1:8091/api/v1/n8n/runs/update",
+        "authentication": "predefinedCredentialType",
+        "nodeCredentialType": "httpBearerAuth",
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "{\n  \"run_id\": \"={{$json.run?.run_id || $json.run_id}}\",\n  \"state\": \"publish_completed\",\n  \"message\": \"Completed Nexus step publish\",\n  \"data\": {\n    \"step\": {\n      \"id\": \"publish\",\n      \"name\": \"Publish to Instagram\",\n      \"description\": \"Publish the approved caption + image to Instagram via the Meta adapter (target=instagram, instagram_account_id required). First run a dry_run to validate credentials, image_url, and caption length. If dry_run passes: publish. Post the result (IG post URL) as a comment. NOTE: image_url must be a public HTTPS URL accessible by Meta's servers.\\n\",\n      \"agent_type\": \"publisher\",\n      \"context_policy\": \"standard\",\n      \"tools\": [\n        \"vcs:read_comments\",\n        \"vcs:add_comment\"\n      ],\n      \"inputs\": [\n        {\n          \"post_text\": \"string\"\n        },\n        {\n          \"post_platform\": \"string\"\n        },\n        {\n          \"image_url\": \"string\"\n        }\n      ],\n      \"outputs\": [\n        {\n          \"publish_status\": \"enum[published|dry_run_only|failed]\"\n        },\n        {\n          \"publish_url\": \"string\"\n        },\n        {\n          \"publish_platform\": \"string\"\n        }\n      ],\n      \"on_success\": \"close_loop\",\n      \"require_human_approval\": true,\n      \"audit_limit\": 20,\n      \"include_audit_history\": true\n    }\n  }\n}"
+      },
+      "id": "complete-publish",
+      "name": "Complete publish",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [
+        2220,
+        -180
+      ],
+      "notesInFlow": true,
+      "notes": "Replace this state transition with a concrete agent/tool call when available."
+    },
+    {
+      "parameters": {
+        "method": "POST",
+        "url": "http://nexus-bridge-1:8091/api/v1/n8n/runs/update",
+        "authentication": "predefinedCredentialType",
+        "nodeCredentialType": "httpBearerAuth",
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "{\n  \"run_id\": \"={{$json.run?.run_id || $json.run_id}}\",\n  \"state\": \"close_loop\",\n  \"message\": \"Starting Nexus step close_loop\",\n  \"data\": {\n    \"step\": {\n      \"id\": \"close_loop\",\n      \"index\": 6,\n      \"name\": \"Document & Close\",\n      \"description\": \"Write a short summary of the published post. Close the issue with label social:published.\",\n      \"agent_type\": \"writer\",\n      \"context_policy\": \"minimal\",\n      \"tools\": [\n        \"vcs:add_comment\",\n        \"vcs:add_label\",\n        \"vcs:close_issue\"\n      ],\n      \"inputs\": [\n        {\n          \"publish_url\": \"string\"\n        },\n        {\n          \"publish_platform\": \"string\"\n        },\n        {\n          \"post_text\": \"string\"\n        }\n      ],\n      \"outputs\": [\n        {\n          \"summary\": \"string\"\n        }\n      ],\n      \"final_step\": true\n    }\n  }\n}"
+      },
+      "id": "start-close_loop",
+      "name": "06 Start close_loop",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [
+        2360,
+        120
+      ],
+      "notesInFlow": true,
+      "notes": "Write a short summary of the published post. Close the issue with label social:published."
+    },
+    {
+      "parameters": {
+        "method": "POST",
+        "url": "http://nexus-bridge-1:8091/api/v1/n8n/runs/update",
+        "authentication": "predefinedCredentialType",
+        "nodeCredentialType": "httpBearerAuth",
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "{\n  \"run_id\": \"={{$json.run?.run_id || $json.run_id}}\",\n  \"state\": \"close_loop_completed\",\n  \"message\": \"Completed Nexus step close_loop\",\n  \"data\": {\n    \"step\": {\n      \"id\": \"close_loop\",\n      \"name\": \"Document & Close\",\n      \"description\": \"Write a short summary of the published post. Close the issue with label social:published.\",\n      \"agent_type\": \"writer\",\n      \"context_policy\": \"minimal\",\n      \"tools\": [\n        \"vcs:add_comment\",\n        \"vcs:add_label\",\n        \"vcs:close_issue\"\n      ],\n      \"inputs\": [\n        {\n          \"publish_url\": \"string\"\n        },\n        {\n          \"publish_platform\": \"string\"\n        },\n        {\n          \"post_text\": \"string\"\n        }\n      ],\n      \"outputs\": [\n        {\n          \"summary\": \"string\"\n        }\n      ],\n      \"final_step\": true\n    }\n  }\n}"
+      },
+      "id": "complete-close_loop",
+      "name": "Complete close_loop",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [
+        2580,
+        120
+      ],
+      "notesInFlow": true,
+      "notes": "Replace this state transition with a concrete agent/tool call when available."
+    },
+    {
+      "parameters": {
+        "mode": "rules",
+        "rules": {
+          "values": [
+            {
+              "conditions": {
+                "conditions": [
+                  {
+                    "leftValue": "={{$json.next_step}}",
+                    "rightValue": "publish",
+                    "operator": {
+                      "type": "string",
+                      "operation": "equals"
+                    }
+                  }
+                ],
+                "combinator": "and"
+              }
+            },
+            {
+              "conditions": {
+                "conditions": [
+                  {
+                    "leftValue": "={{$json.next_step}}",
+                    "rightValue": "write",
+                    "operator": {
+                      "type": "string",
+                      "operation": "equals"
+                    }
+                  }
+                ],
+                "combinator": "and"
+              }
+            }
+          ]
+        },
+        "options": {}
+      },
+      "id": "switch-switch-route_review",
+      "name": "Switch route_review",
+      "type": "n8n-nodes-base.switch",
+      "typeVersion": 3,
+      "position": [
+        2080,
+        260
+      ],
+      "notesInFlow": true,
+      "notes": "Routes to the Nexus step selected by the preceding Code node."
+    }
+  ],
+  "connections": {
+    "01 Start research": {
+      "main": [
+        [
+          {
+            "node": "Complete research",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "02 Start write": {
+      "main": [
+        [
+          {
+            "node": "Complete write",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "03 Start review": {
+      "main": [
+        [
+          {
+            "node": "Complete review",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "04 Start route_review": {
+      "main": [
+        [
+          {
+            "node": "Route route_review",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "05 Start publish": {
+      "main": [
+        [
+          {
+            "node": "Approval Gate publish",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Approval Gate publish": {
+      "main": [
+        [
+          {
+            "node": "Complete publish",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "06 Start close_loop": {
+      "main": [
+        [
+          {
+            "node": "Complete close_loop",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Create Nexus Run": {
+      "main": [
+        [
+          {
+            "node": "01 Start research",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Manual Trigger": {
+      "main": [
+        [
+          {
+            "node": "Create Nexus Run",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Complete research": {
+      "main": [
+        [
+          {
+            "node": "02 Start write",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Complete write": {
+      "main": [
+        [
+          {
+            "node": "03 Start review",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Complete review": {
+      "main": [
+        [
+          {
+            "node": "04 Start route_review",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Route route_review": {
+      "main": [
+        [
+          {
+            "node": "Switch route_review",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Switch route_review": {
+      "main": [
+        [
+          {
+            "node": "05 Start publish",
+            "type": "main",
+            "index": 0
+          }
+        ],
+        [
+          {
+            "node": "02 Start write",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Complete publish": {
+      "main": [
+        [
+          {
+            "node": "06 Start close_loop",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    }
+  },
+  "settings": {
+    "executionOrder": "v1"
+  },
+  "staticData": null,
+  "tags": [
+    "nexus-arc",
+    "generated"
+  ],
+  "meta": {
+    "nexusArc": {
+      "source": "examples/workflows/instagram_post_workflow.yaml",
+      "workflowType": "social-post",
+      "converter": "nexus.translators.to_n8n"
+    }
+  }
+}

--- a/examples/workflows/n8n/linkedin_post_workflow.json
+++ b/examples/workflows/n8n/linkedin_post_workflow.json
@@ -1,0 +1,541 @@
+{
+  "name": "Social Post Workflow",
+  "nodes": [
+    {
+      "parameters": {},
+      "id": "manual-trigger",
+      "name": "Manual Trigger",
+      "type": "n8n-nodes-base.manualTrigger",
+      "typeVersion": 1,
+      "position": [
+        0,
+        0
+      ]
+    },
+    {
+      "parameters": {
+        "method": "POST",
+        "url": "http://nexus-bridge-1:8091/api/v1/n8n/runs",
+        "authentication": "predefinedCredentialType",
+        "nodeCredentialType": "httpBearerAuth",
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "{\n  \"task\": \"={{$json.task || $json.title || 'Run Nexus workflow'}}\",\n  \"project_key\": \"={{$json.project_key || $json.project || 'nexus'}}\",\n  \"issue_number\": \"={{$json.issue_number || $json.issue || ''}}\",\n  \"requester\": {\n    \"source\": \"n8n\",\n    \"workflow\": \"Social Post Workflow\"\n  },\n  \"metadata\": {\n    \"nexus_workflow\": {\n      \"name\": \"Social Post Workflow\",\n      \"description\": \"Research a topic, write a LinkedIn post, validate it, and publish. Optional X/Meta cross-post.\",\n      \"version\": \"1.0.0\"\n    },\n    \"workflow_type\": \"social-post\",\n    \"source\": \"examples/workflows/linkedin_post_workflow.yaml\"\n  }\n}"
+      },
+      "id": "create-nexus-run",
+      "name": "Create Nexus Run",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [
+        260,
+        0
+      ],
+      "notesInFlow": true,
+      "notes": "Creates the durable Nexus run that n8n will advance."
+    },
+    {
+      "parameters": {
+        "method": "POST",
+        "url": "http://nexus-bridge-1:8091/api/v1/n8n/runs/update",
+        "authentication": "predefinedCredentialType",
+        "nodeCredentialType": "httpBearerAuth",
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "{\n  \"run_id\": \"={{$json.run?.run_id || $json.run_id}}\",\n  \"state\": \"research\",\n  \"message\": \"Starting Nexus step research\",\n  \"data\": {\n    \"step\": {\n      \"id\": \"research\",\n      \"index\": 1,\n      \"name\": \"Research\",\n      \"description\": \"Gather relevant context about the topic from the issue description, linked docs, web search results, and any project knowledge base. Produce a structured brief: key facts, tone, audience, CTA suggestion, and 3\\u20135 relevant hashtags.\\n\",\n      \"agent_type\": \"researcher\",\n      \"context_policy\": \"minimal\",\n      \"tools\": [\n        \"vcs:read_issue\",\n        \"vcs:add_comment\"\n      ],\n      \"inputs\": [\n        {\n          \"topic\": \"string\"\n        },\n        {\n          \"audience\": \"string\"\n        }\n      ],\n      \"outputs\": [\n        {\n          \"research_brief\": \"string\"\n        },\n        {\n          \"key_facts\": \"list[string]\"\n        },\n        {\n          \"suggested_hashtags\": \"list[string]\"\n        }\n      ],\n      \"on_success\": \"write\"\n    }\n  }\n}"
+      },
+      "id": "start-research",
+      "name": "01 Start research",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [
+        560,
+        0
+      ],
+      "notesInFlow": true,
+      "notes": "Gather relevant context about the topic from the issue description, linked docs, web search results, and any project knowledge base. Produce a structured brief: key facts, tone, audience, CTA suggestion, and 3\u20135 relevant hashtags.\n"
+    },
+    {
+      "parameters": {
+        "method": "POST",
+        "url": "http://nexus-bridge-1:8091/api/v1/n8n/runs/update",
+        "authentication": "predefinedCredentialType",
+        "nodeCredentialType": "httpBearerAuth",
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "{\n  \"run_id\": \"={{$json.run?.run_id || $json.run_id}}\",\n  \"state\": \"research_completed\",\n  \"message\": \"Completed Nexus step research\",\n  \"data\": {\n    \"step\": {\n      \"id\": \"research\",\n      \"name\": \"Research\",\n      \"description\": \"Gather relevant context about the topic from the issue description, linked docs, web search results, and any project knowledge base. Produce a structured brief: key facts, tone, audience, CTA suggestion, and 3\\u20135 relevant hashtags.\\n\",\n      \"agent_type\": \"researcher\",\n      \"context_policy\": \"minimal\",\n      \"tools\": [\n        \"vcs:read_issue\",\n        \"vcs:add_comment\"\n      ],\n      \"inputs\": [\n        {\n          \"topic\": \"string\"\n        },\n        {\n          \"audience\": \"string\"\n        }\n      ],\n      \"outputs\": [\n        {\n          \"research_brief\": \"string\"\n        },\n        {\n          \"key_facts\": \"list[string]\"\n        },\n        {\n          \"suggested_hashtags\": \"list[string]\"\n        }\n      ],\n      \"on_success\": \"write\"\n    }\n  }\n}"
+      },
+      "id": "complete-research",
+      "name": "Complete research",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [
+        780,
+        0
+      ],
+      "notesInFlow": true,
+      "notes": "Replace this state transition with a concrete agent/tool call when available."
+    },
+    {
+      "parameters": {
+        "method": "POST",
+        "url": "http://nexus-bridge-1:8091/api/v1/n8n/runs/update",
+        "authentication": "predefinedCredentialType",
+        "nodeCredentialType": "httpBearerAuth",
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "{\n  \"run_id\": \"={{$json.run?.run_id || $json.run_id}}\",\n  \"state\": \"write\",\n  \"message\": \"Starting Nexus step write\",\n  \"data\": {\n    \"step\": {\n      \"id\": \"write\",\n      \"index\": 2,\n      \"name\": \"Write LinkedIn Post\",\n      \"description\": \"Write a high-quality LinkedIn post based on the research brief. Format: hook (1\\u20132 lines) \\u2192 body (insight or story, 3\\u20135 paragraphs) \\u2192 CTA \\u2192 hashtags. Tone: professional but human. Max 3000 characters. No generic openers. Output the final post text only \\u2014 no markdown formatting wrappers.\\n\",\n      \"agent_type\": \"writer\",\n      \"context_policy\": \"standard\",\n      \"tools\": [\n        \"vcs:read_comments\",\n        \"vcs:add_comment\"\n      ],\n      \"inputs\": [\n        {\n          \"research_brief\": \"string\"\n        },\n        {\n          \"key_facts\": \"list[string]\"\n        },\n        {\n          \"suggested_hashtags\": \"list[string]\"\n        }\n      ],\n      \"outputs\": [\n        {\n          \"post_text\": \"string\"\n        },\n        {\n          \"post_platform\": \"string\"\n        },\n        {\n          \"post_word_count\": \"integer\"\n        }\n      ],\n      \"on_success\": \"review\",\n      \"audit_limit\": 10,\n      \"include_audit_history\": true\n    }\n  }\n}"
+      },
+      "id": "start-write",
+      "name": "02 Start write",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [
+        920,
+        120
+      ],
+      "notesInFlow": true,
+      "notes": "Write a high-quality LinkedIn post based on the research brief. Format: hook (1\u20132 lines) \u2192 body (insight or story, 3\u20135 paragraphs) \u2192 CTA \u2192 hashtags. Tone: professional but human. Max 3000 characters. No generic openers. Output the final post text only \u2014 no markdown formatting wrappers.\n"
+    },
+    {
+      "parameters": {
+        "method": "POST",
+        "url": "http://nexus-bridge-1:8091/api/v1/n8n/runs/update",
+        "authentication": "predefinedCredentialType",
+        "nodeCredentialType": "httpBearerAuth",
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "{\n  \"run_id\": \"={{$json.run?.run_id || $json.run_id}}\",\n  \"state\": \"write_completed\",\n  \"message\": \"Completed Nexus step write\",\n  \"data\": {\n    \"step\": {\n      \"id\": \"write\",\n      \"name\": \"Write LinkedIn Post\",\n      \"description\": \"Write a high-quality LinkedIn post based on the research brief. Format: hook (1\\u20132 lines) \\u2192 body (insight or story, 3\\u20135 paragraphs) \\u2192 CTA \\u2192 hashtags. Tone: professional but human. Max 3000 characters. No generic openers. Output the final post text only \\u2014 no markdown formatting wrappers.\\n\",\n      \"agent_type\": \"writer\",\n      \"context_policy\": \"standard\",\n      \"tools\": [\n        \"vcs:read_comments\",\n        \"vcs:add_comment\"\n      ],\n      \"inputs\": [\n        {\n          \"research_brief\": \"string\"\n        },\n        {\n          \"key_facts\": \"list[string]\"\n        },\n        {\n          \"suggested_hashtags\": \"list[string]\"\n        }\n      ],\n      \"outputs\": [\n        {\n          \"post_text\": \"string\"\n        },\n        {\n          \"post_platform\": \"string\"\n        },\n        {\n          \"post_word_count\": \"integer\"\n        }\n      ],\n      \"on_success\": \"review\",\n      \"audit_limit\": 10,\n      \"include_audit_history\": true\n    }\n  }\n}"
+      },
+      "id": "complete-write",
+      "name": "Complete write",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [
+        1140,
+        120
+      ],
+      "notesInFlow": true,
+      "notes": "Replace this state transition with a concrete agent/tool call when available."
+    },
+    {
+      "parameters": {
+        "method": "POST",
+        "url": "http://nexus-bridge-1:8091/api/v1/n8n/runs/update",
+        "authentication": "predefinedCredentialType",
+        "nodeCredentialType": "httpBearerAuth",
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "{\n  \"run_id\": \"={{$json.run?.run_id || $json.run_id}}\",\n  \"state\": \"review\",\n  \"message\": \"Starting Nexus step review\",\n  \"data\": {\n    \"step\": {\n      \"id\": \"review\",\n      \"index\": 3,\n      \"name\": \"Review & Validate\",\n      \"description\": \"Review the post for: accuracy, tone consistency, platform compliance (LinkedIn rules), brand voice, no unverified claims, appropriate hashtag count (3\\u20135). Either approve or request specific changes with actionable feedback.\\n\",\n      \"agent_type\": \"reviewer\",\n      \"context_policy\": \"standard\",\n      \"tools\": [\n        \"vcs:read_comments\",\n        \"vcs:add_comment\"\n      ],\n      \"inputs\": [\n        {\n          \"post_text\": \"string\"\n        }\n      ],\n      \"outputs\": [\n        {\n          \"review_status\": \"enum[approved|changes_requested]\"\n        },\n        {\n          \"review_notes\": \"string\"\n        }\n      ],\n      \"on_success\": \"route_review\",\n      \"audit_limit\": 20,\n      \"include_audit_history\": true\n    }\n  }\n}"
+      },
+      "id": "start-review",
+      "name": "03 Start review",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [
+        1280,
+        0
+      ],
+      "notesInFlow": true,
+      "notes": "Review the post for: accuracy, tone consistency, platform compliance (LinkedIn rules), brand voice, no unverified claims, appropriate hashtag count (3\u20135). Either approve or request specific changes with actionable feedback.\n"
+    },
+    {
+      "parameters": {
+        "method": "POST",
+        "url": "http://nexus-bridge-1:8091/api/v1/n8n/runs/update",
+        "authentication": "predefinedCredentialType",
+        "nodeCredentialType": "httpBearerAuth",
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "{\n  \"run_id\": \"={{$json.run?.run_id || $json.run_id}}\",\n  \"state\": \"review_completed\",\n  \"message\": \"Completed Nexus step review\",\n  \"data\": {\n    \"step\": {\n      \"id\": \"review\",\n      \"name\": \"Review & Validate\",\n      \"description\": \"Review the post for: accuracy, tone consistency, platform compliance (LinkedIn rules), brand voice, no unverified claims, appropriate hashtag count (3\\u20135). Either approve or request specific changes with actionable feedback.\\n\",\n      \"agent_type\": \"reviewer\",\n      \"context_policy\": \"standard\",\n      \"tools\": [\n        \"vcs:read_comments\",\n        \"vcs:add_comment\"\n      ],\n      \"inputs\": [\n        {\n          \"post_text\": \"string\"\n        }\n      ],\n      \"outputs\": [\n        {\n          \"review_status\": \"enum[approved|changes_requested]\"\n        },\n        {\n          \"review_notes\": \"string\"\n        }\n      ],\n      \"on_success\": \"route_review\",\n      \"audit_limit\": 20,\n      \"include_audit_history\": true\n    }\n  }\n}"
+      },
+      "id": "complete-review",
+      "name": "Complete review",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [
+        1500,
+        0
+      ],
+      "notesInFlow": true,
+      "notes": "Replace this state transition with a concrete agent/tool call when available."
+    },
+    {
+      "parameters": {
+        "method": "POST",
+        "url": "http://nexus-bridge-1:8091/api/v1/n8n/runs/update",
+        "authentication": "predefinedCredentialType",
+        "nodeCredentialType": "httpBearerAuth",
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "{\n  \"run_id\": \"={{$json.run?.run_id || $json.run_id}}\",\n  \"state\": \"route_review\",\n  \"message\": \"Starting Nexus step route_review\",\n  \"data\": {\n    \"step\": {\n      \"id\": \"route_review\",\n      \"index\": 4,\n      \"name\": \"Route After Review\",\n      \"agent_type\": \"router\",\n      \"context_policy\": \"minimal\",\n      \"routes\": [\n        {\n          \"when\": \"review_status == 'approved'\",\n          \"then\": \"publish\"\n        },\n        {\n          \"when\": \"review_status == 'changes_requested'\",\n          \"then\": \"write\"\n        },\n        {\n          \"default\": \"write\"\n        }\n      ]\n    }\n  }\n}"
+      },
+      "id": "start-route_review",
+      "name": "04 Start route_review",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [
+        1640,
+        260
+      ]
+    },
+    {
+      "parameters": {
+        "jsCode": "const routes = [\n  {\n    \"when\": \"review_status == 'approved'\",\n    \"then\": \"publish\"\n  },\n  {\n    \"when\": \"review_status == 'changes_requested'\",\n    \"then\": \"write\"\n  },\n  {\n    \"default\": \"write\"\n  }\n];\nconst state = $json;\n\nfunction toJsExpression(expr) {\n  return String(expr)\n    .replace(/\\band\\b/g, '&&')\n    .replace(/\\bor\\b/g, '||')\n    .replace(/\\bnot\\b/g, '!')\n    .replace(/\\bTrue\\b/g, 'true')\n    .replace(/\\bFalse\\b/g, 'false')\n    .replace(/\\bNone\\b/g, 'null');\n}\n\nfunction evaluate(expr) {\n  const keys = Object.keys(state);\n  const values = Object.values(state);\n  try {\n    return Boolean(Function(...keys, `return (${toJsExpression(expr)});`)(...values));\n  } catch (error) {\n    return false;\n  }\n}\n\nlet nextStep = null;\nfor (const route of routes) {\n  if (route.when && evaluate(route.when)) {\n    nextStep = route.then;\n    break;\n  }\n  if (!route.when && route.default && nextStep === null) {\n    nextStep = route.default;\n  }\n}\n\nreturn [{ json: { ...state, next_step: nextStep } }];\n"
+      },
+      "id": "route-route_review",
+      "name": "Route route_review",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [
+        1860,
+        260
+      ],
+      "notesInFlow": true,
+      "notes": "Evaluates Nexus route rules and writes next_step."
+    },
+    {
+      "parameters": {
+        "method": "POST",
+        "url": "http://nexus-bridge-1:8091/api/v1/n8n/runs/update",
+        "authentication": "predefinedCredentialType",
+        "nodeCredentialType": "httpBearerAuth",
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "{\n  \"run_id\": \"={{$json.run?.run_id || $json.run_id}}\",\n  \"state\": \"publish\",\n  \"message\": \"Starting Nexus step publish\",\n  \"data\": {\n    \"step\": {\n      \"id\": \"publish\",\n      \"index\": 5,\n      \"name\": \"Publish to LinkedIn\",\n      \"description\": \"Publish the approved post to LinkedIn. First run a dry_run to validate credentials and content format. If dry_run passes, call social:publish with platform=linkedin. Post the publish result (post URL or error) as a comment. DO NOT publish without a passing dry_run.\\n\",\n      \"agent_type\": \"publisher\",\n      \"context_policy\": \"standard\",\n      \"tools\": [\n        \"vcs:read_comments\",\n        \"vcs:add_comment\"\n      ],\n      \"inputs\": [\n        {\n          \"post_text\": \"string\"\n        },\n        {\n          \"post_platform\": \"string\"\n        }\n      ],\n      \"outputs\": [\n        {\n          \"publish_status\": \"enum[published|dry_run_only|failed]\"\n        },\n        {\n          \"publish_url\": \"string\"\n        },\n        {\n          \"publish_platform\": \"string\"\n        }\n      ],\n      \"on_success\": \"close_loop\",\n      \"require_human_approval\": true,\n      \"audit_limit\": 20,\n      \"include_audit_history\": true\n    }\n  }\n}"
+      },
+      "id": "start-publish",
+      "name": "05 Start publish",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [
+        2000,
+        -180
+      ],
+      "notesInFlow": true,
+      "notes": "Publish the approved post to LinkedIn. First run a dry_run to validate credentials and content format. If dry_run passes, call social:publish with platform=linkedin. Post the publish result (post URL or error) as a comment. DO NOT publish without a passing dry_run.\n"
+    },
+    {
+      "parameters": {
+        "method": "POST",
+        "url": "http://nexus-bridge-1:8091/api/v1/n8n/runs/update",
+        "authentication": "predefinedCredentialType",
+        "nodeCredentialType": "httpBearerAuth",
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "{\n  \"run_id\": \"={{$json.run?.run_id || $json.run_id}}\",\n  \"state\": \"publish_awaiting_approval\",\n  \"message\": \"Human approval required before publish\",\n  \"data\": {\n    \"step_id\": \"publish\",\n    \"agent_type\": \"publisher\"\n  }\n}"
+      },
+      "id": "approval-publish",
+      "name": "Approval Gate publish",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [
+        2220,
+        -300
+      ],
+      "notesInFlow": true,
+      "notes": "Connect this node to an n8n approval/wait mechanism if the gate must pause."
+    },
+    {
+      "parameters": {
+        "method": "POST",
+        "url": "http://nexus-bridge-1:8091/api/v1/n8n/runs/update",
+        "authentication": "predefinedCredentialType",
+        "nodeCredentialType": "httpBearerAuth",
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "{\n  \"run_id\": \"={{$json.run?.run_id || $json.run_id}}\",\n  \"state\": \"publish_completed\",\n  \"message\": \"Completed Nexus step publish\",\n  \"data\": {\n    \"step\": {\n      \"id\": \"publish\",\n      \"name\": \"Publish to LinkedIn\",\n      \"description\": \"Publish the approved post to LinkedIn. First run a dry_run to validate credentials and content format. If dry_run passes, call social:publish with platform=linkedin. Post the publish result (post URL or error) as a comment. DO NOT publish without a passing dry_run.\\n\",\n      \"agent_type\": \"publisher\",\n      \"context_policy\": \"standard\",\n      \"tools\": [\n        \"vcs:read_comments\",\n        \"vcs:add_comment\"\n      ],\n      \"inputs\": [\n        {\n          \"post_text\": \"string\"\n        },\n        {\n          \"post_platform\": \"string\"\n        }\n      ],\n      \"outputs\": [\n        {\n          \"publish_status\": \"enum[published|dry_run_only|failed]\"\n        },\n        {\n          \"publish_url\": \"string\"\n        },\n        {\n          \"publish_platform\": \"string\"\n        }\n      ],\n      \"on_success\": \"close_loop\",\n      \"require_human_approval\": true,\n      \"audit_limit\": 20,\n      \"include_audit_history\": true\n    }\n  }\n}"
+      },
+      "id": "complete-publish",
+      "name": "Complete publish",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [
+        2220,
+        -180
+      ],
+      "notesInFlow": true,
+      "notes": "Replace this state transition with a concrete agent/tool call when available."
+    },
+    {
+      "parameters": {
+        "method": "POST",
+        "url": "http://nexus-bridge-1:8091/api/v1/n8n/runs/update",
+        "authentication": "predefinedCredentialType",
+        "nodeCredentialType": "httpBearerAuth",
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "{\n  \"run_id\": \"={{$json.run?.run_id || $json.run_id}}\",\n  \"state\": \"close_loop\",\n  \"message\": \"Starting Nexus step close_loop\",\n  \"data\": {\n    \"step\": {\n      \"id\": \"close_loop\",\n      \"index\": 6,\n      \"name\": \"Document & Close\",\n      \"description\": \"Write a short summary of the published post (platform, URL, reach estimate). Close the issue with label social:published.\\n\",\n      \"agent_type\": \"writer\",\n      \"context_policy\": \"minimal\",\n      \"tools\": [\n        \"vcs:add_comment\",\n        \"vcs:add_label\",\n        \"vcs:close_issue\"\n      ],\n      \"inputs\": [\n        {\n          \"publish_url\": \"string\"\n        },\n        {\n          \"publish_platform\": \"string\"\n        },\n        {\n          \"post_text\": \"string\"\n        }\n      ],\n      \"outputs\": [\n        {\n          \"summary\": \"string\"\n        }\n      ],\n      \"final_step\": true\n    }\n  }\n}"
+      },
+      "id": "start-close_loop",
+      "name": "06 Start close_loop",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [
+        2360,
+        120
+      ],
+      "notesInFlow": true,
+      "notes": "Write a short summary of the published post (platform, URL, reach estimate). Close the issue with label social:published.\n"
+    },
+    {
+      "parameters": {
+        "method": "POST",
+        "url": "http://nexus-bridge-1:8091/api/v1/n8n/runs/update",
+        "authentication": "predefinedCredentialType",
+        "nodeCredentialType": "httpBearerAuth",
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "{\n  \"run_id\": \"={{$json.run?.run_id || $json.run_id}}\",\n  \"state\": \"close_loop_completed\",\n  \"message\": \"Completed Nexus step close_loop\",\n  \"data\": {\n    \"step\": {\n      \"id\": \"close_loop\",\n      \"name\": \"Document & Close\",\n      \"description\": \"Write a short summary of the published post (platform, URL, reach estimate). Close the issue with label social:published.\\n\",\n      \"agent_type\": \"writer\",\n      \"context_policy\": \"minimal\",\n      \"tools\": [\n        \"vcs:add_comment\",\n        \"vcs:add_label\",\n        \"vcs:close_issue\"\n      ],\n      \"inputs\": [\n        {\n          \"publish_url\": \"string\"\n        },\n        {\n          \"publish_platform\": \"string\"\n        },\n        {\n          \"post_text\": \"string\"\n        }\n      ],\n      \"outputs\": [\n        {\n          \"summary\": \"string\"\n        }\n      ],\n      \"final_step\": true\n    }\n  }\n}"
+      },
+      "id": "complete-close_loop",
+      "name": "Complete close_loop",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [
+        2580,
+        120
+      ],
+      "notesInFlow": true,
+      "notes": "Replace this state transition with a concrete agent/tool call when available."
+    },
+    {
+      "parameters": {
+        "mode": "rules",
+        "rules": {
+          "values": [
+            {
+              "conditions": {
+                "conditions": [
+                  {
+                    "leftValue": "={{$json.next_step}}",
+                    "rightValue": "publish",
+                    "operator": {
+                      "type": "string",
+                      "operation": "equals"
+                    }
+                  }
+                ],
+                "combinator": "and"
+              }
+            },
+            {
+              "conditions": {
+                "conditions": [
+                  {
+                    "leftValue": "={{$json.next_step}}",
+                    "rightValue": "write",
+                    "operator": {
+                      "type": "string",
+                      "operation": "equals"
+                    }
+                  }
+                ],
+                "combinator": "and"
+              }
+            }
+          ]
+        },
+        "options": {}
+      },
+      "id": "switch-switch-route_review",
+      "name": "Switch route_review",
+      "type": "n8n-nodes-base.switch",
+      "typeVersion": 3,
+      "position": [
+        2080,
+        260
+      ],
+      "notesInFlow": true,
+      "notes": "Routes to the Nexus step selected by the preceding Code node."
+    }
+  ],
+  "connections": {
+    "01 Start research": {
+      "main": [
+        [
+          {
+            "node": "Complete research",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "02 Start write": {
+      "main": [
+        [
+          {
+            "node": "Complete write",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "03 Start review": {
+      "main": [
+        [
+          {
+            "node": "Complete review",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "04 Start route_review": {
+      "main": [
+        [
+          {
+            "node": "Route route_review",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "05 Start publish": {
+      "main": [
+        [
+          {
+            "node": "Approval Gate publish",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Approval Gate publish": {
+      "main": [
+        [
+          {
+            "node": "Complete publish",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "06 Start close_loop": {
+      "main": [
+        [
+          {
+            "node": "Complete close_loop",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Create Nexus Run": {
+      "main": [
+        [
+          {
+            "node": "01 Start research",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Manual Trigger": {
+      "main": [
+        [
+          {
+            "node": "Create Nexus Run",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Complete research": {
+      "main": [
+        [
+          {
+            "node": "02 Start write",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Complete write": {
+      "main": [
+        [
+          {
+            "node": "03 Start review",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Complete review": {
+      "main": [
+        [
+          {
+            "node": "04 Start route_review",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Route route_review": {
+      "main": [
+        [
+          {
+            "node": "Switch route_review",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Switch route_review": {
+      "main": [
+        [
+          {
+            "node": "05 Start publish",
+            "type": "main",
+            "index": 0
+          }
+        ],
+        [
+          {
+            "node": "02 Start write",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Complete publish": {
+      "main": [
+        [
+          {
+            "node": "06 Start close_loop",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    }
+  },
+  "settings": {
+    "executionOrder": "v1"
+  },
+  "staticData": null,
+  "tags": [
+    "nexus-arc",
+    "generated"
+  ],
+  "meta": {
+    "nexusArc": {
+      "source": "examples/workflows/linkedin_post_workflow.yaml",
+      "workflowType": "social-post",
+      "converter": "nexus.translators.to_n8n"
+    }
+  }
+}

--- a/examples/workflows/n8n/multi_social_post_workflow.json
+++ b/examples/workflows/n8n/multi_social_post_workflow.json
@@ -1,0 +1,861 @@
+{
+  "name": "Multi-Platform Social Post Workflow",
+  "nodes": [
+    {
+      "parameters": {},
+      "id": "manual-trigger",
+      "name": "Manual Trigger",
+      "type": "n8n-nodes-base.manualTrigger",
+      "typeVersion": 1,
+      "position": [
+        0,
+        0
+      ]
+    },
+    {
+      "parameters": {
+        "method": "POST",
+        "url": "http://nexus-bridge-1:8091/api/v1/n8n/runs",
+        "authentication": "predefinedCredentialType",
+        "nodeCredentialType": "httpBearerAuth",
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "{\n  \"task\": \"={{$json.task || $json.title || 'Run Nexus workflow'}}\",\n  \"project_key\": \"={{$json.project_key || $json.project || 'nexus'}}\",\n  \"issue_number\": \"={{$json.issue_number || $json.issue || ''}}\",\n  \"requester\": {\n    \"source\": \"n8n\",\n    \"workflow\": \"Multi-Platform Social Post Workflow\"\n  },\n  \"metadata\": {\n    \"nexus_workflow\": {\n      \"name\": \"Multi-Platform Social Post Workflow\",\n      \"description\": \"Research a topic, write platform-adapted content, validate all, then publish to LinkedIn, X, and Instagram in sequence.\\n\",\n      \"version\": \"1.0.0\"\n    },\n    \"workflow_type\": \"social-post\",\n    \"source\": \"examples/workflows/multi_social_post_workflow.yaml\"\n  }\n}"
+      },
+      "id": "create-nexus-run",
+      "name": "Create Nexus Run",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [
+        260,
+        0
+      ],
+      "notesInFlow": true,
+      "notes": "Creates the durable Nexus run that n8n will advance."
+    },
+    {
+      "parameters": {
+        "method": "POST",
+        "url": "http://nexus-bridge-1:8091/api/v1/n8n/runs/update",
+        "authentication": "predefinedCredentialType",
+        "nodeCredentialType": "httpBearerAuth",
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "{\n  \"run_id\": \"={{$json.run?.run_id || $json.run_id}}\",\n  \"state\": \"research\",\n  \"message\": \"Starting Nexus step research\",\n  \"data\": {\n    \"step\": {\n      \"id\": \"research\",\n      \"index\": 1,\n      \"name\": \"Research\",\n      \"description\": \"Research the topic deeply. Produce a master brief covering: core insight, key facts, audience for each platform (LinkedIn=professional, X=technical/punchy, Instagram=visual/human), CTA options, 3\\u20135 universal themes, and image concept.\\n\",\n      \"agent_type\": \"researcher\",\n      \"context_policy\": \"minimal\",\n      \"tools\": [\n        \"vcs:read_issue\",\n        \"vcs:add_comment\"\n      ],\n      \"inputs\": [\n        {\n          \"topic\": \"string\"\n        },\n        {\n          \"platforms\": \"list[string]\"\n        },\n        {\n          \"image_url\": \"string\"\n        }\n      ],\n      \"outputs\": [\n        {\n          \"research_brief\": \"string\"\n        },\n        {\n          \"key_facts\": \"list[string]\"\n        },\n        {\n          \"visual_concept\": \"string\"\n        }\n      ],\n      \"on_success\": \"write_linkedin\"\n    }\n  }\n}"
+      },
+      "id": "start-research",
+      "name": "01 Start research",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [
+        560,
+        0
+      ],
+      "notesInFlow": true,
+      "notes": "Research the topic deeply. Produce a master brief covering: core insight, key facts, audience for each platform (LinkedIn=professional, X=technical/punchy, Instagram=visual/human), CTA options, 3\u20135 universal themes, and image concept.\n"
+    },
+    {
+      "parameters": {
+        "method": "POST",
+        "url": "http://nexus-bridge-1:8091/api/v1/n8n/runs/update",
+        "authentication": "predefinedCredentialType",
+        "nodeCredentialType": "httpBearerAuth",
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "{\n  \"run_id\": \"={{$json.run?.run_id || $json.run_id}}\",\n  \"state\": \"research_completed\",\n  \"message\": \"Completed Nexus step research\",\n  \"data\": {\n    \"step\": {\n      \"id\": \"research\",\n      \"name\": \"Research\",\n      \"description\": \"Research the topic deeply. Produce a master brief covering: core insight, key facts, audience for each platform (LinkedIn=professional, X=technical/punchy, Instagram=visual/human), CTA options, 3\\u20135 universal themes, and image concept.\\n\",\n      \"agent_type\": \"researcher\",\n      \"context_policy\": \"minimal\",\n      \"tools\": [\n        \"vcs:read_issue\",\n        \"vcs:add_comment\"\n      ],\n      \"inputs\": [\n        {\n          \"topic\": \"string\"\n        },\n        {\n          \"platforms\": \"list[string]\"\n        },\n        {\n          \"image_url\": \"string\"\n        }\n      ],\n      \"outputs\": [\n        {\n          \"research_brief\": \"string\"\n        },\n        {\n          \"key_facts\": \"list[string]\"\n        },\n        {\n          \"visual_concept\": \"string\"\n        }\n      ],\n      \"on_success\": \"write_linkedin\"\n    }\n  }\n}"
+      },
+      "id": "complete-research",
+      "name": "Complete research",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [
+        780,
+        0
+      ],
+      "notesInFlow": true,
+      "notes": "Replace this state transition with a concrete agent/tool call when available."
+    },
+    {
+      "parameters": {
+        "method": "POST",
+        "url": "http://nexus-bridge-1:8091/api/v1/n8n/runs/update",
+        "authentication": "predefinedCredentialType",
+        "nodeCredentialType": "httpBearerAuth",
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "{\n  \"run_id\": \"={{$json.run?.run_id || $json.run_id}}\",\n  \"state\": \"write_linkedin\",\n  \"message\": \"Starting Nexus step write_linkedin\",\n  \"data\": {\n    \"step\": {\n      \"id\": \"write_linkedin\",\n      \"index\": 2,\n      \"name\": \"Write LinkedIn Post\",\n      \"description\": \"Write a LinkedIn post based on the research brief. Format: hook \\u2192 body (3\\u20135 paragraphs) \\u2192 CTA \\u2192 hashtags (3\\u20135). Max 3000 chars. Tone: professional, insightful, human.\\n\",\n      \"agent_type\": \"writer\",\n      \"context_policy\": \"standard\",\n      \"tools\": [\n        \"vcs:read_comments\",\n        \"vcs:add_comment\"\n      ],\n      \"inputs\": [\n        {\n          \"research_brief\": \"string\"\n        },\n        {\n          \"key_facts\": \"list[string]\"\n        }\n      ],\n      \"outputs\": [\n        {\n          \"linkedin_post\": \"string\"\n        }\n      ],\n      \"on_success\": \"write_x\",\n      \"audit_limit\": 10,\n      \"include_audit_history\": true\n    }\n  }\n}"
+      },
+      "id": "start-write_linkedin",
+      "name": "02 Start write_linkedin",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [
+        920,
+        120
+      ],
+      "notesInFlow": true,
+      "notes": "Write a LinkedIn post based on the research brief. Format: hook \u2192 body (3\u20135 paragraphs) \u2192 CTA \u2192 hashtags (3\u20135). Max 3000 chars. Tone: professional, insightful, human.\n"
+    },
+    {
+      "parameters": {
+        "method": "POST",
+        "url": "http://nexus-bridge-1:8091/api/v1/n8n/runs/update",
+        "authentication": "predefinedCredentialType",
+        "nodeCredentialType": "httpBearerAuth",
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "{\n  \"run_id\": \"={{$json.run?.run_id || $json.run_id}}\",\n  \"state\": \"write_linkedin_completed\",\n  \"message\": \"Completed Nexus step write_linkedin\",\n  \"data\": {\n    \"step\": {\n      \"id\": \"write_linkedin\",\n      \"name\": \"Write LinkedIn Post\",\n      \"description\": \"Write a LinkedIn post based on the research brief. Format: hook \\u2192 body (3\\u20135 paragraphs) \\u2192 CTA \\u2192 hashtags (3\\u20135). Max 3000 chars. Tone: professional, insightful, human.\\n\",\n      \"agent_type\": \"writer\",\n      \"context_policy\": \"standard\",\n      \"tools\": [\n        \"vcs:read_comments\",\n        \"vcs:add_comment\"\n      ],\n      \"inputs\": [\n        {\n          \"research_brief\": \"string\"\n        },\n        {\n          \"key_facts\": \"list[string]\"\n        }\n      ],\n      \"outputs\": [\n        {\n          \"linkedin_post\": \"string\"\n        }\n      ],\n      \"on_success\": \"write_x\",\n      \"audit_limit\": 10,\n      \"include_audit_history\": true\n    }\n  }\n}"
+      },
+      "id": "complete-write_linkedin",
+      "name": "Complete write_linkedin",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [
+        1140,
+        120
+      ],
+      "notesInFlow": true,
+      "notes": "Replace this state transition with a concrete agent/tool call when available."
+    },
+    {
+      "parameters": {
+        "method": "POST",
+        "url": "http://nexus-bridge-1:8091/api/v1/n8n/runs/update",
+        "authentication": "predefinedCredentialType",
+        "nodeCredentialType": "httpBearerAuth",
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "{\n  \"run_id\": \"={{$json.run?.run_id || $json.run_id}}\",\n  \"state\": \"write_x\",\n  \"message\": \"Starting Nexus step write_x\",\n  \"data\": {\n    \"step\": {\n      \"id\": \"write_x\",\n      \"index\": 3,\n      \"name\": \"Write X Post/Thread\",\n      \"description\": \"Adapt the LinkedIn content for X. Either a single punchy tweet (\\u2264280 chars) or a thread (3\\u20138 tweets). Lead with the sharpest insight. Hashtags: max 2\\u20133 at the end of the last tweet only.\\n\",\n      \"agent_type\": \"writer\",\n      \"context_policy\": \"standard\",\n      \"tools\": [\n        \"vcs:read_comments\",\n        \"vcs:add_comment\"\n      ],\n      \"inputs\": [\n        {\n          \"research_brief\": \"string\"\n        },\n        {\n          \"linkedin_post\": \"string\"\n        }\n      ],\n      \"outputs\": [\n        {\n          \"x_post\": \"string\"\n        },\n        {\n          \"x_is_thread\": \"boolean\"\n        }\n      ],\n      \"on_success\": \"write_instagram\",\n      \"audit_limit\": 15,\n      \"include_audit_history\": true\n    }\n  }\n}"
+      },
+      "id": "start-write_x",
+      "name": "03 Start write_x",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [
+        1280,
+        0
+      ],
+      "notesInFlow": true,
+      "notes": "Adapt the LinkedIn content for X. Either a single punchy tweet (\u2264280 chars) or a thread (3\u20138 tweets). Lead with the sharpest insight. Hashtags: max 2\u20133 at the end of the last tweet only.\n"
+    },
+    {
+      "parameters": {
+        "method": "POST",
+        "url": "http://nexus-bridge-1:8091/api/v1/n8n/runs/update",
+        "authentication": "predefinedCredentialType",
+        "nodeCredentialType": "httpBearerAuth",
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "{\n  \"run_id\": \"={{$json.run?.run_id || $json.run_id}}\",\n  \"state\": \"write_x_completed\",\n  \"message\": \"Completed Nexus step write_x\",\n  \"data\": {\n    \"step\": {\n      \"id\": \"write_x\",\n      \"name\": \"Write X Post/Thread\",\n      \"description\": \"Adapt the LinkedIn content for X. Either a single punchy tweet (\\u2264280 chars) or a thread (3\\u20138 tweets). Lead with the sharpest insight. Hashtags: max 2\\u20133 at the end of the last tweet only.\\n\",\n      \"agent_type\": \"writer\",\n      \"context_policy\": \"standard\",\n      \"tools\": [\n        \"vcs:read_comments\",\n        \"vcs:add_comment\"\n      ],\n      \"inputs\": [\n        {\n          \"research_brief\": \"string\"\n        },\n        {\n          \"linkedin_post\": \"string\"\n        }\n      ],\n      \"outputs\": [\n        {\n          \"x_post\": \"string\"\n        },\n        {\n          \"x_is_thread\": \"boolean\"\n        }\n      ],\n      \"on_success\": \"write_instagram\",\n      \"audit_limit\": 15,\n      \"include_audit_history\": true\n    }\n  }\n}"
+      },
+      "id": "complete-write_x",
+      "name": "Complete write_x",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [
+        1500,
+        0
+      ],
+      "notesInFlow": true,
+      "notes": "Replace this state transition with a concrete agent/tool call when available."
+    },
+    {
+      "parameters": {
+        "method": "POST",
+        "url": "http://nexus-bridge-1:8091/api/v1/n8n/runs/update",
+        "authentication": "predefinedCredentialType",
+        "nodeCredentialType": "httpBearerAuth",
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "{\n  \"run_id\": \"={{$json.run?.run_id || $json.run_id}}\",\n  \"state\": \"write_instagram\",\n  \"message\": \"Starting Nexus step write_instagram\",\n  \"data\": {\n    \"step\": {\n      \"id\": \"write_instagram\",\n      \"index\": 4,\n      \"name\": \"Write Instagram Caption\",\n      \"description\": \"Write an Instagram caption. Hook \\u2192 story/insight \\u2192 CTA \\u2192 hashtag block (10\\u201320). Max 2200 chars. Tone: authentic and visual-first. image_url must be set in the issue for the publish step.\\n\",\n      \"agent_type\": \"writer\",\n      \"context_policy\": \"standard\",\n      \"tools\": [\n        \"vcs:read_comments\",\n        \"vcs:add_comment\"\n      ],\n      \"inputs\": [\n        {\n          \"research_brief\": \"string\"\n        },\n        {\n          \"visual_concept\": \"string\"\n        },\n        {\n          \"image_url\": \"string\"\n        }\n      ],\n      \"outputs\": [\n        {\n          \"instagram_post\": \"string\"\n        }\n      ],\n      \"on_success\": \"review\",\n      \"audit_limit\": 15,\n      \"include_audit_history\": true\n    }\n  }\n}"
+      },
+      "id": "start-write_instagram",
+      "name": "04 Start write_instagram",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [
+        1640,
+        120
+      ],
+      "notesInFlow": true,
+      "notes": "Write an Instagram caption. Hook \u2192 story/insight \u2192 CTA \u2192 hashtag block (10\u201320). Max 2200 chars. Tone: authentic and visual-first. image_url must be set in the issue for the publish step.\n"
+    },
+    {
+      "parameters": {
+        "method": "POST",
+        "url": "http://nexus-bridge-1:8091/api/v1/n8n/runs/update",
+        "authentication": "predefinedCredentialType",
+        "nodeCredentialType": "httpBearerAuth",
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "{\n  \"run_id\": \"={{$json.run?.run_id || $json.run_id}}\",\n  \"state\": \"write_instagram_completed\",\n  \"message\": \"Completed Nexus step write_instagram\",\n  \"data\": {\n    \"step\": {\n      \"id\": \"write_instagram\",\n      \"name\": \"Write Instagram Caption\",\n      \"description\": \"Write an Instagram caption. Hook \\u2192 story/insight \\u2192 CTA \\u2192 hashtag block (10\\u201320). Max 2200 chars. Tone: authentic and visual-first. image_url must be set in the issue for the publish step.\\n\",\n      \"agent_type\": \"writer\",\n      \"context_policy\": \"standard\",\n      \"tools\": [\n        \"vcs:read_comments\",\n        \"vcs:add_comment\"\n      ],\n      \"inputs\": [\n        {\n          \"research_brief\": \"string\"\n        },\n        {\n          \"visual_concept\": \"string\"\n        },\n        {\n          \"image_url\": \"string\"\n        }\n      ],\n      \"outputs\": [\n        {\n          \"instagram_post\": \"string\"\n        }\n      ],\n      \"on_success\": \"review\",\n      \"audit_limit\": 15,\n      \"include_audit_history\": true\n    }\n  }\n}"
+      },
+      "id": "complete-write_instagram",
+      "name": "Complete write_instagram",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [
+        1860,
+        120
+      ],
+      "notesInFlow": true,
+      "notes": "Replace this state transition with a concrete agent/tool call when available."
+    },
+    {
+      "parameters": {
+        "method": "POST",
+        "url": "http://nexus-bridge-1:8091/api/v1/n8n/runs/update",
+        "authentication": "predefinedCredentialType",
+        "nodeCredentialType": "httpBearerAuth",
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "{\n  \"run_id\": \"={{$json.run?.run_id || $json.run_id}}\",\n  \"state\": \"review\",\n  \"message\": \"Starting Nexus step review\",\n  \"data\": {\n    \"step\": {\n      \"id\": \"review\",\n      \"index\": 5,\n      \"name\": \"Review All Three Posts\",\n      \"description\": \"Review all three posts together for: character limits, tone consistency, cross-platform coherence, hashtag counts, no unverified claims. Approve all or request specific changes per platform.\\n\",\n      \"agent_type\": \"reviewer\",\n      \"context_policy\": \"standard\",\n      \"tools\": [\n        \"vcs:read_comments\",\n        \"vcs:add_comment\"\n      ],\n      \"inputs\": [\n        {\n          \"linkedin_post\": \"string\"\n        },\n        {\n          \"x_post\": \"string\"\n        },\n        {\n          \"instagram_post\": \"string\"\n        }\n      ],\n      \"outputs\": [\n        {\n          \"review_status\": \"enum[approved|changes_requested]\"\n        },\n        {\n          \"review_notes\": \"string\"\n        },\n        {\n          \"platforms_approved\": \"list[string]\"\n        }\n      ],\n      \"on_success\": \"route_review\",\n      \"audit_limit\": 30,\n      \"include_audit_history\": true\n    }\n  }\n}"
+      },
+      "id": "start-review",
+      "name": "05 Start review",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [
+        2000,
+        0
+      ],
+      "notesInFlow": true,
+      "notes": "Review all three posts together for: character limits, tone consistency, cross-platform coherence, hashtag counts, no unverified claims. Approve all or request specific changes per platform.\n"
+    },
+    {
+      "parameters": {
+        "method": "POST",
+        "url": "http://nexus-bridge-1:8091/api/v1/n8n/runs/update",
+        "authentication": "predefinedCredentialType",
+        "nodeCredentialType": "httpBearerAuth",
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "{\n  \"run_id\": \"={{$json.run?.run_id || $json.run_id}}\",\n  \"state\": \"review_completed\",\n  \"message\": \"Completed Nexus step review\",\n  \"data\": {\n    \"step\": {\n      \"id\": \"review\",\n      \"name\": \"Review All Three Posts\",\n      \"description\": \"Review all three posts together for: character limits, tone consistency, cross-platform coherence, hashtag counts, no unverified claims. Approve all or request specific changes per platform.\\n\",\n      \"agent_type\": \"reviewer\",\n      \"context_policy\": \"standard\",\n      \"tools\": [\n        \"vcs:read_comments\",\n        \"vcs:add_comment\"\n      ],\n      \"inputs\": [\n        {\n          \"linkedin_post\": \"string\"\n        },\n        {\n          \"x_post\": \"string\"\n        },\n        {\n          \"instagram_post\": \"string\"\n        }\n      ],\n      \"outputs\": [\n        {\n          \"review_status\": \"enum[approved|changes_requested]\"\n        },\n        {\n          \"review_notes\": \"string\"\n        },\n        {\n          \"platforms_approved\": \"list[string]\"\n        }\n      ],\n      \"on_success\": \"route_review\",\n      \"audit_limit\": 30,\n      \"include_audit_history\": true\n    }\n  }\n}"
+      },
+      "id": "complete-review",
+      "name": "Complete review",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [
+        2220,
+        0
+      ],
+      "notesInFlow": true,
+      "notes": "Replace this state transition with a concrete agent/tool call when available."
+    },
+    {
+      "parameters": {
+        "method": "POST",
+        "url": "http://nexus-bridge-1:8091/api/v1/n8n/runs/update",
+        "authentication": "predefinedCredentialType",
+        "nodeCredentialType": "httpBearerAuth",
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "{\n  \"run_id\": \"={{$json.run?.run_id || $json.run_id}}\",\n  \"state\": \"route_review\",\n  \"message\": \"Starting Nexus step route_review\",\n  \"data\": {\n    \"step\": {\n      \"id\": \"route_review\",\n      \"index\": 6,\n      \"name\": \"Route After Review\",\n      \"agent_type\": \"router\",\n      \"context_policy\": \"minimal\",\n      \"routes\": [\n        {\n          \"when\": \"review_status == 'approved'\",\n          \"then\": \"publish_linkedin\"\n        },\n        {\n          \"when\": \"review_status == 'changes_requested'\",\n          \"then\": \"write_linkedin\"\n        },\n        {\n          \"default\": \"write_linkedin\"\n        }\n      ]\n    }\n  }\n}"
+      },
+      "id": "start-route_review",
+      "name": "06 Start route_review",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [
+        2360,
+        260
+      ]
+    },
+    {
+      "parameters": {
+        "jsCode": "const routes = [\n  {\n    \"when\": \"review_status == 'approved'\",\n    \"then\": \"publish_linkedin\"\n  },\n  {\n    \"when\": \"review_status == 'changes_requested'\",\n    \"then\": \"write_linkedin\"\n  },\n  {\n    \"default\": \"write_linkedin\"\n  }\n];\nconst state = $json;\n\nfunction toJsExpression(expr) {\n  return String(expr)\n    .replace(/\\band\\b/g, '&&')\n    .replace(/\\bor\\b/g, '||')\n    .replace(/\\bnot\\b/g, '!')\n    .replace(/\\bTrue\\b/g, 'true')\n    .replace(/\\bFalse\\b/g, 'false')\n    .replace(/\\bNone\\b/g, 'null');\n}\n\nfunction evaluate(expr) {\n  const keys = Object.keys(state);\n  const values = Object.values(state);\n  try {\n    return Boolean(Function(...keys, `return (${toJsExpression(expr)});`)(...values));\n  } catch (error) {\n    return false;\n  }\n}\n\nlet nextStep = null;\nfor (const route of routes) {\n  if (route.when && evaluate(route.when)) {\n    nextStep = route.then;\n    break;\n  }\n  if (!route.when && route.default && nextStep === null) {\n    nextStep = route.default;\n  }\n}\n\nreturn [{ json: { ...state, next_step: nextStep } }];\n"
+      },
+      "id": "route-route_review",
+      "name": "Route route_review",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [
+        2580,
+        260
+      ],
+      "notesInFlow": true,
+      "notes": "Evaluates Nexus route rules and writes next_step."
+    },
+    {
+      "parameters": {
+        "method": "POST",
+        "url": "http://nexus-bridge-1:8091/api/v1/n8n/runs/update",
+        "authentication": "predefinedCredentialType",
+        "nodeCredentialType": "httpBearerAuth",
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "{\n  \"run_id\": \"={{$json.run?.run_id || $json.run_id}}\",\n  \"state\": \"publish_linkedin\",\n  \"message\": \"Starting Nexus step publish_linkedin\",\n  \"data\": {\n    \"step\": {\n      \"id\": \"publish_linkedin\",\n      \"index\": 7,\n      \"name\": \"Publish to LinkedIn\",\n      \"description\": \"Run dry_run on LinkedIn post. If PASSED: publish. Post result as comment. Continue to X publish regardless of outcome (each platform publishes independently).\\n\",\n      \"agent_type\": \"publisher\",\n      \"context_policy\": \"standard\",\n      \"tools\": [\n        \"vcs:read_comments\",\n        \"vcs:add_comment\"\n      ],\n      \"inputs\": [\n        {\n          \"linkedin_post\": \"string\"\n        }\n      ],\n      \"outputs\": [\n        {\n          \"linkedin_publish_status\": \"enum[published|dry_run_only|failed]\"\n        },\n        {\n          \"linkedin_url\": \"string\"\n        }\n      ],\n      \"on_success\": \"publish_x\",\n      \"require_human_approval\": true\n    }\n  }\n}"
+      },
+      "id": "start-publish_linkedin",
+      "name": "07 Start publish_linkedin",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [
+        2720,
+        -180
+      ],
+      "notesInFlow": true,
+      "notes": "Run dry_run on LinkedIn post. If PASSED: publish. Post result as comment. Continue to X publish regardless of outcome (each platform publishes independently).\n"
+    },
+    {
+      "parameters": {
+        "method": "POST",
+        "url": "http://nexus-bridge-1:8091/api/v1/n8n/runs/update",
+        "authentication": "predefinedCredentialType",
+        "nodeCredentialType": "httpBearerAuth",
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "{\n  \"run_id\": \"={{$json.run?.run_id || $json.run_id}}\",\n  \"state\": \"publish_linkedin_awaiting_approval\",\n  \"message\": \"Human approval required before publish_linkedin\",\n  \"data\": {\n    \"step_id\": \"publish_linkedin\",\n    \"agent_type\": \"publisher\"\n  }\n}"
+      },
+      "id": "approval-publish_linkedin",
+      "name": "Approval Gate publish_linkedin",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [
+        2940,
+        -300
+      ],
+      "notesInFlow": true,
+      "notes": "Connect this node to an n8n approval/wait mechanism if the gate must pause."
+    },
+    {
+      "parameters": {
+        "method": "POST",
+        "url": "http://nexus-bridge-1:8091/api/v1/n8n/runs/update",
+        "authentication": "predefinedCredentialType",
+        "nodeCredentialType": "httpBearerAuth",
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "{\n  \"run_id\": \"={{$json.run?.run_id || $json.run_id}}\",\n  \"state\": \"publish_linkedin_completed\",\n  \"message\": \"Completed Nexus step publish_linkedin\",\n  \"data\": {\n    \"step\": {\n      \"id\": \"publish_linkedin\",\n      \"name\": \"Publish to LinkedIn\",\n      \"description\": \"Run dry_run on LinkedIn post. If PASSED: publish. Post result as comment. Continue to X publish regardless of outcome (each platform publishes independently).\\n\",\n      \"agent_type\": \"publisher\",\n      \"context_policy\": \"standard\",\n      \"tools\": [\n        \"vcs:read_comments\",\n        \"vcs:add_comment\"\n      ],\n      \"inputs\": [\n        {\n          \"linkedin_post\": \"string\"\n        }\n      ],\n      \"outputs\": [\n        {\n          \"linkedin_publish_status\": \"enum[published|dry_run_only|failed]\"\n        },\n        {\n          \"linkedin_url\": \"string\"\n        }\n      ],\n      \"on_success\": \"publish_x\",\n      \"require_human_approval\": true\n    }\n  }\n}"
+      },
+      "id": "complete-publish_linkedin",
+      "name": "Complete publish_linkedin",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [
+        2940,
+        -180
+      ],
+      "notesInFlow": true,
+      "notes": "Replace this state transition with a concrete agent/tool call when available."
+    },
+    {
+      "parameters": {
+        "method": "POST",
+        "url": "http://nexus-bridge-1:8091/api/v1/n8n/runs/update",
+        "authentication": "predefinedCredentialType",
+        "nodeCredentialType": "httpBearerAuth",
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "{\n  \"run_id\": \"={{$json.run?.run_id || $json.run_id}}\",\n  \"state\": \"publish_x\",\n  \"message\": \"Starting Nexus step publish_x\",\n  \"data\": {\n    \"step\": {\n      \"id\": \"publish_x\",\n      \"index\": 8,\n      \"name\": \"Publish to X\",\n      \"description\": \"Run dry_run on X post/thread. If PASSED: publish. Post result as comment. Continue to Instagram publish.\\n\",\n      \"agent_type\": \"publisher\",\n      \"context_policy\": \"standard\",\n      \"tools\": [\n        \"vcs:read_comments\",\n        \"vcs:add_comment\"\n      ],\n      \"inputs\": [\n        {\n          \"x_post\": \"string\"\n        },\n        {\n          \"x_is_thread\": \"boolean\"\n        }\n      ],\n      \"outputs\": [\n        {\n          \"x_publish_status\": \"enum[published|dry_run_only|failed]\"\n        },\n        {\n          \"x_url\": \"string\"\n        }\n      ],\n      \"on_success\": \"publish_instagram\",\n      \"require_human_approval\": true\n    }\n  }\n}"
+      },
+      "id": "start-publish_x",
+      "name": "08 Start publish_x",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [
+        3080,
+        -180
+      ],
+      "notesInFlow": true,
+      "notes": "Run dry_run on X post/thread. If PASSED: publish. Post result as comment. Continue to Instagram publish.\n"
+    },
+    {
+      "parameters": {
+        "method": "POST",
+        "url": "http://nexus-bridge-1:8091/api/v1/n8n/runs/update",
+        "authentication": "predefinedCredentialType",
+        "nodeCredentialType": "httpBearerAuth",
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "{\n  \"run_id\": \"={{$json.run?.run_id || $json.run_id}}\",\n  \"state\": \"publish_x_awaiting_approval\",\n  \"message\": \"Human approval required before publish_x\",\n  \"data\": {\n    \"step_id\": \"publish_x\",\n    \"agent_type\": \"publisher\"\n  }\n}"
+      },
+      "id": "approval-publish_x",
+      "name": "Approval Gate publish_x",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [
+        3300,
+        -300
+      ],
+      "notesInFlow": true,
+      "notes": "Connect this node to an n8n approval/wait mechanism if the gate must pause."
+    },
+    {
+      "parameters": {
+        "method": "POST",
+        "url": "http://nexus-bridge-1:8091/api/v1/n8n/runs/update",
+        "authentication": "predefinedCredentialType",
+        "nodeCredentialType": "httpBearerAuth",
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "{\n  \"run_id\": \"={{$json.run?.run_id || $json.run_id}}\",\n  \"state\": \"publish_x_completed\",\n  \"message\": \"Completed Nexus step publish_x\",\n  \"data\": {\n    \"step\": {\n      \"id\": \"publish_x\",\n      \"name\": \"Publish to X\",\n      \"description\": \"Run dry_run on X post/thread. If PASSED: publish. Post result as comment. Continue to Instagram publish.\\n\",\n      \"agent_type\": \"publisher\",\n      \"context_policy\": \"standard\",\n      \"tools\": [\n        \"vcs:read_comments\",\n        \"vcs:add_comment\"\n      ],\n      \"inputs\": [\n        {\n          \"x_post\": \"string\"\n        },\n        {\n          \"x_is_thread\": \"boolean\"\n        }\n      ],\n      \"outputs\": [\n        {\n          \"x_publish_status\": \"enum[published|dry_run_only|failed]\"\n        },\n        {\n          \"x_url\": \"string\"\n        }\n      ],\n      \"on_success\": \"publish_instagram\",\n      \"require_human_approval\": true\n    }\n  }\n}"
+      },
+      "id": "complete-publish_x",
+      "name": "Complete publish_x",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [
+        3300,
+        -180
+      ],
+      "notesInFlow": true,
+      "notes": "Replace this state transition with a concrete agent/tool call when available."
+    },
+    {
+      "parameters": {
+        "method": "POST",
+        "url": "http://nexus-bridge-1:8091/api/v1/n8n/runs/update",
+        "authentication": "predefinedCredentialType",
+        "nodeCredentialType": "httpBearerAuth",
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "{\n  \"run_id\": \"={{$json.run?.run_id || $json.run_id}}\",\n  \"state\": \"publish_instagram\",\n  \"message\": \"Starting Nexus step publish_instagram\",\n  \"data\": {\n    \"step\": {\n      \"id\": \"publish_instagram\",\n      \"index\": 9,\n      \"name\": \"Publish to Instagram\",\n      \"description\": \"Run dry_run on Instagram caption + image. If PASSED: publish via Meta adapter. Post result as comment.\\n\",\n      \"agent_type\": \"publisher\",\n      \"context_policy\": \"standard\",\n      \"tools\": [\n        \"vcs:read_comments\",\n        \"vcs:add_comment\"\n      ],\n      \"inputs\": [\n        {\n          \"instagram_post\": \"string\"\n        },\n        {\n          \"image_url\": \"string\"\n        }\n      ],\n      \"outputs\": [\n        {\n          \"instagram_publish_status\": \"enum[published|dry_run_only|failed]\"\n        },\n        {\n          \"instagram_url\": \"string\"\n        }\n      ],\n      \"on_success\": \"close_loop\",\n      \"require_human_approval\": true\n    }\n  }\n}"
+      },
+      "id": "start-publish_instagram",
+      "name": "09 Start publish_instagram",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [
+        3440,
+        -180
+      ],
+      "notesInFlow": true,
+      "notes": "Run dry_run on Instagram caption + image. If PASSED: publish via Meta adapter. Post result as comment.\n"
+    },
+    {
+      "parameters": {
+        "method": "POST",
+        "url": "http://nexus-bridge-1:8091/api/v1/n8n/runs/update",
+        "authentication": "predefinedCredentialType",
+        "nodeCredentialType": "httpBearerAuth",
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "{\n  \"run_id\": \"={{$json.run?.run_id || $json.run_id}}\",\n  \"state\": \"publish_instagram_awaiting_approval\",\n  \"message\": \"Human approval required before publish_instagram\",\n  \"data\": {\n    \"step_id\": \"publish_instagram\",\n    \"agent_type\": \"publisher\"\n  }\n}"
+      },
+      "id": "approval-publish_instagram",
+      "name": "Approval Gate publish_instagram",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [
+        3660,
+        -300
+      ],
+      "notesInFlow": true,
+      "notes": "Connect this node to an n8n approval/wait mechanism if the gate must pause."
+    },
+    {
+      "parameters": {
+        "method": "POST",
+        "url": "http://nexus-bridge-1:8091/api/v1/n8n/runs/update",
+        "authentication": "predefinedCredentialType",
+        "nodeCredentialType": "httpBearerAuth",
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "{\n  \"run_id\": \"={{$json.run?.run_id || $json.run_id}}\",\n  \"state\": \"publish_instagram_completed\",\n  \"message\": \"Completed Nexus step publish_instagram\",\n  \"data\": {\n    \"step\": {\n      \"id\": \"publish_instagram\",\n      \"name\": \"Publish to Instagram\",\n      \"description\": \"Run dry_run on Instagram caption + image. If PASSED: publish via Meta adapter. Post result as comment.\\n\",\n      \"agent_type\": \"publisher\",\n      \"context_policy\": \"standard\",\n      \"tools\": [\n        \"vcs:read_comments\",\n        \"vcs:add_comment\"\n      ],\n      \"inputs\": [\n        {\n          \"instagram_post\": \"string\"\n        },\n        {\n          \"image_url\": \"string\"\n        }\n      ],\n      \"outputs\": [\n        {\n          \"instagram_publish_status\": \"enum[published|dry_run_only|failed]\"\n        },\n        {\n          \"instagram_url\": \"string\"\n        }\n      ],\n      \"on_success\": \"close_loop\",\n      \"require_human_approval\": true\n    }\n  }\n}"
+      },
+      "id": "complete-publish_instagram",
+      "name": "Complete publish_instagram",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [
+        3660,
+        -180
+      ],
+      "notesInFlow": true,
+      "notes": "Replace this state transition with a concrete agent/tool call when available."
+    },
+    {
+      "parameters": {
+        "method": "POST",
+        "url": "http://nexus-bridge-1:8091/api/v1/n8n/runs/update",
+        "authentication": "predefinedCredentialType",
+        "nodeCredentialType": "httpBearerAuth",
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "{\n  \"run_id\": \"={{$json.run?.run_id || $json.run_id}}\",\n  \"state\": \"close_loop\",\n  \"message\": \"Starting Nexus step close_loop\",\n  \"data\": {\n    \"step\": {\n      \"id\": \"close_loop\",\n      \"index\": 10,\n      \"name\": \"Document & Close\",\n      \"description\": \"Summarise all three publish outcomes. Add label social:published. Close the issue.\\n\",\n      \"agent_type\": \"writer\",\n      \"context_policy\": \"minimal\",\n      \"tools\": [\n        \"vcs:add_comment\",\n        \"vcs:add_label\",\n        \"vcs:close_issue\"\n      ],\n      \"inputs\": [\n        {\n          \"linkedin_url\": \"string\"\n        },\n        {\n          \"x_url\": \"string\"\n        },\n        {\n          \"instagram_url\": \"string\"\n        }\n      ],\n      \"outputs\": [\n        {\n          \"summary\": \"string\"\n        }\n      ],\n      \"final_step\": true\n    }\n  }\n}"
+      },
+      "id": "start-close_loop",
+      "name": "10 Start close_loop",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [
+        3800,
+        120
+      ],
+      "notesInFlow": true,
+      "notes": "Summarise all three publish outcomes. Add label social:published. Close the issue.\n"
+    },
+    {
+      "parameters": {
+        "method": "POST",
+        "url": "http://nexus-bridge-1:8091/api/v1/n8n/runs/update",
+        "authentication": "predefinedCredentialType",
+        "nodeCredentialType": "httpBearerAuth",
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "{\n  \"run_id\": \"={{$json.run?.run_id || $json.run_id}}\",\n  \"state\": \"close_loop_completed\",\n  \"message\": \"Completed Nexus step close_loop\",\n  \"data\": {\n    \"step\": {\n      \"id\": \"close_loop\",\n      \"name\": \"Document & Close\",\n      \"description\": \"Summarise all three publish outcomes. Add label social:published. Close the issue.\\n\",\n      \"agent_type\": \"writer\",\n      \"context_policy\": \"minimal\",\n      \"tools\": [\n        \"vcs:add_comment\",\n        \"vcs:add_label\",\n        \"vcs:close_issue\"\n      ],\n      \"inputs\": [\n        {\n          \"linkedin_url\": \"string\"\n        },\n        {\n          \"x_url\": \"string\"\n        },\n        {\n          \"instagram_url\": \"string\"\n        }\n      ],\n      \"outputs\": [\n        {\n          \"summary\": \"string\"\n        }\n      ],\n      \"final_step\": true\n    }\n  }\n}"
+      },
+      "id": "complete-close_loop",
+      "name": "Complete close_loop",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [
+        4020,
+        120
+      ],
+      "notesInFlow": true,
+      "notes": "Replace this state transition with a concrete agent/tool call when available."
+    },
+    {
+      "parameters": {
+        "mode": "rules",
+        "rules": {
+          "values": [
+            {
+              "conditions": {
+                "conditions": [
+                  {
+                    "leftValue": "={{$json.next_step}}",
+                    "rightValue": "publish_linkedin",
+                    "operator": {
+                      "type": "string",
+                      "operation": "equals"
+                    }
+                  }
+                ],
+                "combinator": "and"
+              }
+            },
+            {
+              "conditions": {
+                "conditions": [
+                  {
+                    "leftValue": "={{$json.next_step}}",
+                    "rightValue": "write_linkedin",
+                    "operator": {
+                      "type": "string",
+                      "operation": "equals"
+                    }
+                  }
+                ],
+                "combinator": "and"
+              }
+            }
+          ]
+        },
+        "options": {}
+      },
+      "id": "switch-switch-route_review",
+      "name": "Switch route_review",
+      "type": "n8n-nodes-base.switch",
+      "typeVersion": 3,
+      "position": [
+        2800,
+        260
+      ],
+      "notesInFlow": true,
+      "notes": "Routes to the Nexus step selected by the preceding Code node."
+    }
+  ],
+  "connections": {
+    "01 Start research": {
+      "main": [
+        [
+          {
+            "node": "Complete research",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "02 Start write_linkedin": {
+      "main": [
+        [
+          {
+            "node": "Complete write_linkedin",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "03 Start write_x": {
+      "main": [
+        [
+          {
+            "node": "Complete write_x",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "04 Start write_instagram": {
+      "main": [
+        [
+          {
+            "node": "Complete write_instagram",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "05 Start review": {
+      "main": [
+        [
+          {
+            "node": "Complete review",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "06 Start route_review": {
+      "main": [
+        [
+          {
+            "node": "Route route_review",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "07 Start publish_linkedin": {
+      "main": [
+        [
+          {
+            "node": "Approval Gate publish_linkedin",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Approval Gate publish_linkedin": {
+      "main": [
+        [
+          {
+            "node": "Complete publish_linkedin",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "08 Start publish_x": {
+      "main": [
+        [
+          {
+            "node": "Approval Gate publish_x",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Approval Gate publish_x": {
+      "main": [
+        [
+          {
+            "node": "Complete publish_x",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "09 Start publish_instagram": {
+      "main": [
+        [
+          {
+            "node": "Approval Gate publish_instagram",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Approval Gate publish_instagram": {
+      "main": [
+        [
+          {
+            "node": "Complete publish_instagram",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "10 Start close_loop": {
+      "main": [
+        [
+          {
+            "node": "Complete close_loop",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Create Nexus Run": {
+      "main": [
+        [
+          {
+            "node": "01 Start research",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Manual Trigger": {
+      "main": [
+        [
+          {
+            "node": "Create Nexus Run",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Complete research": {
+      "main": [
+        [
+          {
+            "node": "02 Start write_linkedin",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Complete write_linkedin": {
+      "main": [
+        [
+          {
+            "node": "03 Start write_x",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Complete write_x": {
+      "main": [
+        [
+          {
+            "node": "04 Start write_instagram",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Complete write_instagram": {
+      "main": [
+        [
+          {
+            "node": "05 Start review",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Complete review": {
+      "main": [
+        [
+          {
+            "node": "06 Start route_review",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Route route_review": {
+      "main": [
+        [
+          {
+            "node": "Switch route_review",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Switch route_review": {
+      "main": [
+        [
+          {
+            "node": "07 Start publish_linkedin",
+            "type": "main",
+            "index": 0
+          }
+        ],
+        [
+          {
+            "node": "02 Start write_linkedin",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Complete publish_linkedin": {
+      "main": [
+        [
+          {
+            "node": "08 Start publish_x",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Complete publish_x": {
+      "main": [
+        [
+          {
+            "node": "09 Start publish_instagram",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Complete publish_instagram": {
+      "main": [
+        [
+          {
+            "node": "10 Start close_loop",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    }
+  },
+  "settings": {
+    "executionOrder": "v1"
+  },
+  "staticData": null,
+  "tags": [
+    "nexus-arc",
+    "generated"
+  ],
+  "meta": {
+    "nexusArc": {
+      "source": "examples/workflows/multi_social_post_workflow.yaml",
+      "workflowType": "social-post",
+      "converter": "nexus.translators.to_n8n"
+    }
+  }
+}

--- a/examples/workflows/n8n/social_media_marketing_workflow.json
+++ b/examples/workflows/n8n/social_media_marketing_workflow.json
@@ -1,0 +1,1046 @@
+{
+  "name": "Social Media Marketing Workflow",
+  "nodes": [
+    {
+      "parameters": {},
+      "id": "manual-trigger",
+      "name": "Manual Trigger",
+      "type": "n8n-nodes-base.manualTrigger",
+      "typeVersion": 1,
+      "position": [
+        0,
+        0
+      ]
+    },
+    {
+      "parameters": {
+        "method": "POST",
+        "url": "http://nexus-bridge-1:8091/api/v1/n8n/runs",
+        "authentication": "predefinedCredentialType",
+        "nodeCredentialType": "httpBearerAuth",
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "{\n  \"task\": \"={{$json.task || $json.title || 'Run Nexus workflow'}}\",\n  \"project_key\": \"={{$json.project_key || $json.project || 'nexus'}}\",\n  \"issue_number\": \"={{$json.issue_number || $json.issue || ''}}\",\n  \"requester\": {\n    \"source\": \"n8n\",\n    \"workflow\": \"Social Media Marketing Workflow\"\n  },\n  \"metadata\": {\n    \"nexus_workflow\": {\n      \"name\": \"Social Media Marketing Workflow\",\n      \"description\": \"Dry-run-first campaign content creation, approval, and multi-platform publishing workflow.\",\n      \"version\": \"1.0.0\"\n    },\n    \"workflow_type\": \"social-marketing\",\n    \"source\": \"examples/workflows/social_media_marketing_workflow.yaml\"\n  }\n}"
+      },
+      "id": "create-nexus-run",
+      "name": "Create Nexus Run",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [
+        260,
+        0
+      ],
+      "notesInFlow": true,
+      "notes": "Creates the durable Nexus run that n8n will advance."
+    },
+    {
+      "parameters": {
+        "method": "POST",
+        "url": "http://nexus-bridge-1:8091/api/v1/n8n/runs/update",
+        "authentication": "predefinedCredentialType",
+        "nodeCredentialType": "httpBearerAuth",
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "{\n  \"run_id\": \"={{$json.run?.run_id || $json.run_id}}\",\n  \"state\": \"triage\",\n  \"message\": \"Starting Nexus step triage\",\n  \"data\": {\n    \"step\": {\n      \"id\": \"triage\",\n      \"index\": 1,\n      \"name\": \"Triage & Classification\",\n      \"description\": \"Classify campaign request, priority, and execution path\",\n      \"agent_type\": \"triage\",\n      \"context_policy\": \"minimal\",\n      \"tools\": [\n        \"vcs:read_issue\",\n        \"vcs:add_comment\",\n        \"vcs:add_label\"\n      ],\n      \"inputs\": [\n        {\n          \"issue_url\": \"string\"\n        }\n      ],\n      \"outputs\": [\n        {\n          \"classification\": \"enum[marketing|other]\"\n        },\n        {\n          \"priority\": \"enum[p0-critical|p1-high|p2-medium|p3-low]\"\n        },\n        {\n          \"needs_design\": \"boolean\"\n        }\n      ],\n      \"on_success\": \"route_triage\"\n    }\n  }\n}"
+      },
+      "id": "start-triage",
+      "name": "01 Start triage",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [
+        560,
+        0
+      ],
+      "notesInFlow": true,
+      "notes": "Classify campaign request, priority, and execution path"
+    },
+    {
+      "parameters": {
+        "method": "POST",
+        "url": "http://nexus-bridge-1:8091/api/v1/n8n/runs/update",
+        "authentication": "predefinedCredentialType",
+        "nodeCredentialType": "httpBearerAuth",
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "{\n  \"run_id\": \"={{$json.run?.run_id || $json.run_id}}\",\n  \"state\": \"triage_completed\",\n  \"message\": \"Completed Nexus step triage\",\n  \"data\": {\n    \"step\": {\n      \"id\": \"triage\",\n      \"name\": \"Triage & Classification\",\n      \"description\": \"Classify campaign request, priority, and execution path\",\n      \"agent_type\": \"triage\",\n      \"context_policy\": \"minimal\",\n      \"tools\": [\n        \"vcs:read_issue\",\n        \"vcs:add_comment\",\n        \"vcs:add_label\"\n      ],\n      \"inputs\": [\n        {\n          \"issue_url\": \"string\"\n        }\n      ],\n      \"outputs\": [\n        {\n          \"classification\": \"enum[marketing|other]\"\n        },\n        {\n          \"priority\": \"enum[p0-critical|p1-high|p2-medium|p3-low]\"\n        },\n        {\n          \"needs_design\": \"boolean\"\n        }\n      ],\n      \"on_success\": \"route_triage\"\n    }\n  }\n}"
+      },
+      "id": "complete-triage",
+      "name": "Complete triage",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [
+        780,
+        0
+      ],
+      "notesInFlow": true,
+      "notes": "Replace this state transition with a concrete agent/tool call when available."
+    },
+    {
+      "parameters": {
+        "method": "POST",
+        "url": "http://nexus-bridge-1:8091/api/v1/n8n/runs/update",
+        "authentication": "predefinedCredentialType",
+        "nodeCredentialType": "httpBearerAuth",
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "{\n  \"run_id\": \"={{$json.run?.run_id || $json.run_id}}\",\n  \"state\": \"route_triage\",\n  \"message\": \"Starting Nexus step route_triage\",\n  \"data\": {\n    \"step\": {\n      \"id\": \"route_triage\",\n      \"index\": 2,\n      \"name\": \"Route After Triage\",\n      \"agent_type\": \"router\",\n      \"context_policy\": \"minimal\",\n      \"routes\": [\n        {\n          \"when\": \"classification == 'marketing' and needs_design == true\",\n          \"then\": \"design\"\n        },\n        {\n          \"when\": \"classification == 'marketing'\",\n          \"then\": \"develop\"\n        },\n        {\n          \"default\": \"close_rejected\"\n        }\n      ]\n    }\n  }\n}"
+      },
+      "id": "start-route_triage",
+      "name": "02 Start route_triage",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [
+        920,
+        260
+      ]
+    },
+    {
+      "parameters": {
+        "jsCode": "const routes = [\n  {\n    \"when\": \"classification == 'marketing' and needs_design == true\",\n    \"then\": \"design\"\n  },\n  {\n    \"when\": \"classification == 'marketing'\",\n    \"then\": \"develop\"\n  },\n  {\n    \"default\": \"close_rejected\"\n  }\n];\nconst state = $json;\n\nfunction toJsExpression(expr) {\n  return String(expr)\n    .replace(/\\band\\b/g, '&&')\n    .replace(/\\bor\\b/g, '||')\n    .replace(/\\bnot\\b/g, '!')\n    .replace(/\\bTrue\\b/g, 'true')\n    .replace(/\\bFalse\\b/g, 'false')\n    .replace(/\\bNone\\b/g, 'null');\n}\n\nfunction evaluate(expr) {\n  const keys = Object.keys(state);\n  const values = Object.values(state);\n  try {\n    return Boolean(Function(...keys, `return (${toJsExpression(expr)});`)(...values));\n  } catch (error) {\n    return false;\n  }\n}\n\nlet nextStep = null;\nfor (const route of routes) {\n  if (route.when && evaluate(route.when)) {\n    nextStep = route.then;\n    break;\n  }\n  if (!route.when && route.default && nextStep === null) {\n    nextStep = route.default;\n  }\n}\n\nreturn [{ json: { ...state, next_step: nextStep } }];\n"
+      },
+      "id": "route-route_triage",
+      "name": "Route route_triage",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [
+        1140,
+        260
+      ],
+      "notesInFlow": true,
+      "notes": "Evaluates Nexus route rules and writes next_step."
+    },
+    {
+      "parameters": {
+        "method": "POST",
+        "url": "http://nexus-bridge-1:8091/api/v1/n8n/runs/update",
+        "authentication": "predefinedCredentialType",
+        "nodeCredentialType": "httpBearerAuth",
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "{\n  \"run_id\": \"={{$json.run?.run_id || $json.run_id}}\",\n  \"state\": \"design\",\n  \"message\": \"Starting Nexus step design\",\n  \"data\": {\n    \"step\": {\n      \"id\": \"design\",\n      \"index\": 3,\n      \"name\": \"Architecture & Design\",\n      \"description\": \"Create a design proposal covering campaign contracts, channels, and rollout constraints\",\n      \"agent_type\": \"designer\",\n      \"context_policy\": \"standard\",\n      \"tools\": [\n        \"vcs:create_branch\",\n        \"vcs:create_file\",\n        \"vcs:create_pr\"\n      ],\n      \"inputs\": [\n        {\n          \"issue_url\": \"string\"\n        },\n        {\n          \"classification\": \"string\"\n        }\n      ],\n      \"outputs\": [\n        {\n          \"campaign_architecture\": \"string\"\n        },\n        {\n          \"platform_plan\": \"list[string]\"\n        },\n        {\n          \"estimated_effort\": \"string\"\n        }\n      ],\n      \"on_success\": \"develop\",\n      \"audit_limit\": 50,\n      \"include_audit_history\": true\n    }\n  }\n}"
+      },
+      "id": "start-design",
+      "name": "03 Start design",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [
+        1280,
+        0
+      ],
+      "notesInFlow": true,
+      "notes": "Create a design proposal covering campaign contracts, channels, and rollout constraints"
+    },
+    {
+      "parameters": {
+        "method": "POST",
+        "url": "http://nexus-bridge-1:8091/api/v1/n8n/runs/update",
+        "authentication": "predefinedCredentialType",
+        "nodeCredentialType": "httpBearerAuth",
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "{\n  \"run_id\": \"={{$json.run?.run_id || $json.run_id}}\",\n  \"state\": \"design_completed\",\n  \"message\": \"Completed Nexus step design\",\n  \"data\": {\n    \"step\": {\n      \"id\": \"design\",\n      \"name\": \"Architecture & Design\",\n      \"description\": \"Create a design proposal covering campaign contracts, channels, and rollout constraints\",\n      \"agent_type\": \"designer\",\n      \"context_policy\": \"standard\",\n      \"tools\": [\n        \"vcs:create_branch\",\n        \"vcs:create_file\",\n        \"vcs:create_pr\"\n      ],\n      \"inputs\": [\n        {\n          \"issue_url\": \"string\"\n        },\n        {\n          \"classification\": \"string\"\n        }\n      ],\n      \"outputs\": [\n        {\n          \"campaign_architecture\": \"string\"\n        },\n        {\n          \"platform_plan\": \"list[string]\"\n        },\n        {\n          \"estimated_effort\": \"string\"\n        }\n      ],\n      \"on_success\": \"develop\",\n      \"audit_limit\": 50,\n      \"include_audit_history\": true\n    }\n  }\n}"
+      },
+      "id": "complete-design",
+      "name": "Complete design",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [
+        1500,
+        0
+      ],
+      "notesInFlow": true,
+      "notes": "Replace this state transition with a concrete agent/tool call when available."
+    },
+    {
+      "parameters": {
+        "method": "POST",
+        "url": "http://nexus-bridge-1:8091/api/v1/n8n/runs/update",
+        "authentication": "predefinedCredentialType",
+        "nodeCredentialType": "httpBearerAuth",
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "{\n  \"run_id\": \"={{$json.run?.run_id || $json.run_id}}\",\n  \"state\": \"develop\",\n  \"message\": \"Starting Nexus step develop\",\n  \"data\": {\n    \"step\": {\n      \"id\": \"develop\",\n      \"index\": 4,\n      \"name\": \"Implementation\",\n      \"description\": \"Implement the workflow definition, campaign payloads, and dry-run publish contract\",\n      \"agent_type\": \"developer\",\n      \"context_policy\": \"deep\",\n      \"tools\": [\n        \"vcs:read_issue\",\n        \"vcs:read_comments\",\n        \"vcs:create_branch\",\n        \"vcs:create_file\",\n        \"vcs:edit_file\",\n        \"vcs:commit_changes\"\n      ],\n      \"inputs\": [\n        {\n          \"issue_url\": \"string\"\n        },\n        {\n          \"platform_plan\": \"list[string]\"\n        }\n      ],\n      \"outputs\": [\n        {\n          \"content_bundle\": \"list[string]\"\n        },\n        {\n          \"implementation_notes\": \"string\"\n        },\n        {\n          \"test_coverage\": \"string\"\n        }\n      ],\n      \"on_success\": \"review\",\n      \"audit_limit\": 50,\n      \"include_audit_history\": true\n    }\n  }\n}"
+      },
+      "id": "start-develop",
+      "name": "04 Start develop",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [
+        1640,
+        120
+      ],
+      "notesInFlow": true,
+      "notes": "Implement the workflow definition, campaign payloads, and dry-run publish contract"
+    },
+    {
+      "parameters": {
+        "method": "POST",
+        "url": "http://nexus-bridge-1:8091/api/v1/n8n/coding/execute",
+        "authentication": "predefinedCredentialType",
+        "nodeCredentialType": "httpBearerAuth",
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "{\n  \"run_id\": \"={{$json.run?.run_id || $json.run_id}}\",\n  \"task\": \"={{$json.task || $json.run?.task || \\\"Implement the workflow definition, campaign payloads, and dry-run publish contract\\\"}}\",\n  \"project_key\": \"={{$json.project_key || $json.run?.project_key || 'nexus'}}\",\n  \"worker\": \"opencode\",\n  \"agent\": \"build\",\n  \"base_branch\": \"develop\",\n  \"metadata\": {\n    \"step\": {\n      \"id\": \"develop\",\n      \"name\": \"Implementation\",\n      \"description\": \"Implement the workflow definition, campaign payloads, and dry-run publish contract\",\n      \"agent_type\": \"developer\",\n      \"context_policy\": \"deep\",\n      \"tools\": [\n        \"vcs:read_issue\",\n        \"vcs:read_comments\",\n        \"vcs:create_branch\",\n        \"vcs:create_file\",\n        \"vcs:edit_file\",\n        \"vcs:commit_changes\"\n      ],\n      \"inputs\": [\n        {\n          \"issue_url\": \"string\"\n        },\n        {\n          \"platform_plan\": \"list[string]\"\n        }\n      ],\n      \"outputs\": [\n        {\n          \"content_bundle\": \"list[string]\"\n        },\n        {\n          \"implementation_notes\": \"string\"\n        },\n        {\n          \"test_coverage\": \"string\"\n        }\n      ],\n      \"on_success\": \"review\",\n      \"audit_limit\": 50,\n      \"include_audit_history\": true\n    }\n  }\n}"
+      },
+      "id": "execute-opencode-develop",
+      "name": "Execute OpenCode develop",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [
+        1860,
+        120
+      ],
+      "notesInFlow": true,
+      "notes": "Guarded Nexus endpoint: allowlist, isolated worktree, no push/merge/PR."
+    },
+    {
+      "parameters": {
+        "method": "POST",
+        "url": "http://nexus-bridge-1:8091/api/v1/n8n/runs/update",
+        "authentication": "predefinedCredentialType",
+        "nodeCredentialType": "httpBearerAuth",
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "{\n  \"run_id\": \"={{$json.run?.run_id || $json.run_id}}\",\n  \"state\": \"review\",\n  \"message\": \"Starting Nexus step review\",\n  \"data\": {\n    \"step\": {\n      \"id\": \"review\",\n      \"index\": 5,\n      \"name\": \"Code Review\",\n      \"description\": \"Review implementation for correctness, quality, and standards; approve only after full regression (or equivalent full CI suite) passes\",\n      \"agent_type\": \"reviewer\",\n      \"context_policy\": \"standard\",\n      \"tools\": [\n        \"vcs:review_pr\",\n        \"vcs:request_changes\",\n        \"vcs:approve_pr\"\n      ],\n      \"inputs\": [\n        {\n          \"content_bundle\": \"list[string]\"\n        }\n      ],\n      \"outputs\": [\n        {\n          \"review_status\": \"enum[approved|changes_requested|rejected]\"\n        },\n        {\n          \"review_comments\": \"list[string]\"\n        }\n      ],\n      \"on_success\": \"route_review\"\n    }\n  }\n}"
+      },
+      "id": "start-review",
+      "name": "05 Start review",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [
+        2000,
+        0
+      ],
+      "notesInFlow": true,
+      "notes": "Review implementation for correctness, quality, and standards; approve only after full regression (or equivalent full CI suite) passes"
+    },
+    {
+      "parameters": {
+        "method": "POST",
+        "url": "http://nexus-bridge-1:8091/api/v1/n8n/runs/update",
+        "authentication": "predefinedCredentialType",
+        "nodeCredentialType": "httpBearerAuth",
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "{\n  \"run_id\": \"={{$json.run?.run_id || $json.run_id}}\",\n  \"state\": \"review_completed\",\n  \"message\": \"Completed Nexus step review\",\n  \"data\": {\n    \"step\": {\n      \"id\": \"review\",\n      \"name\": \"Code Review\",\n      \"description\": \"Review implementation for correctness, quality, and standards; approve only after full regression (or equivalent full CI suite) passes\",\n      \"agent_type\": \"reviewer\",\n      \"context_policy\": \"standard\",\n      \"tools\": [\n        \"vcs:review_pr\",\n        \"vcs:request_changes\",\n        \"vcs:approve_pr\"\n      ],\n      \"inputs\": [\n        {\n          \"content_bundle\": \"list[string]\"\n        }\n      ],\n      \"outputs\": [\n        {\n          \"review_status\": \"enum[approved|changes_requested|rejected]\"\n        },\n        {\n          \"review_comments\": \"list[string]\"\n        }\n      ],\n      \"on_success\": \"route_review\"\n    }\n  }\n}"
+      },
+      "id": "complete-review",
+      "name": "Complete review",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [
+        2220,
+        0
+      ],
+      "notesInFlow": true,
+      "notes": "Replace this state transition with a concrete agent/tool call when available."
+    },
+    {
+      "parameters": {
+        "method": "POST",
+        "url": "http://nexus-bridge-1:8091/api/v1/n8n/runs/update",
+        "authentication": "predefinedCredentialType",
+        "nodeCredentialType": "httpBearerAuth",
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "{\n  \"run_id\": \"={{$json.run?.run_id || $json.run_id}}\",\n  \"state\": \"route_review\",\n  \"message\": \"Starting Nexus step route_review\",\n  \"data\": {\n    \"step\": {\n      \"id\": \"route_review\",\n      \"index\": 6,\n      \"name\": \"Route After Review\",\n      \"agent_type\": \"router\",\n      \"context_policy\": \"minimal\",\n      \"routes\": [\n        {\n          \"when\": \"review_status == 'approved'\",\n          \"then\": \"compliance\"\n        },\n        {\n          \"when\": \"review_status == 'changes_requested'\",\n          \"then\": \"develop\"\n        },\n        {\n          \"default\": \"close_rejected\"\n        }\n      ]\n    }\n  }\n}"
+      },
+      "id": "start-route_review",
+      "name": "06 Start route_review",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [
+        2360,
+        260
+      ]
+    },
+    {
+      "parameters": {
+        "jsCode": "const routes = [\n  {\n    \"when\": \"review_status == 'approved'\",\n    \"then\": \"compliance\"\n  },\n  {\n    \"when\": \"review_status == 'changes_requested'\",\n    \"then\": \"develop\"\n  },\n  {\n    \"default\": \"close_rejected\"\n  }\n];\nconst state = $json;\n\nfunction toJsExpression(expr) {\n  return String(expr)\n    .replace(/\\band\\b/g, '&&')\n    .replace(/\\bor\\b/g, '||')\n    .replace(/\\bnot\\b/g, '!')\n    .replace(/\\bTrue\\b/g, 'true')\n    .replace(/\\bFalse\\b/g, 'false')\n    .replace(/\\bNone\\b/g, 'null');\n}\n\nfunction evaluate(expr) {\n  const keys = Object.keys(state);\n  const values = Object.values(state);\n  try {\n    return Boolean(Function(...keys, `return (${toJsExpression(expr)});`)(...values));\n  } catch (error) {\n    return false;\n  }\n}\n\nlet nextStep = null;\nfor (const route of routes) {\n  if (route.when && evaluate(route.when)) {\n    nextStep = route.then;\n    break;\n  }\n  if (!route.when && route.default && nextStep === null) {\n    nextStep = route.default;\n  }\n}\n\nreturn [{ json: { ...state, next_step: nextStep } }];\n"
+      },
+      "id": "route-route_review",
+      "name": "Route route_review",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [
+        2580,
+        260
+      ],
+      "notesInFlow": true,
+      "notes": "Evaluates Nexus route rules and writes next_step."
+    },
+    {
+      "parameters": {
+        "method": "POST",
+        "url": "http://nexus-bridge-1:8091/api/v1/n8n/runs/update",
+        "authentication": "predefinedCredentialType",
+        "nodeCredentialType": "httpBearerAuth",
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "{\n  \"run_id\": \"={{$json.run?.run_id || $json.run_id}}\",\n  \"state\": \"compliance\",\n  \"message\": \"Starting Nexus step compliance\",\n  \"data\": {\n    \"step\": {\n      \"id\": \"compliance\",\n      \"index\": 7,\n      \"name\": \"Compliance & Security Review\",\n      \"description\": \"Validate legal/safety/privacy requirements for generated content\",\n      \"agent_type\": \"compliance\",\n      \"context_policy\": \"standard\",\n      \"tools\": [\n        \"vcs:review_pr\"\n      ],\n      \"inputs\": [\n        {\n          \"content_bundle\": \"list[string]\"\n        }\n      ],\n      \"outputs\": [\n        {\n          \"compliance_status\": \"enum[approved|blocked]\"\n        },\n        {\n          \"compliance_issues\": \"list[string]\"\n        }\n      ],\n      \"on_success\": \"route_compliance\",\n      \"require_human_approval\": true\n    }\n  }\n}"
+      },
+      "id": "start-compliance",
+      "name": "07 Start compliance",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [
+        2720,
+        -180
+      ],
+      "notesInFlow": true,
+      "notes": "Validate legal/safety/privacy requirements for generated content"
+    },
+    {
+      "parameters": {
+        "method": "POST",
+        "url": "http://nexus-bridge-1:8091/api/v1/n8n/runs/update",
+        "authentication": "predefinedCredentialType",
+        "nodeCredentialType": "httpBearerAuth",
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "{\n  \"run_id\": \"={{$json.run?.run_id || $json.run_id}}\",\n  \"state\": \"compliance_awaiting_approval\",\n  \"message\": \"Human approval required before compliance\",\n  \"data\": {\n    \"step_id\": \"compliance\",\n    \"agent_type\": \"compliance\"\n  }\n}"
+      },
+      "id": "approval-compliance",
+      "name": "Approval Gate compliance",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [
+        2940,
+        -300
+      ],
+      "notesInFlow": true,
+      "notes": "Connect this node to an n8n approval/wait mechanism if the gate must pause."
+    },
+    {
+      "parameters": {
+        "method": "POST",
+        "url": "http://nexus-bridge-1:8091/api/v1/n8n/runs/update",
+        "authentication": "predefinedCredentialType",
+        "nodeCredentialType": "httpBearerAuth",
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "{\n  \"run_id\": \"={{$json.run?.run_id || $json.run_id}}\",\n  \"state\": \"compliance_completed\",\n  \"message\": \"Completed Nexus step compliance\",\n  \"data\": {\n    \"step\": {\n      \"id\": \"compliance\",\n      \"name\": \"Compliance & Security Review\",\n      \"description\": \"Validate legal/safety/privacy requirements for generated content\",\n      \"agent_type\": \"compliance\",\n      \"context_policy\": \"standard\",\n      \"tools\": [\n        \"vcs:review_pr\"\n      ],\n      \"inputs\": [\n        {\n          \"content_bundle\": \"list[string]\"\n        }\n      ],\n      \"outputs\": [\n        {\n          \"compliance_status\": \"enum[approved|blocked]\"\n        },\n        {\n          \"compliance_issues\": \"list[string]\"\n        }\n      ],\n      \"on_success\": \"route_compliance\",\n      \"require_human_approval\": true\n    }\n  }\n}"
+      },
+      "id": "complete-compliance",
+      "name": "Complete compliance",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [
+        2940,
+        -180
+      ],
+      "notesInFlow": true,
+      "notes": "Replace this state transition with a concrete agent/tool call when available."
+    },
+    {
+      "parameters": {
+        "method": "POST",
+        "url": "http://nexus-bridge-1:8091/api/v1/n8n/runs/update",
+        "authentication": "predefinedCredentialType",
+        "nodeCredentialType": "httpBearerAuth",
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "{\n  \"run_id\": \"={{$json.run?.run_id || $json.run_id}}\",\n  \"state\": \"route_compliance\",\n  \"message\": \"Starting Nexus step route_compliance\",\n  \"data\": {\n    \"step\": {\n      \"id\": \"route_compliance\",\n      \"index\": 8,\n      \"name\": \"Route After Compliance\",\n      \"agent_type\": \"router\",\n      \"context_policy\": \"minimal\",\n      \"routes\": [\n        {\n          \"when\": \"compliance_status == 'approved'\",\n          \"then\": \"deploy\"\n        },\n        {\n          \"default\": \"develop\"\n        }\n      ]\n    }\n  }\n}"
+      },
+      "id": "start-route_compliance",
+      "name": "08 Start route_compliance",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [
+        3080,
+        260
+      ]
+    },
+    {
+      "parameters": {
+        "jsCode": "const routes = [\n  {\n    \"when\": \"compliance_status == 'approved'\",\n    \"then\": \"deploy\"\n  },\n  {\n    \"default\": \"develop\"\n  }\n];\nconst state = $json;\n\nfunction toJsExpression(expr) {\n  return String(expr)\n    .replace(/\\band\\b/g, '&&')\n    .replace(/\\bor\\b/g, '||')\n    .replace(/\\bnot\\b/g, '!')\n    .replace(/\\bTrue\\b/g, 'true')\n    .replace(/\\bFalse\\b/g, 'false')\n    .replace(/\\bNone\\b/g, 'null');\n}\n\nfunction evaluate(expr) {\n  const keys = Object.keys(state);\n  const values = Object.values(state);\n  try {\n    return Boolean(Function(...keys, `return (${toJsExpression(expr)});`)(...values));\n  } catch (error) {\n    return false;\n  }\n}\n\nlet nextStep = null;\nfor (const route of routes) {\n  if (route.when && evaluate(route.when)) {\n    nextStep = route.then;\n    break;\n  }\n  if (!route.when && route.default && nextStep === null) {\n    nextStep = route.default;\n  }\n}\n\nreturn [{ json: { ...state, next_step: nextStep } }];\n"
+      },
+      "id": "route-route_compliance",
+      "name": "Route route_compliance",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [
+        3300,
+        260
+      ],
+      "notesInFlow": true,
+      "notes": "Evaluates Nexus route rules and writes next_step."
+    },
+    {
+      "parameters": {
+        "method": "POST",
+        "url": "http://nexus-bridge-1:8091/api/v1/n8n/runs/update",
+        "authentication": "predefinedCredentialType",
+        "nodeCredentialType": "httpBearerAuth",
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "{\n  \"run_id\": \"={{$json.run?.run_id || $json.run_id}}\",\n  \"state\": \"deploy\",\n  \"message\": \"Starting Nexus step deploy\",\n  \"data\": {\n    \"step\": {\n      \"id\": \"deploy\",\n      \"index\": 9,\n      \"name\": \"Merge & Deploy\",\n      \"description\": \"Publish approved content via platform integrations, defaulting to dry-run until adapters are production ready\",\n      \"agent_type\": \"deployer\",\n      \"context_policy\": \"standard\",\n      \"tools\": [\n        \"vcs:merge_pr\",\n        \"vcs:create_release\"\n      ],\n      \"inputs\": [\n        {\n          \"content_bundle\": \"list[string]\"\n        }\n      ],\n      \"outputs\": [\n        {\n          \"deployment_status\": \"string\"\n        },\n        {\n          \"publish_results\": \"list[string]\"\n        }\n      ],\n      \"on_success\": \"close_loop\",\n      \"require_human_approval\": true\n    }\n  }\n}"
+      },
+      "id": "start-deploy",
+      "name": "09 Start deploy",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [
+        3440,
+        -180
+      ],
+      "notesInFlow": true,
+      "notes": "Publish approved content via platform integrations, defaulting to dry-run until adapters are production ready"
+    },
+    {
+      "parameters": {
+        "method": "POST",
+        "url": "http://nexus-bridge-1:8091/api/v1/n8n/runs/update",
+        "authentication": "predefinedCredentialType",
+        "nodeCredentialType": "httpBearerAuth",
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "{\n  \"run_id\": \"={{$json.run?.run_id || $json.run_id}}\",\n  \"state\": \"deploy_awaiting_approval\",\n  \"message\": \"Human approval required before deploy\",\n  \"data\": {\n    \"step_id\": \"deploy\",\n    \"agent_type\": \"deployer\"\n  }\n}"
+      },
+      "id": "approval-deploy",
+      "name": "Approval Gate deploy",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [
+        3660,
+        -300
+      ],
+      "notesInFlow": true,
+      "notes": "Connect this node to an n8n approval/wait mechanism if the gate must pause."
+    },
+    {
+      "parameters": {
+        "method": "POST",
+        "url": "http://nexus-bridge-1:8091/api/v1/n8n/runs/update",
+        "authentication": "predefinedCredentialType",
+        "nodeCredentialType": "httpBearerAuth",
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "{\n  \"run_id\": \"={{$json.run?.run_id || $json.run_id}}\",\n  \"state\": \"deploy_completed\",\n  \"message\": \"Completed Nexus step deploy\",\n  \"data\": {\n    \"step\": {\n      \"id\": \"deploy\",\n      \"name\": \"Merge & Deploy\",\n      \"description\": \"Publish approved content via platform integrations, defaulting to dry-run until adapters are production ready\",\n      \"agent_type\": \"deployer\",\n      \"context_policy\": \"standard\",\n      \"tools\": [\n        \"vcs:merge_pr\",\n        \"vcs:create_release\"\n      ],\n      \"inputs\": [\n        {\n          \"content_bundle\": \"list[string]\"\n        }\n      ],\n      \"outputs\": [\n        {\n          \"deployment_status\": \"string\"\n        },\n        {\n          \"publish_results\": \"list[string]\"\n        }\n      ],\n      \"on_success\": \"close_loop\",\n      \"require_human_approval\": true\n    }\n  }\n}"
+      },
+      "id": "complete-deploy",
+      "name": "Complete deploy",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [
+        3660,
+        -180
+      ],
+      "notesInFlow": true,
+      "notes": "Replace this state transition with a concrete agent/tool call when available."
+    },
+    {
+      "parameters": {
+        "method": "POST",
+        "url": "http://nexus-bridge-1:8091/api/v1/n8n/runs/update",
+        "authentication": "predefinedCredentialType",
+        "nodeCredentialType": "httpBearerAuth",
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "{\n  \"run_id\": \"={{$json.run?.run_id || $json.run_id}}\",\n  \"state\": \"close_loop\",\n  \"message\": \"Starting Nexus step close_loop\",\n  \"data\": {\n    \"step\": {\n      \"id\": \"close_loop\",\n      \"index\": 10,\n      \"name\": \"Document & Close\",\n      \"description\": \"Update docs, summarize campaign outcomes, and close the issue\",\n      \"agent_type\": \"writer\",\n      \"context_policy\": \"standard\",\n      \"tools\": [\n        \"vcs:create_file\",\n        \"vcs:edit_file\",\n        \"vcs:close_issue\"\n      ],\n      \"inputs\": [\n        {\n          \"issue_url\": \"string\"\n        },\n        {\n          \"publish_results\": \"list[string]\"\n        }\n      ],\n      \"outputs\": [\n        {\n          \"documentation_url\": \"string\"\n        },\n        {\n          \"campaign_summary\": \"string\"\n        }\n      ],\n      \"final_step\": true\n    }\n  }\n}"
+      },
+      "id": "start-close_loop",
+      "name": "10 Start close_loop",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [
+        3800,
+        120
+      ],
+      "notesInFlow": true,
+      "notes": "Update docs, summarize campaign outcomes, and close the issue"
+    },
+    {
+      "parameters": {
+        "method": "POST",
+        "url": "http://nexus-bridge-1:8091/api/v1/n8n/runs/update",
+        "authentication": "predefinedCredentialType",
+        "nodeCredentialType": "httpBearerAuth",
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "{\n  \"run_id\": \"={{$json.run?.run_id || $json.run_id}}\",\n  \"state\": \"close_loop_completed\",\n  \"message\": \"Completed Nexus step close_loop\",\n  \"data\": {\n    \"step\": {\n      \"id\": \"close_loop\",\n      \"name\": \"Document & Close\",\n      \"description\": \"Update docs, summarize campaign outcomes, and close the issue\",\n      \"agent_type\": \"writer\",\n      \"context_policy\": \"standard\",\n      \"tools\": [\n        \"vcs:create_file\",\n        \"vcs:edit_file\",\n        \"vcs:close_issue\"\n      ],\n      \"inputs\": [\n        {\n          \"issue_url\": \"string\"\n        },\n        {\n          \"publish_results\": \"list[string]\"\n        }\n      ],\n      \"outputs\": [\n        {\n          \"documentation_url\": \"string\"\n        },\n        {\n          \"campaign_summary\": \"string\"\n        }\n      ],\n      \"final_step\": true\n    }\n  }\n}"
+      },
+      "id": "complete-close_loop",
+      "name": "Complete close_loop",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [
+        4020,
+        120
+      ],
+      "notesInFlow": true,
+      "notes": "Replace this state transition with a concrete agent/tool call when available."
+    },
+    {
+      "parameters": {
+        "method": "POST",
+        "url": "http://nexus-bridge-1:8091/api/v1/n8n/runs/update",
+        "authentication": "predefinedCredentialType",
+        "nodeCredentialType": "httpBearerAuth",
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "{\n  \"run_id\": \"={{$json.run?.run_id || $json.run_id}}\",\n  \"state\": \"close_rejected\",\n  \"message\": \"Starting Nexus step close_rejected\",\n  \"data\": {\n    \"step\": {\n      \"id\": \"close_rejected\",\n      \"index\": 11,\n      \"name\": \"Close Rejected Issue\",\n      \"description\": \"Post rejection summary when review/compliance cannot pass\",\n      \"agent_type\": \"finalizer\",\n      \"context_policy\": \"minimal\",\n      \"tools\": [\n        \"vcs:close_issue\"\n      ],\n      \"inputs\": [\n        {\n          \"issue_url\": \"string\"\n        },\n        {\n          \"review_comments\": \"list[string]\"\n        }\n      ],\n      \"final_step\": true\n    }\n  }\n}"
+      },
+      "id": "start-close_rejected",
+      "name": "11 Start close_rejected",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [
+        4160,
+        0
+      ],
+      "notesInFlow": true,
+      "notes": "Post rejection summary when review/compliance cannot pass"
+    },
+    {
+      "parameters": {
+        "method": "POST",
+        "url": "http://nexus-bridge-1:8091/api/v1/n8n/runs/update",
+        "authentication": "predefinedCredentialType",
+        "nodeCredentialType": "httpBearerAuth",
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "{\n  \"run_id\": \"={{$json.run?.run_id || $json.run_id}}\",\n  \"state\": \"close_rejected_completed\",\n  \"message\": \"Completed Nexus step close_rejected\",\n  \"data\": {\n    \"step\": {\n      \"id\": \"close_rejected\",\n      \"name\": \"Close Rejected Issue\",\n      \"description\": \"Post rejection summary when review/compliance cannot pass\",\n      \"agent_type\": \"finalizer\",\n      \"context_policy\": \"minimal\",\n      \"tools\": [\n        \"vcs:close_issue\"\n      ],\n      \"inputs\": [\n        {\n          \"issue_url\": \"string\"\n        },\n        {\n          \"review_comments\": \"list[string]\"\n        }\n      ],\n      \"final_step\": true\n    }\n  }\n}"
+      },
+      "id": "complete-close_rejected",
+      "name": "Complete close_rejected",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [
+        4380,
+        0
+      ],
+      "notesInFlow": true,
+      "notes": "Replace this state transition with a concrete agent/tool call when available."
+    },
+    {
+      "parameters": {
+        "mode": "rules",
+        "rules": {
+          "values": [
+            {
+              "conditions": {
+                "conditions": [
+                  {
+                    "leftValue": "={{$json.next_step}}",
+                    "rightValue": "design",
+                    "operator": {
+                      "type": "string",
+                      "operation": "equals"
+                    }
+                  }
+                ],
+                "combinator": "and"
+              }
+            },
+            {
+              "conditions": {
+                "conditions": [
+                  {
+                    "leftValue": "={{$json.next_step}}",
+                    "rightValue": "develop",
+                    "operator": {
+                      "type": "string",
+                      "operation": "equals"
+                    }
+                  }
+                ],
+                "combinator": "and"
+              }
+            },
+            {
+              "conditions": {
+                "conditions": [
+                  {
+                    "leftValue": "={{$json.next_step}}",
+                    "rightValue": "close_rejected",
+                    "operator": {
+                      "type": "string",
+                      "operation": "equals"
+                    }
+                  }
+                ],
+                "combinator": "and"
+              }
+            }
+          ]
+        },
+        "options": {}
+      },
+      "id": "switch-switch-route_triage",
+      "name": "Switch route_triage",
+      "type": "n8n-nodes-base.switch",
+      "typeVersion": 3,
+      "position": [
+        1360,
+        260
+      ],
+      "notesInFlow": true,
+      "notes": "Routes to the Nexus step selected by the preceding Code node."
+    },
+    {
+      "parameters": {
+        "mode": "rules",
+        "rules": {
+          "values": [
+            {
+              "conditions": {
+                "conditions": [
+                  {
+                    "leftValue": "={{$json.next_step}}",
+                    "rightValue": "compliance",
+                    "operator": {
+                      "type": "string",
+                      "operation": "equals"
+                    }
+                  }
+                ],
+                "combinator": "and"
+              }
+            },
+            {
+              "conditions": {
+                "conditions": [
+                  {
+                    "leftValue": "={{$json.next_step}}",
+                    "rightValue": "develop",
+                    "operator": {
+                      "type": "string",
+                      "operation": "equals"
+                    }
+                  }
+                ],
+                "combinator": "and"
+              }
+            },
+            {
+              "conditions": {
+                "conditions": [
+                  {
+                    "leftValue": "={{$json.next_step}}",
+                    "rightValue": "close_rejected",
+                    "operator": {
+                      "type": "string",
+                      "operation": "equals"
+                    }
+                  }
+                ],
+                "combinator": "and"
+              }
+            }
+          ]
+        },
+        "options": {}
+      },
+      "id": "switch-switch-route_review",
+      "name": "Switch route_review",
+      "type": "n8n-nodes-base.switch",
+      "typeVersion": 3,
+      "position": [
+        2800,
+        260
+      ],
+      "notesInFlow": true,
+      "notes": "Routes to the Nexus step selected by the preceding Code node."
+    },
+    {
+      "parameters": {
+        "mode": "rules",
+        "rules": {
+          "values": [
+            {
+              "conditions": {
+                "conditions": [
+                  {
+                    "leftValue": "={{$json.next_step}}",
+                    "rightValue": "deploy",
+                    "operator": {
+                      "type": "string",
+                      "operation": "equals"
+                    }
+                  }
+                ],
+                "combinator": "and"
+              }
+            },
+            {
+              "conditions": {
+                "conditions": [
+                  {
+                    "leftValue": "={{$json.next_step}}",
+                    "rightValue": "develop",
+                    "operator": {
+                      "type": "string",
+                      "operation": "equals"
+                    }
+                  }
+                ],
+                "combinator": "and"
+              }
+            }
+          ]
+        },
+        "options": {}
+      },
+      "id": "switch-switch-route_compliance",
+      "name": "Switch route_compliance",
+      "type": "n8n-nodes-base.switch",
+      "typeVersion": 3,
+      "position": [
+        3520,
+        260
+      ],
+      "notesInFlow": true,
+      "notes": "Routes to the Nexus step selected by the preceding Code node."
+    }
+  ],
+  "connections": {
+    "01 Start triage": {
+      "main": [
+        [
+          {
+            "node": "Complete triage",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "02 Start route_triage": {
+      "main": [
+        [
+          {
+            "node": "Route route_triage",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "03 Start design": {
+      "main": [
+        [
+          {
+            "node": "Complete design",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "04 Start develop": {
+      "main": [
+        [
+          {
+            "node": "Execute OpenCode develop",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "05 Start review": {
+      "main": [
+        [
+          {
+            "node": "Complete review",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "06 Start route_review": {
+      "main": [
+        [
+          {
+            "node": "Route route_review",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "07 Start compliance": {
+      "main": [
+        [
+          {
+            "node": "Approval Gate compliance",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Approval Gate compliance": {
+      "main": [
+        [
+          {
+            "node": "Complete compliance",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "08 Start route_compliance": {
+      "main": [
+        [
+          {
+            "node": "Route route_compliance",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "09 Start deploy": {
+      "main": [
+        [
+          {
+            "node": "Approval Gate deploy",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Approval Gate deploy": {
+      "main": [
+        [
+          {
+            "node": "Complete deploy",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "10 Start close_loop": {
+      "main": [
+        [
+          {
+            "node": "Complete close_loop",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "11 Start close_rejected": {
+      "main": [
+        [
+          {
+            "node": "Complete close_rejected",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Create Nexus Run": {
+      "main": [
+        [
+          {
+            "node": "01 Start triage",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Manual Trigger": {
+      "main": [
+        [
+          {
+            "node": "Create Nexus Run",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Complete triage": {
+      "main": [
+        [
+          {
+            "node": "02 Start route_triage",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Route route_triage": {
+      "main": [
+        [
+          {
+            "node": "Switch route_triage",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Switch route_triage": {
+      "main": [
+        [
+          {
+            "node": "03 Start design",
+            "type": "main",
+            "index": 0
+          }
+        ],
+        [
+          {
+            "node": "04 Start develop",
+            "type": "main",
+            "index": 0
+          }
+        ],
+        [
+          {
+            "node": "11 Start close_rejected",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Complete design": {
+      "main": [
+        [
+          {
+            "node": "04 Start develop",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Execute OpenCode develop": {
+      "main": [
+        [
+          {
+            "node": "05 Start review",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Complete review": {
+      "main": [
+        [
+          {
+            "node": "06 Start route_review",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Route route_review": {
+      "main": [
+        [
+          {
+            "node": "Switch route_review",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Switch route_review": {
+      "main": [
+        [
+          {
+            "node": "07 Start compliance",
+            "type": "main",
+            "index": 0
+          }
+        ],
+        [
+          {
+            "node": "04 Start develop",
+            "type": "main",
+            "index": 0
+          }
+        ],
+        [
+          {
+            "node": "11 Start close_rejected",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Complete compliance": {
+      "main": [
+        [
+          {
+            "node": "08 Start route_compliance",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Route route_compliance": {
+      "main": [
+        [
+          {
+            "node": "Switch route_compliance",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Switch route_compliance": {
+      "main": [
+        [
+          {
+            "node": "09 Start deploy",
+            "type": "main",
+            "index": 0
+          }
+        ],
+        [
+          {
+            "node": "04 Start develop",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Complete deploy": {
+      "main": [
+        [
+          {
+            "node": "10 Start close_loop",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    }
+  },
+  "settings": {
+    "executionOrder": "v1"
+  },
+  "staticData": null,
+  "tags": [
+    "nexus-arc",
+    "generated"
+  ],
+  "meta": {
+    "nexusArc": {
+      "source": "examples/workflows/social_media_marketing_workflow.yaml",
+      "workflowType": "social-marketing",
+      "converter": "nexus.translators.to_n8n"
+    }
+  }
+}

--- a/examples/workflows/n8n/x_post_workflow.json
+++ b/examples/workflows/n8n/x_post_workflow.json
@@ -1,0 +1,541 @@
+{
+  "name": "X (Twitter) Post Workflow",
+  "nodes": [
+    {
+      "parameters": {},
+      "id": "manual-trigger",
+      "name": "Manual Trigger",
+      "type": "n8n-nodes-base.manualTrigger",
+      "typeVersion": 1,
+      "position": [
+        0,
+        0
+      ]
+    },
+    {
+      "parameters": {
+        "method": "POST",
+        "url": "http://nexus-bridge-1:8091/api/v1/n8n/runs",
+        "authentication": "predefinedCredentialType",
+        "nodeCredentialType": "httpBearerAuth",
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "{\n  \"task\": \"={{$json.task || $json.title || 'Run Nexus workflow'}}\",\n  \"project_key\": \"={{$json.project_key || $json.project || 'nexus'}}\",\n  \"issue_number\": \"={{$json.issue_number || $json.issue || ''}}\",\n  \"requester\": {\n    \"source\": \"n8n\",\n    \"workflow\": \"X (Twitter) Post Workflow\"\n  },\n  \"metadata\": {\n    \"nexus_workflow\": {\n      \"name\": \"X (Twitter) Post Workflow\",\n      \"description\": \"Research a topic, write an X post or thread, validate it, and publish.\",\n      \"version\": \"1.0.0\"\n    },\n    \"workflow_type\": \"social-post\",\n    \"source\": \"examples/workflows/x_post_workflow.yaml\"\n  }\n}"
+      },
+      "id": "create-nexus-run",
+      "name": "Create Nexus Run",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [
+        260,
+        0
+      ],
+      "notesInFlow": true,
+      "notes": "Creates the durable Nexus run that n8n will advance."
+    },
+    {
+      "parameters": {
+        "method": "POST",
+        "url": "http://nexus-bridge-1:8091/api/v1/n8n/runs/update",
+        "authentication": "predefinedCredentialType",
+        "nodeCredentialType": "httpBearerAuth",
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "{\n  \"run_id\": \"={{$json.run?.run_id || $json.run_id}}\",\n  \"state\": \"research\",\n  \"message\": \"Starting Nexus step research\",\n  \"data\": {\n    \"step\": {\n      \"id\": \"research\",\n      \"index\": 1,\n      \"name\": \"Research\",\n      \"description\": \"Gather context about the topic. Identify: key insight or hook, audience, ideal format (single tweet vs thread), and 2\\u20134 relevant hashtags. X audience skews technical/professional. Punchy, opinionated content performs better.\\n\",\n      \"agent_type\": \"researcher\",\n      \"context_policy\": \"minimal\",\n      \"tools\": [\n        \"vcs:read_issue\",\n        \"vcs:add_comment\"\n      ],\n      \"inputs\": [\n        {\n          \"topic\": \"string\"\n        },\n        {\n          \"audience\": \"string\"\n        },\n        {\n          \"thread_mode\": \"boolean\"\n        }\n      ],\n      \"outputs\": [\n        {\n          \"research_brief\": \"string\"\n        },\n        {\n          \"key_insight\": \"string\"\n        },\n        {\n          \"recommended_format\": \"enum[single_tweet|thread]\"\n        },\n        {\n          \"suggested_hashtags\": \"list[string]\"\n        }\n      ],\n      \"on_success\": \"write\"\n    }\n  }\n}"
+      },
+      "id": "start-research",
+      "name": "01 Start research",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [
+        560,
+        0
+      ],
+      "notesInFlow": true,
+      "notes": "Gather context about the topic. Identify: key insight or hook, audience, ideal format (single tweet vs thread), and 2\u20134 relevant hashtags. X audience skews technical/professional. Punchy, opinionated content performs better.\n"
+    },
+    {
+      "parameters": {
+        "method": "POST",
+        "url": "http://nexus-bridge-1:8091/api/v1/n8n/runs/update",
+        "authentication": "predefinedCredentialType",
+        "nodeCredentialType": "httpBearerAuth",
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "{\n  \"run_id\": \"={{$json.run?.run_id || $json.run_id}}\",\n  \"state\": \"research_completed\",\n  \"message\": \"Completed Nexus step research\",\n  \"data\": {\n    \"step\": {\n      \"id\": \"research\",\n      \"name\": \"Research\",\n      \"description\": \"Gather context about the topic. Identify: key insight or hook, audience, ideal format (single tweet vs thread), and 2\\u20134 relevant hashtags. X audience skews technical/professional. Punchy, opinionated content performs better.\\n\",\n      \"agent_type\": \"researcher\",\n      \"context_policy\": \"minimal\",\n      \"tools\": [\n        \"vcs:read_issue\",\n        \"vcs:add_comment\"\n      ],\n      \"inputs\": [\n        {\n          \"topic\": \"string\"\n        },\n        {\n          \"audience\": \"string\"\n        },\n        {\n          \"thread_mode\": \"boolean\"\n        }\n      ],\n      \"outputs\": [\n        {\n          \"research_brief\": \"string\"\n        },\n        {\n          \"key_insight\": \"string\"\n        },\n        {\n          \"recommended_format\": \"enum[single_tweet|thread]\"\n        },\n        {\n          \"suggested_hashtags\": \"list[string]\"\n        }\n      ],\n      \"on_success\": \"write\"\n    }\n  }\n}"
+      },
+      "id": "complete-research",
+      "name": "Complete research",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [
+        780,
+        0
+      ],
+      "notesInFlow": true,
+      "notes": "Replace this state transition with a concrete agent/tool call when available."
+    },
+    {
+      "parameters": {
+        "method": "POST",
+        "url": "http://nexus-bridge-1:8091/api/v1/n8n/runs/update",
+        "authentication": "predefinedCredentialType",
+        "nodeCredentialType": "httpBearerAuth",
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "{\n  \"run_id\": \"={{$json.run?.run_id || $json.run_id}}\",\n  \"state\": \"write\",\n  \"message\": \"Starting Nexus step write\",\n  \"data\": {\n    \"step\": {\n      \"id\": \"write\",\n      \"index\": 2,\n      \"name\": \"Write X Post\",\n      \"description\": \"Write the X post or thread based on the research brief. Single tweet: max 280 chars, punchy, one clear idea. Thread: 3\\u20138 tweets, each \\u2264280 chars. Number them (1/ 2/ etc.). Tone: direct, confident, conversational. No corporate speak. Hashtags: max 2\\u20133, at the end of the last tweet only.\\n\",\n      \"agent_type\": \"writer\",\n      \"context_policy\": \"standard\",\n      \"tools\": [\n        \"vcs:read_comments\",\n        \"vcs:add_comment\"\n      ],\n      \"inputs\": [\n        {\n          \"research_brief\": \"string\"\n        },\n        {\n          \"key_insight\": \"string\"\n        },\n        {\n          \"recommended_format\": \"string\"\n        },\n        {\n          \"suggested_hashtags\": \"list[string]\"\n        }\n      ],\n      \"outputs\": [\n        {\n          \"post_text\": \"string\"\n        },\n        {\n          \"post_platform\": \"string\"\n        },\n        {\n          \"is_thread\": \"boolean\"\n        },\n        {\n          \"tweet_count\": \"integer\"\n        }\n      ],\n      \"on_success\": \"review\",\n      \"audit_limit\": 10,\n      \"include_audit_history\": true\n    }\n  }\n}"
+      },
+      "id": "start-write",
+      "name": "02 Start write",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [
+        920,
+        120
+      ],
+      "notesInFlow": true,
+      "notes": "Write the X post or thread based on the research brief. Single tweet: max 280 chars, punchy, one clear idea. Thread: 3\u20138 tweets, each \u2264280 chars. Number them (1/ 2/ etc.). Tone: direct, confident, conversational. No corporate speak. Hashtags: max 2\u20133, at the end of the last tweet only.\n"
+    },
+    {
+      "parameters": {
+        "method": "POST",
+        "url": "http://nexus-bridge-1:8091/api/v1/n8n/runs/update",
+        "authentication": "predefinedCredentialType",
+        "nodeCredentialType": "httpBearerAuth",
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "{\n  \"run_id\": \"={{$json.run?.run_id || $json.run_id}}\",\n  \"state\": \"write_completed\",\n  \"message\": \"Completed Nexus step write\",\n  \"data\": {\n    \"step\": {\n      \"id\": \"write\",\n      \"name\": \"Write X Post\",\n      \"description\": \"Write the X post or thread based on the research brief. Single tweet: max 280 chars, punchy, one clear idea. Thread: 3\\u20138 tweets, each \\u2264280 chars. Number them (1/ 2/ etc.). Tone: direct, confident, conversational. No corporate speak. Hashtags: max 2\\u20133, at the end of the last tweet only.\\n\",\n      \"agent_type\": \"writer\",\n      \"context_policy\": \"standard\",\n      \"tools\": [\n        \"vcs:read_comments\",\n        \"vcs:add_comment\"\n      ],\n      \"inputs\": [\n        {\n          \"research_brief\": \"string\"\n        },\n        {\n          \"key_insight\": \"string\"\n        },\n        {\n          \"recommended_format\": \"string\"\n        },\n        {\n          \"suggested_hashtags\": \"list[string]\"\n        }\n      ],\n      \"outputs\": [\n        {\n          \"post_text\": \"string\"\n        },\n        {\n          \"post_platform\": \"string\"\n        },\n        {\n          \"is_thread\": \"boolean\"\n        },\n        {\n          \"tweet_count\": \"integer\"\n        }\n      ],\n      \"on_success\": \"review\",\n      \"audit_limit\": 10,\n      \"include_audit_history\": true\n    }\n  }\n}"
+      },
+      "id": "complete-write",
+      "name": "Complete write",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [
+        1140,
+        120
+      ],
+      "notesInFlow": true,
+      "notes": "Replace this state transition with a concrete agent/tool call when available."
+    },
+    {
+      "parameters": {
+        "method": "POST",
+        "url": "http://nexus-bridge-1:8091/api/v1/n8n/runs/update",
+        "authentication": "predefinedCredentialType",
+        "nodeCredentialType": "httpBearerAuth",
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "{\n  \"run_id\": \"={{$json.run?.run_id || $json.run_id}}\",\n  \"state\": \"review\",\n  \"message\": \"Starting Nexus step review\",\n  \"data\": {\n    \"step\": {\n      \"id\": \"review\",\n      \"index\": 3,\n      \"name\": \"Review & Validate\",\n      \"description\": \"Review the post for: character limits (each tweet \\u2264280 chars), tone (punchy, not corporate), hashtag count (\\u22643), no unverified claims, no policy violations. Approve or request specific changes.\\n\",\n      \"agent_type\": \"reviewer\",\n      \"context_policy\": \"standard\",\n      \"tools\": [\n        \"vcs:read_comments\",\n        \"vcs:add_comment\"\n      ],\n      \"inputs\": [\n        {\n          \"post_text\": \"string\"\n        },\n        {\n          \"is_thread\": \"boolean\"\n        }\n      ],\n      \"outputs\": [\n        {\n          \"review_status\": \"enum[approved|changes_requested]\"\n        },\n        {\n          \"review_notes\": \"string\"\n        }\n      ],\n      \"on_success\": \"route_review\",\n      \"audit_limit\": 20,\n      \"include_audit_history\": true\n    }\n  }\n}"
+      },
+      "id": "start-review",
+      "name": "03 Start review",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [
+        1280,
+        0
+      ],
+      "notesInFlow": true,
+      "notes": "Review the post for: character limits (each tweet \u2264280 chars), tone (punchy, not corporate), hashtag count (\u22643), no unverified claims, no policy violations. Approve or request specific changes.\n"
+    },
+    {
+      "parameters": {
+        "method": "POST",
+        "url": "http://nexus-bridge-1:8091/api/v1/n8n/runs/update",
+        "authentication": "predefinedCredentialType",
+        "nodeCredentialType": "httpBearerAuth",
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "{\n  \"run_id\": \"={{$json.run?.run_id || $json.run_id}}\",\n  \"state\": \"review_completed\",\n  \"message\": \"Completed Nexus step review\",\n  \"data\": {\n    \"step\": {\n      \"id\": \"review\",\n      \"name\": \"Review & Validate\",\n      \"description\": \"Review the post for: character limits (each tweet \\u2264280 chars), tone (punchy, not corporate), hashtag count (\\u22643), no unverified claims, no policy violations. Approve or request specific changes.\\n\",\n      \"agent_type\": \"reviewer\",\n      \"context_policy\": \"standard\",\n      \"tools\": [\n        \"vcs:read_comments\",\n        \"vcs:add_comment\"\n      ],\n      \"inputs\": [\n        {\n          \"post_text\": \"string\"\n        },\n        {\n          \"is_thread\": \"boolean\"\n        }\n      ],\n      \"outputs\": [\n        {\n          \"review_status\": \"enum[approved|changes_requested]\"\n        },\n        {\n          \"review_notes\": \"string\"\n        }\n      ],\n      \"on_success\": \"route_review\",\n      \"audit_limit\": 20,\n      \"include_audit_history\": true\n    }\n  }\n}"
+      },
+      "id": "complete-review",
+      "name": "Complete review",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [
+        1500,
+        0
+      ],
+      "notesInFlow": true,
+      "notes": "Replace this state transition with a concrete agent/tool call when available."
+    },
+    {
+      "parameters": {
+        "method": "POST",
+        "url": "http://nexus-bridge-1:8091/api/v1/n8n/runs/update",
+        "authentication": "predefinedCredentialType",
+        "nodeCredentialType": "httpBearerAuth",
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "{\n  \"run_id\": \"={{$json.run?.run_id || $json.run_id}}\",\n  \"state\": \"route_review\",\n  \"message\": \"Starting Nexus step route_review\",\n  \"data\": {\n    \"step\": {\n      \"id\": \"route_review\",\n      \"index\": 4,\n      \"name\": \"Route After Review\",\n      \"agent_type\": \"router\",\n      \"context_policy\": \"minimal\",\n      \"routes\": [\n        {\n          \"when\": \"review_status == 'approved'\",\n          \"then\": \"publish\"\n        },\n        {\n          \"when\": \"review_status == 'changes_requested'\",\n          \"then\": \"write\"\n        },\n        {\n          \"default\": \"write\"\n        }\n      ]\n    }\n  }\n}"
+      },
+      "id": "start-route_review",
+      "name": "04 Start route_review",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [
+        1640,
+        260
+      ]
+    },
+    {
+      "parameters": {
+        "jsCode": "const routes = [\n  {\n    \"when\": \"review_status == 'approved'\",\n    \"then\": \"publish\"\n  },\n  {\n    \"when\": \"review_status == 'changes_requested'\",\n    \"then\": \"write\"\n  },\n  {\n    \"default\": \"write\"\n  }\n];\nconst state = $json;\n\nfunction toJsExpression(expr) {\n  return String(expr)\n    .replace(/\\band\\b/g, '&&')\n    .replace(/\\bor\\b/g, '||')\n    .replace(/\\bnot\\b/g, '!')\n    .replace(/\\bTrue\\b/g, 'true')\n    .replace(/\\bFalse\\b/g, 'false')\n    .replace(/\\bNone\\b/g, 'null');\n}\n\nfunction evaluate(expr) {\n  const keys = Object.keys(state);\n  const values = Object.values(state);\n  try {\n    return Boolean(Function(...keys, `return (${toJsExpression(expr)});`)(...values));\n  } catch (error) {\n    return false;\n  }\n}\n\nlet nextStep = null;\nfor (const route of routes) {\n  if (route.when && evaluate(route.when)) {\n    nextStep = route.then;\n    break;\n  }\n  if (!route.when && route.default && nextStep === null) {\n    nextStep = route.default;\n  }\n}\n\nreturn [{ json: { ...state, next_step: nextStep } }];\n"
+      },
+      "id": "route-route_review",
+      "name": "Route route_review",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [
+        1860,
+        260
+      ],
+      "notesInFlow": true,
+      "notes": "Evaluates Nexus route rules and writes next_step."
+    },
+    {
+      "parameters": {
+        "method": "POST",
+        "url": "http://nexus-bridge-1:8091/api/v1/n8n/runs/update",
+        "authentication": "predefinedCredentialType",
+        "nodeCredentialType": "httpBearerAuth",
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "{\n  \"run_id\": \"={{$json.run?.run_id || $json.run_id}}\",\n  \"state\": \"publish\",\n  \"message\": \"Starting Nexus step publish\",\n  \"data\": {\n    \"step\": {\n      \"id\": \"publish\",\n      \"index\": 5,\n      \"name\": \"Publish to X\",\n      \"description\": \"Publish the approved post or thread to X. First run a dry_run to validate character limits and credentials. For threads: set metadata.thread_mode=True. Post the result (tweet URL or first tweet URL) as a comment.\\n\",\n      \"agent_type\": \"publisher\",\n      \"context_policy\": \"standard\",\n      \"tools\": [\n        \"vcs:read_comments\",\n        \"vcs:add_comment\"\n      ],\n      \"inputs\": [\n        {\n          \"post_text\": \"string\"\n        },\n        {\n          \"post_platform\": \"string\"\n        },\n        {\n          \"is_thread\": \"boolean\"\n        }\n      ],\n      \"outputs\": [\n        {\n          \"publish_status\": \"enum[published|dry_run_only|failed]\"\n        },\n        {\n          \"publish_url\": \"string\"\n        },\n        {\n          \"publish_platform\": \"string\"\n        }\n      ],\n      \"on_success\": \"close_loop\",\n      \"require_human_approval\": true,\n      \"audit_limit\": 20,\n      \"include_audit_history\": true\n    }\n  }\n}"
+      },
+      "id": "start-publish",
+      "name": "05 Start publish",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [
+        2000,
+        -180
+      ],
+      "notesInFlow": true,
+      "notes": "Publish the approved post or thread to X. First run a dry_run to validate character limits and credentials. For threads: set metadata.thread_mode=True. Post the result (tweet URL or first tweet URL) as a comment.\n"
+    },
+    {
+      "parameters": {
+        "method": "POST",
+        "url": "http://nexus-bridge-1:8091/api/v1/n8n/runs/update",
+        "authentication": "predefinedCredentialType",
+        "nodeCredentialType": "httpBearerAuth",
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "{\n  \"run_id\": \"={{$json.run?.run_id || $json.run_id}}\",\n  \"state\": \"publish_awaiting_approval\",\n  \"message\": \"Human approval required before publish\",\n  \"data\": {\n    \"step_id\": \"publish\",\n    \"agent_type\": \"publisher\"\n  }\n}"
+      },
+      "id": "approval-publish",
+      "name": "Approval Gate publish",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [
+        2220,
+        -300
+      ],
+      "notesInFlow": true,
+      "notes": "Connect this node to an n8n approval/wait mechanism if the gate must pause."
+    },
+    {
+      "parameters": {
+        "method": "POST",
+        "url": "http://nexus-bridge-1:8091/api/v1/n8n/runs/update",
+        "authentication": "predefinedCredentialType",
+        "nodeCredentialType": "httpBearerAuth",
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "{\n  \"run_id\": \"={{$json.run?.run_id || $json.run_id}}\",\n  \"state\": \"publish_completed\",\n  \"message\": \"Completed Nexus step publish\",\n  \"data\": {\n    \"step\": {\n      \"id\": \"publish\",\n      \"name\": \"Publish to X\",\n      \"description\": \"Publish the approved post or thread to X. First run a dry_run to validate character limits and credentials. For threads: set metadata.thread_mode=True. Post the result (tweet URL or first tweet URL) as a comment.\\n\",\n      \"agent_type\": \"publisher\",\n      \"context_policy\": \"standard\",\n      \"tools\": [\n        \"vcs:read_comments\",\n        \"vcs:add_comment\"\n      ],\n      \"inputs\": [\n        {\n          \"post_text\": \"string\"\n        },\n        {\n          \"post_platform\": \"string\"\n        },\n        {\n          \"is_thread\": \"boolean\"\n        }\n      ],\n      \"outputs\": [\n        {\n          \"publish_status\": \"enum[published|dry_run_only|failed]\"\n        },\n        {\n          \"publish_url\": \"string\"\n        },\n        {\n          \"publish_platform\": \"string\"\n        }\n      ],\n      \"on_success\": \"close_loop\",\n      \"require_human_approval\": true,\n      \"audit_limit\": 20,\n      \"include_audit_history\": true\n    }\n  }\n}"
+      },
+      "id": "complete-publish",
+      "name": "Complete publish",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [
+        2220,
+        -180
+      ],
+      "notesInFlow": true,
+      "notes": "Replace this state transition with a concrete agent/tool call when available."
+    },
+    {
+      "parameters": {
+        "method": "POST",
+        "url": "http://nexus-bridge-1:8091/api/v1/n8n/runs/update",
+        "authentication": "predefinedCredentialType",
+        "nodeCredentialType": "httpBearerAuth",
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "{\n  \"run_id\": \"={{$json.run?.run_id || $json.run_id}}\",\n  \"state\": \"close_loop\",\n  \"message\": \"Starting Nexus step close_loop\",\n  \"data\": {\n    \"step\": {\n      \"id\": \"close_loop\",\n      \"index\": 6,\n      \"name\": \"Document & Close\",\n      \"description\": \"Write a short summary of the published post. Close the issue with label social:published.\",\n      \"agent_type\": \"writer\",\n      \"context_policy\": \"minimal\",\n      \"tools\": [\n        \"vcs:add_comment\",\n        \"vcs:add_label\",\n        \"vcs:close_issue\"\n      ],\n      \"inputs\": [\n        {\n          \"publish_url\": \"string\"\n        },\n        {\n          \"publish_platform\": \"string\"\n        },\n        {\n          \"post_text\": \"string\"\n        }\n      ],\n      \"outputs\": [\n        {\n          \"summary\": \"string\"\n        }\n      ],\n      \"final_step\": true\n    }\n  }\n}"
+      },
+      "id": "start-close_loop",
+      "name": "06 Start close_loop",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [
+        2360,
+        120
+      ],
+      "notesInFlow": true,
+      "notes": "Write a short summary of the published post. Close the issue with label social:published."
+    },
+    {
+      "parameters": {
+        "method": "POST",
+        "url": "http://nexus-bridge-1:8091/api/v1/n8n/runs/update",
+        "authentication": "predefinedCredentialType",
+        "nodeCredentialType": "httpBearerAuth",
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "{\n  \"run_id\": \"={{$json.run?.run_id || $json.run_id}}\",\n  \"state\": \"close_loop_completed\",\n  \"message\": \"Completed Nexus step close_loop\",\n  \"data\": {\n    \"step\": {\n      \"id\": \"close_loop\",\n      \"name\": \"Document & Close\",\n      \"description\": \"Write a short summary of the published post. Close the issue with label social:published.\",\n      \"agent_type\": \"writer\",\n      \"context_policy\": \"minimal\",\n      \"tools\": [\n        \"vcs:add_comment\",\n        \"vcs:add_label\",\n        \"vcs:close_issue\"\n      ],\n      \"inputs\": [\n        {\n          \"publish_url\": \"string\"\n        },\n        {\n          \"publish_platform\": \"string\"\n        },\n        {\n          \"post_text\": \"string\"\n        }\n      ],\n      \"outputs\": [\n        {\n          \"summary\": \"string\"\n        }\n      ],\n      \"final_step\": true\n    }\n  }\n}"
+      },
+      "id": "complete-close_loop",
+      "name": "Complete close_loop",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [
+        2580,
+        120
+      ],
+      "notesInFlow": true,
+      "notes": "Replace this state transition with a concrete agent/tool call when available."
+    },
+    {
+      "parameters": {
+        "mode": "rules",
+        "rules": {
+          "values": [
+            {
+              "conditions": {
+                "conditions": [
+                  {
+                    "leftValue": "={{$json.next_step}}",
+                    "rightValue": "publish",
+                    "operator": {
+                      "type": "string",
+                      "operation": "equals"
+                    }
+                  }
+                ],
+                "combinator": "and"
+              }
+            },
+            {
+              "conditions": {
+                "conditions": [
+                  {
+                    "leftValue": "={{$json.next_step}}",
+                    "rightValue": "write",
+                    "operator": {
+                      "type": "string",
+                      "operation": "equals"
+                    }
+                  }
+                ],
+                "combinator": "and"
+              }
+            }
+          ]
+        },
+        "options": {}
+      },
+      "id": "switch-switch-route_review",
+      "name": "Switch route_review",
+      "type": "n8n-nodes-base.switch",
+      "typeVersion": 3,
+      "position": [
+        2080,
+        260
+      ],
+      "notesInFlow": true,
+      "notes": "Routes to the Nexus step selected by the preceding Code node."
+    }
+  ],
+  "connections": {
+    "01 Start research": {
+      "main": [
+        [
+          {
+            "node": "Complete research",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "02 Start write": {
+      "main": [
+        [
+          {
+            "node": "Complete write",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "03 Start review": {
+      "main": [
+        [
+          {
+            "node": "Complete review",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "04 Start route_review": {
+      "main": [
+        [
+          {
+            "node": "Route route_review",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "05 Start publish": {
+      "main": [
+        [
+          {
+            "node": "Approval Gate publish",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Approval Gate publish": {
+      "main": [
+        [
+          {
+            "node": "Complete publish",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "06 Start close_loop": {
+      "main": [
+        [
+          {
+            "node": "Complete close_loop",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Create Nexus Run": {
+      "main": [
+        [
+          {
+            "node": "01 Start research",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Manual Trigger": {
+      "main": [
+        [
+          {
+            "node": "Create Nexus Run",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Complete research": {
+      "main": [
+        [
+          {
+            "node": "02 Start write",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Complete write": {
+      "main": [
+        [
+          {
+            "node": "03 Start review",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Complete review": {
+      "main": [
+        [
+          {
+            "node": "04 Start route_review",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Route route_review": {
+      "main": [
+        [
+          {
+            "node": "Switch route_review",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Switch route_review": {
+      "main": [
+        [
+          {
+            "node": "05 Start publish",
+            "type": "main",
+            "index": 0
+          }
+        ],
+        [
+          {
+            "node": "02 Start write",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Complete publish": {
+      "main": [
+        [
+          {
+            "node": "06 Start close_loop",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    }
+  },
+  "settings": {
+    "executionOrder": "v1"
+  },
+  "staticData": null,
+  "tags": [
+    "nexus-arc",
+    "generated"
+  ],
+  "meta": {
+    "nexusArc": {
+      "source": "examples/workflows/x_post_workflow.yaml",
+      "workflowType": "social-post",
+      "converter": "nexus.translators.to_n8n"
+    }
+  }
+}

--- a/nexus/cli.py
+++ b/nexus/cli.py
@@ -2,6 +2,7 @@ import argparse
 
 from nexus.translators.to_copilot import translate_agent_to_copilot
 from nexus.translators.to_markdown import translate_agent_to_markdown
+from nexus.translators.to_n8n import translate_workflow_to_n8n
 from nexus.translators.to_python import translate_agent_to_python
 
 
@@ -27,6 +28,26 @@ def main():
     python_parser = translate_sub.add_parser("to-python", help="Convert YAML to Python class")
     python_parser.add_argument("file", help="YAML file to translate")
 
+    # Translate workflow to n8n
+    n8n_parser = translate_sub.add_parser("to-n8n", help="Convert workflow YAML to n8n JSON")
+    n8n_parser.add_argument("file", help="Workflow YAML file to translate")
+    n8n_parser.add_argument(
+        "--workflow-type",
+        default="",
+        help="Optional workflow type/tier to resolve before conversion",
+    )
+    n8n_parser.add_argument(
+        "--bridge-url",
+        default="http://nexus-bridge-1:8091",
+        help="Base URL for the Nexus command bridge from n8n",
+    )
+    n8n_parser.add_argument(
+        "-o",
+        "--output",
+        default="",
+        help="Write JSON to this file instead of stdout",
+    )
+
     bridge_parser = subparsers.add_parser("command-bridge", help="Run the Nexus command bridge")
     bridge_parser.add_argument("--host", default=None, help="Bridge host")
     bridge_parser.add_argument("--port", type=int, default=None, help="Bridge port")
@@ -45,6 +66,17 @@ def main():
             print(translate_agent_to_copilot(args.file))
         elif args.subcommand == "to-python":
             print(translate_agent_to_python(args.file))
+        elif args.subcommand == "to-n8n":
+            rendered = translate_workflow_to_n8n(
+                args.file,
+                workflow_type=args.workflow_type,
+                bridge_url=args.bridge_url,
+            )
+            if args.output:
+                with open(args.output, "w", encoding="utf-8") as handle:
+                    handle.write(rendered)
+            else:
+                print(rendered, end="")
     elif args.command == "command-bridge":
         from nexus.command_bridge_service import run_command_bridge
 

--- a/nexus/core/command_bridge/n8n_state_machine.py
+++ b/nexus/core/command_bridge/n8n_state_machine.py
@@ -28,6 +28,7 @@ _VALID_STATES = {
 }
 _TERMINAL_STATES = {"done", "blocked", "failed", "cancelled"}
 _BRANCH_RE = re.compile(r"^[A-Za-z0-9._/-]+$")
+_STATE_RE = re.compile(r"^[a-z][a-z0-9_]{0,79}$")
 
 
 def create_run(payload: dict[str, Any]) -> dict[str, Any]:
@@ -366,7 +367,7 @@ def _command_preview(cmd: list[str]) -> list[str]:
 
 def _normalize_state(value: Any) -> str:
     state = str(value or "").strip().lower().replace("-", "_")
-    if state not in _VALID_STATES:
+    if state not in _VALID_STATES and not _STATE_RE.match(state):
         raise ValueError(f"invalid run state: {value}")
     return state
 

--- a/nexus/translators/to_n8n.py
+++ b/nexus/translators/to_n8n.py
@@ -1,0 +1,539 @@
+"""Nexus workflow YAML to n8n workflow JSON translator."""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+from nexus.core.workflow_engine.workflow_definition_loader import resolve_workflow_steps_list
+
+_DEFAULT_BRIDGE_URL = "http://nexus-bridge-1:8091"
+
+
+def translate_workflow_to_n8n(
+    yaml_path: str | Path,
+    *,
+    workflow_type: str = "",
+    bridge_url: str = _DEFAULT_BRIDGE_URL,
+) -> str:
+    """Load a Nexus workflow definition and return importable n8n JSON."""
+    workflow = convert_workflow_to_n8n(
+        yaml_path,
+        workflow_type=workflow_type,
+        bridge_url=bridge_url,
+    )
+    return json.dumps(workflow, indent=2, sort_keys=False) + "\n"
+
+
+def convert_workflow_to_n8n(
+    yaml_path: str | Path,
+    *,
+    workflow_type: str = "",
+    bridge_url: str = _DEFAULT_BRIDGE_URL,
+) -> dict[str, Any]:
+    """Convert a Nexus workflow YAML file to an n8n workflow dictionary.
+
+    The generated workflow treats n8n as the state machine and Nexus as the
+    controlled execution surface. Each Nexus step emits a state update through
+    the n8n bridge. Developer steps call the guarded OpenCode execution endpoint;
+    other agent steps are represented as state transitions for import-time
+    customization.
+    """
+    source_path = Path(yaml_path)
+    data = _load_workflow_yaml(source_path)
+    steps = resolve_workflow_steps_list(data, workflow_type)
+    if not steps:
+        raise ValueError(f"No workflow steps found in {source_path}")
+
+    metadata = data.get("metadata") if isinstance(data.get("metadata"), dict) else {}
+    workflow_name = str(metadata.get("name") or source_path.stem).strip()
+    if workflow_type:
+        workflow_name = f"{workflow_name} [{workflow_type}]"
+
+    builder = _N8nWorkflowBuilder(
+        workflow_name=workflow_name,
+        source_path=source_path,
+        data=data,
+        steps=steps,
+        workflow_type=workflow_type,
+        bridge_url=bridge_url.rstrip("/"),
+    )
+    return builder.build()
+
+
+def _load_workflow_yaml(path: Path) -> dict[str, Any]:
+    with path.open(encoding="utf-8") as handle:
+        data = yaml.safe_load(handle)
+    if not isinstance(data, dict):
+        raise ValueError(f"Workflow definition must be a mapping: {path}")
+    data["__yaml_path"] = str(path)
+    return data
+
+
+class _N8nWorkflowBuilder:
+    def __init__(
+        self,
+        *,
+        workflow_name: str,
+        source_path: Path,
+        data: dict[str, Any],
+        steps: list[dict[str, Any]],
+        workflow_type: str,
+        bridge_url: str,
+    ) -> None:
+        self.workflow_name = workflow_name
+        self.source_path = source_path
+        self.data = data
+        self.steps = [step for step in steps if isinstance(step, dict)]
+        self.workflow_type = workflow_type
+        self.bridge_url = bridge_url
+        self.nodes: list[dict[str, Any]] = []
+        self.connections: dict[str, dict[str, list[list[dict[str, Any]]]]] = {}
+        self.step_start_names: dict[str, str] = {}
+        self.step_exit_names: dict[str, str] = {}
+
+    def build(self) -> dict[str, Any]:
+        self._add_manual_trigger()
+        create_run_name = self._add_create_run()
+        self._register_step_nodes()
+        first_step_id = _step_id(self.steps[0], 1)
+        self._connect("Create Nexus Run", self.step_start_names[first_step_id])
+        self._connect("Manual Trigger", create_run_name)
+        self._wire_step_transitions()
+
+        return {
+            "name": self.workflow_name,
+            "nodes": self.nodes,
+            "connections": self.connections,
+            "settings": {"executionOrder": "v1"},
+            "staticData": None,
+            "tags": ["nexus-arc", "generated"],
+            "meta": {
+                "nexusArc": {
+                    "source": str(self.source_path),
+                    "workflowType": self.workflow_type or self.data.get("workflow_type"),
+                    "converter": "nexus.translators.to_n8n",
+                }
+            },
+        }
+
+    def _add_manual_trigger(self) -> None:
+        self._node(
+            node_id="manual-trigger",
+            name="Manual Trigger",
+            node_type="n8n-nodes-base.manualTrigger",
+            type_version=1,
+            parameters={},
+            position=(0, 0),
+        )
+
+    def _add_create_run(self) -> str:
+        metadata = self.data.get("metadata") if isinstance(self.data.get("metadata"), dict) else {}
+        body = {
+            "task": "={{$json.task || $json.title || 'Run Nexus workflow'}}",
+            "project_key": "={{$json.project_key || $json.project || 'nexus'}}",
+            "issue_number": "={{$json.issue_number || $json.issue || ''}}",
+            "requester": {"source": "n8n", "workflow": self.workflow_name},
+            "metadata": {
+                "nexus_workflow": metadata,
+                "workflow_type": self.workflow_type or self.data.get("workflow_type"),
+                "source": str(self.source_path),
+            },
+        }
+        self._http_node(
+            node_id="create-nexus-run",
+            name="Create Nexus Run",
+            method="POST",
+            url=f"{self.bridge_url}/api/v1/n8n/runs",
+            json_body=body,
+            position=(260, 0),
+            notes="Creates the durable Nexus run that n8n will advance.",
+        )
+        return "Create Nexus Run"
+
+    def _register_step_nodes(self) -> None:
+        for index, step in enumerate(self.steps, start=1):
+            step_id = _step_id(step, index)
+            x = 560 + (index - 1) * 360
+            y = _lane_for_step(step, index)
+            start_name = self._add_step_start(step, step_id, index, x, y)
+            self.step_start_names[step_id] = start_name
+
+            if _is_router_step(step):
+                exit_name = self._add_route_nodes(step, step_id, x + 220, y)
+            else:
+                previous_name = start_name
+                if bool(step.get("require_human_approval")):
+                    approval_name = self._add_approval_gate(step, step_id, x + 220, y - 120)
+                    self._connect(previous_name, approval_name)
+                    previous_name = approval_name
+
+                execute_name = self._add_step_execution(step, step_id, x + 220, y)
+                self._connect(previous_name, execute_name)
+                exit_name = execute_name
+
+            self.step_exit_names[step_id] = exit_name
+
+    def _add_step_start(
+        self, step: dict[str, Any], step_id: str, index: int, x: int, y: int
+    ) -> str:
+        name = f"{index:02d} Start {step_id}"
+        payload = {
+            "run_id": _run_id_expression(),
+            "state": step_id,
+            "message": f"Starting Nexus step {step_id}",
+            "data": {"step": _public_step_payload(step, step_id, index)},
+        }
+        self._http_node(
+            node_id=f"start-{_slug(step_id)}",
+            name=name,
+            method="POST",
+            url=f"{self.bridge_url}/api/v1/n8n/runs/update",
+            json_body=payload,
+            position=(x, y),
+            notes=step.get("description"),
+        )
+        return name
+
+    def _add_approval_gate(self, step: dict[str, Any], step_id: str, x: int, y: int) -> str:
+        name = f"Approval Gate {step_id}"
+        payload = {
+            "run_id": _run_id_expression(),
+            "state": f"{step_id}_awaiting_approval",
+            "message": f"Human approval required before {step_id}",
+            "data": {"step_id": step_id, "agent_type": step.get("agent_type")},
+        }
+        self._http_node(
+            node_id=f"approval-{_slug(step_id)}",
+            name=name,
+            method="POST",
+            url=f"{self.bridge_url}/api/v1/n8n/runs/update",
+            json_body=payload,
+            position=(x, y),
+            notes="Connect this node to an n8n approval/wait mechanism if the gate must pause.",
+        )
+        return name
+
+    def _add_step_execution(self, step: dict[str, Any], step_id: str, x: int, y: int) -> str:
+        agent_type = str(step.get("agent_type") or "agent")
+        if agent_type == "developer":
+            name = f"Execute OpenCode {step_id}"
+            payload = {
+                "run_id": _run_id_expression(),
+                "task": (
+                    "={{$json.task || $json.run?.task || "
+                    + json.dumps(step.get("description") or f"Execute {step_id}")
+                    + "}}"
+                ),
+                "project_key": "={{$json.project_key || $json.run?.project_key || 'nexus'}}",
+                "worker": "opencode",
+                "agent": "build",
+                "base_branch": "develop",
+                "metadata": {"step": _public_step_payload(step, step_id, 0)},
+            }
+            self._http_node(
+                node_id=f"execute-opencode-{_slug(step_id)}",
+                name=name,
+                method="POST",
+                url=f"{self.bridge_url}/api/v1/n8n/coding/execute",
+                json_body=payload,
+                position=(x, y),
+                notes="Guarded Nexus endpoint: allowlist, isolated worktree, no push/merge/PR.",
+            )
+            return name
+
+        name = f"Complete {step_id}"
+        payload = {
+            "run_id": _run_id_expression(),
+            "state": f"{step_id}_completed",
+            "message": f"Completed Nexus step {step_id}",
+            "data": {"step": _public_step_payload(step, step_id, 0)},
+        }
+        self._http_node(
+            node_id=f"complete-{_slug(step_id)}",
+            name=name,
+            method="POST",
+            url=f"{self.bridge_url}/api/v1/n8n/runs/update",
+            json_body=payload,
+            position=(x, y),
+            notes="Replace this state transition with a concrete agent/tool call when available.",
+        )
+        return name
+
+    def _add_route_nodes(self, step: dict[str, Any], step_id: str, x: int, y: int) -> str:
+        name = f"Route {step_id}"
+        routes = step.get("routes") if isinstance(step.get("routes"), list) else []
+        code = _route_code(routes)
+        self._node(
+            node_id=f"route-{_slug(step_id)}",
+            name=name,
+            node_type="n8n-nodes-base.code",
+            type_version=2,
+            parameters={"jsCode": code},
+            position=(x, y),
+            notes="Evaluates Nexus route rules and writes next_step.",
+        )
+        self._connect(self.step_start_names[step_id], name)
+        return name
+
+    def _wire_step_transitions(self) -> None:
+        for index, step in enumerate(self.steps, start=1):
+            step_id = _step_id(step, index)
+            exit_name = self.step_exit_names[step_id]
+            if _is_router_step(step):
+                self._wire_router(step, exit_name)
+                continue
+
+            target = step.get("on_success")
+            if not target and not step.get("final_step"):
+                target = _next_step_id(self.steps, index)
+            if isinstance(target, str) and target in self.step_start_names:
+                self._connect(exit_name, self.step_start_names[target])
+
+    def _wire_router(self, step: dict[str, Any], route_node_name: str) -> None:
+        routes = step.get("routes") if isinstance(step.get("routes"), list) else []
+        targets = _route_targets(routes)
+        if not targets:
+            return
+
+        switch_name = f"Switch {route_node_name.removeprefix('Route ')}"
+        switch_x, switch_y = _position_after(route_node_name, self.nodes, dx=220)
+        self._node(
+            node_id=f"switch-{_slug(switch_name)}",
+            name=switch_name,
+            node_type="n8n-nodes-base.switch",
+            type_version=3,
+            parameters={
+                "mode": "rules",
+                "rules": {
+                    "values": [
+                        {
+                            "conditions": {
+                                "conditions": [
+                                    {
+                                        "leftValue": "={{$json.next_step}}",
+                                        "rightValue": target,
+                                        "operator": {
+                                            "type": "string",
+                                            "operation": "equals",
+                                        },
+                                    }
+                                ],
+                                "combinator": "and",
+                            }
+                        }
+                        for target in targets
+                    ]
+                },
+                "options": {},
+            },
+            position=(switch_x, switch_y),
+            notes="Routes to the Nexus step selected by the preceding Code node.",
+        )
+        self._connect(route_node_name, switch_name)
+        for output_index, target in enumerate(targets):
+            start_name = self.step_start_names.get(target)
+            if start_name:
+                self._connect(switch_name, start_name, output_index=output_index)
+
+    def _http_node(
+        self,
+        *,
+        node_id: str,
+        name: str,
+        method: str,
+        url: str,
+        json_body: dict[str, Any],
+        position: tuple[int, int],
+        notes: str | None = None,
+    ) -> None:
+        self._node(
+            node_id=node_id,
+            name=name,
+            node_type="n8n-nodes-base.httpRequest",
+            type_version=4.2,
+            parameters={
+                "method": method,
+                "url": url,
+                "authentication": "predefinedCredentialType",
+                "nodeCredentialType": "httpBearerAuth",
+                "sendBody": True,
+                "specifyBody": "json",
+                "jsonBody": json.dumps(json_body, indent=2),
+            },
+            position=position,
+            notes=notes,
+        )
+
+    def _node(
+        self,
+        *,
+        node_id: str,
+        name: str,
+        node_type: str,
+        type_version: float,
+        parameters: dict[str, Any],
+        position: tuple[int, int],
+        notes: str | None = None,
+    ) -> None:
+        node: dict[str, Any] = {
+            "parameters": parameters,
+            "id": node_id,
+            "name": name,
+            "type": node_type,
+            "typeVersion": type_version,
+            "position": [position[0], position[1]],
+        }
+        if notes:
+            node["notesInFlow"] = True
+            node["notes"] = str(notes)
+        self.nodes.append(node)
+
+    def _connect(self, source: str, target: str, *, output_index: int = 0) -> None:
+        source_conn = self.connections.setdefault(source, {"main": []})
+        while len(source_conn["main"]) <= output_index:
+            source_conn["main"].append([])
+        edge = {"node": target, "type": "main", "index": 0}
+        if edge not in source_conn["main"][output_index]:
+            source_conn["main"][output_index].append(edge)
+
+
+def _step_id(step: dict[str, Any], index: int) -> str:
+    return str(step.get("id") or step.get("name") or f"step_{index}").strip()
+
+
+def _next_step_id(steps: list[dict[str, Any]], current_index: int) -> str | None:
+    if current_index >= len(steps):
+        return None
+    return _step_id(steps[current_index], current_index + 1)
+
+
+def _is_router_step(step: dict[str, Any]) -> bool:
+    return str(step.get("agent_type") or "").strip() == "router" or isinstance(
+        step.get("routes"), list
+    )
+
+
+def _route_targets(routes: list[Any]) -> list[str]:
+    targets: list[str] = []
+    for route in routes:
+        if not isinstance(route, dict):
+            continue
+        target = route.get("then") or route.get("goto") or route.get("default")
+        if isinstance(target, str) and target and target not in targets:
+            targets.append(target)
+    return targets
+
+
+def _route_code(routes: list[Any]) -> str:
+    normalized_routes: list[dict[str, str]] = []
+    for route in routes:
+        if not isinstance(route, dict):
+            continue
+        target = route.get("then") or route.get("goto") or route.get("default")
+        if not isinstance(target, str) or not target:
+            continue
+        if "when" in route:
+            normalized_routes.append({"when": str(route["when"]), "then": target})
+        else:
+            normalized_routes.append({"default": target})
+
+    routes_json = json.dumps(normalized_routes, indent=2)
+    return f"""const routes = {routes_json};
+const state = $json;
+
+function toJsExpression(expr) {{
+  return String(expr)
+    .replace(/\\band\\b/g, '&&')
+    .replace(/\\bor\\b/g, '||')
+    .replace(/\\bnot\\b/g, '!')
+    .replace(/\\bTrue\\b/g, 'true')
+    .replace(/\\bFalse\\b/g, 'false')
+    .replace(/\\bNone\\b/g, 'null');
+}}
+
+function evaluate(expr) {{
+  const keys = Object.keys(state);
+  const values = Object.values(state);
+  try {{
+    return Boolean(Function(...keys, `return (${{toJsExpression(expr)}});`)(...values));
+  }} catch (error) {{
+    return false;
+  }}
+}}
+
+let nextStep = null;
+for (const route of routes) {{
+  if (route.when && evaluate(route.when)) {{
+    nextStep = route.then;
+    break;
+  }}
+  if (!route.when && route.default && nextStep === null) {{
+    nextStep = route.default;
+  }}
+}}
+
+return [{{ json: {{ ...state, next_step: nextStep }} }}];
+"""
+
+
+def _public_step_payload(step: dict[str, Any], step_id: str, index: int) -> dict[str, Any]:
+    keys = (
+        "name",
+        "description",
+        "agent_type",
+        "context_policy",
+        "tools",
+        "inputs",
+        "outputs",
+        "routes",
+        "on_success",
+        "final_step",
+        "require_human_approval",
+        "audit_limit",
+        "include_audit_history",
+        "parallel",
+    )
+    payload = {"id": step_id}
+    if index:
+        payload["index"] = index
+    for key in keys:
+        if key in step:
+            payload[key] = step[key]
+    return payload
+
+
+def _run_id_expression() -> str:
+    return "={{$json.run?.run_id || $json.run_id}}"
+
+
+def _slug(value: str) -> str:
+    slug = re.sub(r"[^a-zA-Z0-9_-]+", "-", value.strip().lower()).strip("-")
+    return slug or "node"
+
+
+def _lane_for_step(step: dict[str, Any], index: int) -> int:
+    agent_type = str(step.get("agent_type") or "")
+    if agent_type == "router":
+        return 260
+    if bool(step.get("require_human_approval")):
+        return -180
+    return 0 if index % 2 else 120
+
+
+def _position_after(
+    node_name: str,
+    nodes: list[dict[str, Any]],
+    *,
+    dx: int = 220,
+    dy: int = 0,
+) -> tuple[int, int]:
+    for node in nodes:
+        if node.get("name") == node_name:
+            x, y = node.get("position", [0, 0])
+            return int(x) + dx, int(y) + dy
+    return dx, dy

--- a/tests/test_command_bridge_http.py
+++ b/tests/test_command_bridge_http.py
@@ -347,6 +347,60 @@ def test_n8n_run_lifecycle_requires_auth_and_persists_state(tmp_path, monkeypatc
     assert get_payload["run"]["events"][-1]["message"] == "Gab approved"
 
 
+def test_n8n_run_lifecycle_accepts_workflow_step_states(tmp_path, monkeypatch):
+    monkeypatch.setenv("NEXUS_N8N_STATE_DIR", str(tmp_path / "state"))
+    app = create_command_bridge_app(
+        _FakeRouter(),
+        config=CommandBridgeConfig(auth_token="secret"),
+    )
+    _call_app(
+        app,
+        method="POST",
+        path="/api/v1/n8n/runs",
+        auth="Bearer secret",
+        payload={"run_id": "enterprise-run", "task": "ship the converter"},
+    )
+
+    states = ["triage", "design_completed", "compliance_awaiting_approval", "route_review"]
+    for state in states:
+        status, payload = _call_app(
+            app,
+            method="POST",
+            path="/api/v1/n8n/runs/update",
+            auth="Bearer secret",
+            payload={"run_id": "enterprise-run", "state": state},
+        )
+
+        assert status.startswith("200")
+        assert payload["run"]["state"] == state
+
+
+def test_n8n_run_lifecycle_rejects_malformed_custom_state(tmp_path, monkeypatch):
+    monkeypatch.setenv("NEXUS_N8N_STATE_DIR", str(tmp_path / "state"))
+    app = create_command_bridge_app(
+        _FakeRouter(),
+        config=CommandBridgeConfig(auth_token="secret"),
+    )
+    _call_app(
+        app,
+        method="POST",
+        path="/api/v1/n8n/runs",
+        auth="Bearer secret",
+        payload={"run_id": "enterprise-run", "task": "ship the converter"},
+    )
+
+    status, payload = _call_app(
+        app,
+        method="POST",
+        path="/api/v1/n8n/runs/update",
+        auth="Bearer secret",
+        payload={"run_id": "enterprise-run", "state": "../bad-state"},
+    )
+
+    assert status.startswith("400")
+    assert "invalid run state" in payload["error"]
+
+
 def test_n8n_coding_execute_prepares_opencode_dry_run(tmp_path, monkeypatch):
     repo = tmp_path / "repo"
     repo.mkdir()

--- a/tests/test_n8n_workflow_translator.py
+++ b/tests/test_n8n_workflow_translator.py
@@ -1,0 +1,61 @@
+import json
+from pathlib import Path
+
+from nexus.translators.to_n8n import convert_workflow_to_n8n, translate_workflow_to_n8n
+
+ROOT = Path(__file__).resolve().parents[1]
+ENTERPRISE_FULL = ROOT / "examples" / "workflows" / "enterprise_full_workflow.yaml"
+ENTERPRISE_ROUTER = ROOT / "examples" / "workflows" / "enterprise_workflow.yaml"
+
+
+def _node_by_name(workflow: dict, name: str) -> dict:
+    for node in workflow["nodes"]:
+        if node["name"] == name:
+            return node
+    raise AssertionError(f"missing node {name!r}")
+
+
+def test_converts_enterprise_full_compliance_gate():
+    workflow = convert_workflow_to_n8n(ENTERPRISE_FULL)
+
+    assert workflow["name"] == "Enterprise Full Workflow"
+    assert workflow["settings"]["executionOrder"] == "v1"
+    assert workflow["meta"]["nexusArc"]["source"].endswith("enterprise_full_workflow.yaml")
+
+    compliance = _node_by_name(workflow, "07 Start compliance")
+    assert compliance["type"] == "n8n-nodes-base.httpRequest"
+    assert compliance["parameters"]["url"].endswith("/api/v1/n8n/runs/update")
+    assert '"state": "compliance"' in compliance["parameters"]["jsonBody"]
+
+    approval = _node_by_name(workflow, "Approval Gate compliance")
+    assert "Human approval required" in approval["parameters"]["jsonBody"]
+
+    route = _node_by_name(workflow, "Route route_compliance")
+    assert route["type"] == "n8n-nodes-base.code"
+    assert "compliance_status == 'approved'" in route["parameters"]["jsCode"]
+
+
+def test_developer_steps_use_guarded_opencode_endpoint():
+    workflow = convert_workflow_to_n8n(ENTERPRISE_FULL)
+
+    develop = _node_by_name(workflow, "Execute OpenCode develop")
+    assert develop["parameters"]["url"].endswith("/api/v1/n8n/coding/execute")
+    assert '"worker": "opencode"' in develop["parameters"]["jsonBody"]
+    assert "isolated worktree" in develop["notes"]
+
+
+def test_router_workflow_can_resolve_requested_tier():
+    workflow = convert_workflow_to_n8n(ENTERPRISE_ROUTER, workflow_type="full")
+    node_names = {node["name"] for node in workflow["nodes"]}
+
+    assert workflow["name"] == "Enterprise Workflow Router [full]"
+    assert "07 Start compliance" in node_names
+    assert "Approval Gate deploy" in node_names
+
+
+def test_translator_outputs_valid_json():
+    rendered = translate_workflow_to_n8n(ENTERPRISE_FULL)
+    parsed = json.loads(rendered)
+
+    assert parsed["nodes"][0]["name"] == "Manual Trigger"
+    assert parsed["connections"]["Manual Trigger"]["main"][0][0]["node"] == "Create Nexus Run"


### PR DESCRIPTION
## Summary
- add a Nexus YAML to importable n8n workflow JSON translator
- add `nexus translate to-n8n` CLI command
- generate n8n JSON templates for the existing example workflows, including enterprise compliance gates

## Checks
- `/home/ubuntu/git/ghabs/nexus-arc/venv/bin/python -m pytest -q -o addopts='' tests/test_n8n_workflow_translator.py`
- `/home/ubuntu/git/ghabs/nexus-arc/venv/bin/python -m pytest -q -o addopts='' tests/test_workflow_dry_run.py tests/test_workflow_type.py tests/test_n8n_workflow_translator.py`
- `/home/ubuntu/git/ghabs/nexus-arc/venv/bin/python -m ruff check nexus/translators/to_n8n.py nexus/cli.py tests/test_n8n_workflow_translator.py`
- `/home/ubuntu/git/ghabs/nexus-arc/venv/bin/python -m black --check nexus/translators/to_n8n.py nexus/cli.py tests/test_n8n_workflow_translator.py`
- CLI smoke: `nexus translate to-n8n examples/workflows/enterprise_full_workflow.yaml | python3 -m json.tool`
- JSON validation for all generated `examples/workflows/n8n/*.json`